### PR TITLE
refactor: db changes for syncing.

### DIFF
--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -75,7 +75,7 @@ WHERE _id IN :chapterIds;
 
 insert:
 INSERT INTO chapters(manga_id, url, name, scanlator, read, bookmark, last_page_read, chapter_number, source_order, date_fetch, date_upload, last_modified_at)
-VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, strftime('%s', 'now'));
+VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, 0);
 
 update:
 UPDATE chapters

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -117,7 +117,7 @@ AND source IN :sourceIds;
 
 insert:
 INSERT INTO mangas(source, url, artist, author, description, genre, title, status, thumbnail_url, favorite, last_update, next_update, initialized, viewer, chapter_flags, cover_last_modified, date_added, update_strategy, calculate_interval, last_modified_at)
-VALUES (:source, :url, :artist, :author, :description, :genre, :title, :status, :thumbnailUrl, :favorite, :lastUpdate, :nextUpdate, :initialized, :viewerFlags, :chapterFlags, :coverLastModified, :dateAdded, :updateStrategy, :calculateInterval, strftime('%s', 'now'));
+VALUES (:source, :url, :artist, :author, :description, :genre, :title, :status, :thumbnailUrl, :favorite, :lastUpdate, :nextUpdate, :initialized, :viewerFlags, :chapterFlags, :coverLastModified, :dateAdded, :updateStrategy, :calculateInterval, 0);
 
 update:
 UPDATE mangas SET

--- a/data/src/main/sqldelight/tachiyomi/data/mangas_categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas_categories.sq
@@ -20,7 +20,7 @@ END;
 
 insert:
 INSERT INTO mangas_categories(manga_id, category_id, last_modified_at)
-VALUES (:mangaId, :categoryId, strftime('%s', 'now'));
+VALUES (:mangaId, :categoryId, 0);
 
 deleteMangaCategoryByMangaId:
 DELETE FROM mangas_categories


### PR DESCRIPTION
Set the lastModifiedAt default to 0 on insert, this way when syncing it doesn't mark chapter as unread.

For example:
Device A: has a manga with 79 chapter main device used for reading and more up to date.
Device B: haven't done any update library so it's stale, something like 78 chapter now when the user sync it will get the data from Device B as latest since on insert previously sets the current time. 
Device A: Marks the chapter that was read as unread.

Well another approach is to sync before library update, but with this changes it they don't have to sync before updating library.