### PR TITLE
Adding Type-safe project accessors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,15 +139,15 @@ android {
 }
 
 dependencies {
-    implementation(project(":i18n"))
-    implementation(project(":core"))
-    implementation(project(":core-metadata"))
-    implementation(project(":source-api"))
-    implementation(project(":source-local"))
-    implementation(project(":data"))
-    implementation(project(":domain"))
-    implementation(project(":presentation-core"))
-    implementation(project(":presentation-widget"))
+    implementation(projects.i18n)
+    implementation(projects.core)
+    implementation(projects.coreMetadata)
+    implementation(projects.sourceApi)
+    implementation(projects.sourceLocal)
+    implementation(projects.data)
+    implementation(projects.domain)
+    implementation(projects.presentationCore)
+    implementation(projects.presentationWidget)
 
     // Compose
     implementation(platform(compose.bom))

--- a/core-metadata/build.gradle.kts
+++ b/core-metadata/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":source-api"))
+    implementation(projects.sourceApi)
 
     implementation(kotlinx.bundles.serialization)
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":i18n"))
+    implementation(projects.i18n)
 
     api(libs.logcat)
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
-    implementation(project(":source-api"))
-    implementation(project(":domain"))
-    implementation(project(":core"))
+    implementation(projects.sourceApi)
+    implementation(projects.domain)
+    implementation(projects.core)
 
     api(libs.bundles.sqldelight)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -14,8 +14,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":source-api"))
-    implementation(project(":core"))
+    implementation(projects.sourceApi)
+    implementation(projects.core)
 
     implementation(platform(kotlinx.coroutines.bom))
     implementation(kotlinx.bundles.coroutines)

--- a/presentation-core/build.gradle.kts
+++ b/presentation-core/build.gradle.kts
@@ -21,8 +21,8 @@ android {
 }
 
 dependencies {
-    api(project(":core"))
-    api(project(":i18n"))
+    api(projects.core)
+    api(projects.i18n)
 
     // Compose
     implementation(platform(compose.bom))

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
@@ -11,17 +11,14 @@ import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
-import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -177,10 +174,8 @@ fun AdaptiveSheet(
                         orientation = Orientation.Vertical,
                         enabled = enableSwipeDismiss,
                     )
-                    .windowInsetsPadding(
-                        WindowInsets.systemBars
-                            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
-                    ),
+                    .navigationBarsPadding()
+                    .statusBarsPadding(),
                 shape = MaterialTheme.shapes.extraLarge,
                 tonalElevation = tonalElevation,
                 content = {

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
@@ -11,14 +11,17 @@ import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -174,8 +177,10 @@ fun AdaptiveSheet(
                         orientation = Orientation.Vertical,
                         enabled = enableSwipeDismiss,
                     )
-                    .navigationBarsPadding()
-                    .statusBarsPadding(),
+                    .windowInsetsPadding(
+                        WindowInsets.systemBars
+                            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+                    ),
                 shape = MaterialTheme.shapes.extraLarge,
                 tonalElevation = tonalElevation,
                 content = {

--- a/presentation-widget/build.gradle.kts
+++ b/presentation-widget/build.gradle.kts
@@ -21,10 +21,10 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":domain"))
-    implementation(project(":presentation-core"))
-    api(project(":i18n"))
+    implementation(projects.core)
+    implementation(projects.domain)
+    implementation(projects.presentationCore)
+    api(projects.i18n)
 
     implementation(compose.glance)
     lintChecks(compose.lintchecks)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,3 +47,5 @@ include(":presentation-widget")
 include(":presentation-core")
 include(":source-local")
 include(":core-metadata")
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,5 +49,3 @@ include(":presentation-widget")
 include(":presentation-core")
 include(":source-local")
 include(":core-metadata")
-
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,8 @@ dependencyResolutionManagement {
     }
 }
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 rootProject.name = "Mihon"
 include(":app")
 include(":i18n")
@@ -48,4 +50,4 @@ include(":presentation-core")
 include(":source-local")
 include(":core-metadata")
 
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+

--- a/source-api/build.gradle.kts
+++ b/source-api/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation(project(":core"))
+                implementation(projects.core)
                 api(libs.preferencektx)
 
                 // Workaround for https://youtrack.jetbrains.com/issue/KT-57605

--- a/source-local/build.gradle.kts
+++ b/source-local/build.gradle.kts
@@ -8,8 +8,8 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":source-api"))
-                api(project(":i18n"))
+                implementation(projects.sourceApi)
+                api(projects.i18n)
 
                 implementation(libs.unifile)
                 implementation(libs.junrar)
@@ -17,11 +17,11 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation(project(":core"))
-                implementation(project(":core-metadata"))
+                implementation(projects.core)
+                implementation(projects.coreMetadata)
 
                 // Move ChapterRecognition to separate module?
-                implementation(project(":domain"))
+                implementation(projects.domain)
 
                 implementation(kotlinx.bundles.serialization)
             }


### PR DESCRIPTION
# Description
Since the app has several modules, we can take advantage of the [gradle new feature](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors). The project accessors are mapped from the project path. For example, if a project path is `:commons:utils:some:lib` then the project accessor will be `projects.commons.utils.some.lib`.

before:
```kt
dependencies {
    implementation(project(":i18n"))
    implementation(project(":core"))
}
```

after:
```kt
dependencies {
    implementation(projects.i18n)
    implementation(projects.core)
}
```

This way we don't need to relay on strings that are prone to error.

