### PR TITLE
Fixing bottom sheet UI bug in non-tablet devices

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/AdaptiveSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/AdaptiveSheet.kt
@@ -97,5 +97,5 @@ fun AdaptiveSheet(
 
 private val dialogProperties = DialogProperties(
     usePlatformDefaultWidth = false,
-    decorFitsSystemWindows = false,
+    decorFitsSystemWindows = true,
 )

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
@@ -11,17 +11,14 @@ import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -177,10 +174,8 @@ fun AdaptiveSheet(
                         orientation = Orientation.Vertical,
                         enabled = enableSwipeDismiss,
                     )
-                    .windowInsetsPadding(
-                        WindowInsets.systemBars
-                            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
-                    ),
+                    .navigationBarsPadding()
+                    .statusBarsPadding(),
                 shape = MaterialTheme.shapes.extraLarge,
                 tonalElevation = tonalElevation,
                 content = {


### PR DESCRIPTION
# Description
All bottom sheets (dialogs) were experiencing a UI bug on API 30 and lower, where the bottom part was being cut off by the system bar. This became more noticeable when using the navigation bar. Additionally, on some devices, the dialog was adding extra padding, causing a flick in the animation. 

Another thing worth mentioning is that users on lower versions were having a different experience, as the modal was not presented in the same way as on more recent Android versions (without padding and dim background).

# Fix proposal
The proposed solution is simple: set `decorFitsSystemWindows` of the Dialog to true, so that internally the theme R.style.DialogWindowTheme is used. Additionally, extra paddings for the status bar and navigation bar were included.

I didn't understand why `decorFitsSystemWindows` was intentionally set to false. If this solution is not accepted, I can look for other alternatives.


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:
-->
### Images
| Bug 1 | Bug 2 |
| ------- | ------- |
| ![](https://github.com/mihonapp/mihon/assets/9647399/6f2fac27-cc3b-41f1-b7a7-a023d48233f8) | ![](https://github.com/mihonapp/mihon/assets/9647399/55e78436-e4ca-4642-b3d6-a5c8fad3a48e) |

| Expected (API34) | Fix (API29) |
| ------- | ------- |
| ![](https://github.com/mihonapp/mihon/assets/9647399/257a1149-29c8-4056-89e1-7ef87d23b446) | ![](https://github.com/mihonapp/mihon/assets/9647399/f0abf034-a93f-4091-a7a0-439c7ab58015) |

### Video

https://github.com/mihonapp/mihon/assets/9647399/7dc53e87-684a-4292-866d-4bee11dc54f7

I'm thrilled to hear that you've decided to keep this fork! I've always wanted to contribute to the repository but never found the time. Looking forward to contributing more in the future.

