### PR TITLE
Removing extensions from config issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ⚠️ Extension/source issue
-    url: https://github.com/tachiyomiorg/extensions/issues/new/choose
-    about: Issues and requests for official extensions and sources should be opened in the extensions repository instead
-  - name: 📦 Mihon extensions
-    url: https://mihon.app/extensions/
-    about: List of all available extensions with download links
   - name: 🖥️ Mihon website
     url: https://mihon.app/
     about: Guides, troubleshooting, and answers to common questions


### PR DESCRIPTION
# Description
The PR removes the extension-related links from the issue menu.


![Screenshot 2024-01-24 at 10 01 16 AM](https://github.com/mihonapp/mihon/assets/9647399/2cea9dde-db69-46ba-b746-fd0bdf8f0b1f)

