### PR TITLE
Fix refreshing from enhanced tracker

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/RefreshTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/RefreshTracks.kt
@@ -30,9 +30,9 @@ class RefreshTracks(
                 .map { (track, service) ->
                     async {
                         return@async try {
-                            val updatedTrack = service!!.refresh(track.toDbTrack())
-                            insertTrack.await(updatedTrack.toDomainTrack()!!)
-                            syncChapterProgressWithTrack.await(mangaId, track, service)
+                            val updatedTrack = service!!.refresh(track.toDbTrack()).toDomainTrack()!!
+                            insertTrack.await(updatedTrack)
+                            syncChapterProgressWithTrack.await(mangaId, updatedTrack, service)
                             null
                         } catch (e: Throwable) {
                             service to e


### PR DESCRIPTION
The problem:
When adding an enhanced tracking to an entry, the chapters wouldn't be updated as read when clicking on "tracker" to refresh read progress made on the service. The bug seems to come from [98d6ce2](https://github.com/tachiyomiorg/tachiyomi/commit/98d6ce2eaf2c1e85f4763dd37303155d1fc6690d)

Also closes #95

Possibly related to #55 , but that issue seems to be for updating progress made on Mihon, not the other way around.