### PR TITLE
Hide display cutout setting if fullscreen is off

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -42,7 +42,7 @@ internal fun ColumnScope.GeneralPage(screenModel: ReaderSettingsScreenModel) {
         pref = screenModel.preferences.fullscreen(),
     )
 
-    if (screenModel.hasDisplayCutout) {
+    if (screenModel.hasDisplayCutout && screenModel.preferences.fullscreen().get()) {
         CheckboxItem(
             label = stringResource(MR.strings.pref_cutout_short),
             pref = screenModel.preferences.cutoutShort(),


### PR DESCRIPTION
"- make it behave like the one on more -> setting -> reader"

Made by @riztard but his fork is scuffed