### PR TITLE
Remove official extensions check from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -94,8 +94,6 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with an official extension, I should be opening an issue in the [extensions repository](https://github.com/tachiyomiorg/extensions/issues/new/choose).
-          required: true
         - label: I have gone through the [FAQ](https://mihon.app/docs/faq/general) and [troubleshooting guide](https://mihon.app/docs/guides/troubleshooting/).
           required: true
         - label: I have updated the app to version **[0.16.1](https://github.com/mihonapp/mihon/releases/latest)**.

--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -31,8 +31,6 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: If this is an issue with an official extension, I should be opening an issue in the [extensions repository](https://github.com/tachiyomiorg/extensions/issues/new/choose).
-          required: true
         - label: I have updated the app to version **[0.16.1](https://github.com/mihonapp/mihon/releases/latest)**.
           required: true
         - label: I will fill out all of the requested information in this form.


### PR DESCRIPTION
Since there are no official extensions anymore, the check from the issue templates to consider opening an issue in the official repository instead in cases of issues or feature requests for for extensions, is to be removed.