### PR TITLE
Replace "tachiyomi" with "mihon" in crash log name

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -21,7 +21,7 @@ class CrashLogUtil(
 
     suspend fun dumpLogs() = withNonCancellableContext {
         try {
-            val file = context.createFileInCacheDir("tachiyomi_crash_logs.txt")
+            val file = context.createFileInCacheDir("mihon_crash_logs.txt")
 
             file.appendText(getDebugInfo() + "\n\n")
             getExtensionsInfo()?.let { file.appendText("$it\n\n") }


### PR DESCRIPTION
Closes #223.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

Checked if the file share still works as expected (it does), and it can be shared to places like Discord as previous.