### PR TITLE
Replaced mentions of Tachiyomi with Mihon in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,9 @@ contact_links:
   - name: ⚠️ Extension/source issue
     url: https://github.com/tachiyomiorg/extensions/issues/new/choose
     about: Issues and requests for official extensions and sources should be opened in the extensions repository instead
-  - name: 📦 Tachiyomi extensions
+  - name: 📦 Mihon extensions
     url: https://mihon.app/extensions/
     about: List of all available extensions with download links
-  - name: 🖥️ Tachiyomi website
+  - name: 🖥️ Mihon website
     url: https://mihon.app/
     about: Guides, troubleshooting, and answers to common questions

--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -1,5 +1,5 @@
 name: 🐞 Issue report
-description: Report an issue in Tachiyomi
+description: Report an issue in Mihon
 labels: [Bug]
 body:
 
@@ -48,10 +48,10 @@ body:
         You can paste the crash logs in plain text or upload it as an attachment.
 
   - type: input
-    id: tachiyomi-version
+    id: mihon-version
     attributes:
-      label: Tachiyomi version
-      description: You can find your Tachiyomi version in **More → About**.
+      label: Mihon version
+      description: You can find your Mihon version in **More → About**.
       placeholder: |
         Example: "0.15.3"
     validations:

--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -1,5 +1,5 @@
 name: ⭐ Feature request
-description: Suggest a feature to improve Tachiyomi
+description: Suggest a feature to improve Mihon
 labels: [Feature request]
 body:
 
@@ -7,7 +7,7 @@ body:
     id: feature-description
     attributes:
       label: Describe your suggested feature
-      description: How can Tachiyomi be improved?
+      description: How can Mihon be improved?
       placeholder: |
         Example:
           "It should work like this..."


### PR DESCRIPTION
Saw these when I opened #21 earlier and wanted to help. Hope that this won't break workflows or anything, but considering this PR only changes labels and descriptions (and an apparently unused step ID), it should be fine.