### PR TITLE
Add click-to-copy extension debug info

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
@@ -227,21 +227,22 @@ private fun DetailsHeader(
                     bottom = MaterialTheme.padding.small,
                 )
                 .clickable {
-                    val extDebugInfo = """
+                    val extDebugInfo = buildString {
+                        append("""
                         Extension name: ${extension.name} (lang: ${extension.lang}; package: ${extension.pkgName})
                         Extension version: ${extension.versionName} (lib: ${extension.libVersion}; version code: ${extension.versionCode})
                         NSFW: ${extension.isNsfw}
-                    """.trimIndent() + if (extension is Extension.Installed) {
-                        // extra line to not continue in the last line of previous output
-                        """
-                            
+                        """.trimIndent())
+
+                        if (extension is Extension.Installed) {
+                            append("\n\n")
+                            append("""
                             Update available: ${extension.hasUpdate}
                             Obsolete: ${extension.isObsolete}
                             Shared: ${extension.isShared}
-                            Repository: ${extension.repoUrl}
-                        """.trimIndent()
-                    } else {
-                        ""
+                            Repository: ${extension.repoUrl} 
+                            """.trimIndent())
+                        }
                     }
                     context.copyToClipboard("Extension Debug information", extDebugInfo)
                 },

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
@@ -240,7 +240,9 @@ private fun DetailsHeader(
                             Shared: ${extension.isShared}
                             Repository: ${extension.repoUrl}
                         """.trimIndent()
-                    } else ""
+                    } else {
+                        ""
+                    }
                     context.copyToClipboard("Extension Debug information", extDebugInfo)
                 },
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
@@ -228,20 +228,24 @@ private fun DetailsHeader(
                 )
                 .clickable {
                     val extDebugInfo = buildString {
-                        append("""
-                        Extension name: ${extension.name} (lang: ${extension.lang}; package: ${extension.pkgName})
-                        Extension version: ${extension.versionName} (lib: ${extension.libVersion}; version code: ${extension.versionCode})
-                        NSFW: ${extension.isNsfw}
-                        """.trimIndent())
+                        append(
+                            """
+                            Extension name: ${extension.name} (lang: ${extension.lang}; package: ${extension.pkgName})
+                            Extension version: ${extension.versionName} (lib: ${extension.libVersion}; version code: ${extension.versionCode})
+                            NSFW: ${extension.isNsfw}
+                            """.trimIndent()
+                        )
 
                         if (extension is Extension.Installed) {
                             append("\n\n")
-                            append("""
-                            Update available: ${extension.hasUpdate}
-                            Obsolete: ${extension.isObsolete}
-                            Shared: ${extension.isShared}
-                            Repository: ${extension.repoUrl} 
-                            """.trimIndent())
+                            append(
+                                """
+                                Update available: ${extension.hasUpdate}
+                                Obsolete: ${extension.isObsolete}
+                                Shared: ${extension.isShared}
+                                Repository: ${extension.repoUrl} 
+                                """.trimIndent()
+                            )
                         }
                     }
                     context.copyToClipboard("Extension Debug information", extDebugInfo)

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionDetailsScreen.kt
@@ -53,6 +53,7 @@ import eu.kanade.tachiyomi.extension.model.Extension
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.ui.browse.extension.details.ExtensionDetailsScreenModel
 import eu.kanade.tachiyomi.util.system.LocaleHelper
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
@@ -224,7 +225,24 @@ private fun DetailsHeader(
                     end = MaterialTheme.padding.medium,
                     top = MaterialTheme.padding.medium,
                     bottom = MaterialTheme.padding.small,
-                ),
+                )
+                .clickable {
+                    val extDebugInfo = """
+                        Extension name: ${extension.name} (lang: ${extension.lang}; package: ${extension.pkgName})
+                        Extension version: ${extension.versionName} (lib: ${extension.libVersion}; version code: ${extension.versionCode})
+                        NSFW: ${extension.isNsfw}
+                    """.trimIndent() + if (extension is Extension.Installed) {
+                        // extra line to not continue in the last line of previous output
+                        """
+                            
+                            Update available: ${extension.hasUpdate}
+                            Obsolete: ${extension.isObsolete}
+                            Shared: ${extension.isShared}
+                            Repository: ${extension.repoUrl}
+                        """.trimIndent()
+                    } else ""
+                    context.copyToClipboard("Extension Debug information", extDebugInfo)
+                },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             ExtensionIcon(


### PR DESCRIPTION
Adds some debug info about an extension to the user's clipboard when tapping the logo/name/package name area at the top of the details screen. Modeled after the debug info from the About screen.

Closes #168.

The output is formatted like this:

```
Extension name: [NAME] (lang: [LANG]; package: [PACKAGE NAME])
Extension version: [FULL SEMVER] (lib: [EXT-LIB VERSION]; version code: [EXT VERSION CODE]
NSFW: [true/false]
```

If the extension is installed, the following info is added as well:

```
Update available: [true/false]
Obsolete: [true/false]
Shared: [true/false]
Repository: [URL OF REPO]
```
So a sample output could look like

```
Extension name: MyExample (lang: en; package: eu.kanade.tachiyomi.extension.en.myexample)
Extension version: 1.4.69 (lib: 1.4; version code: 69)
NSFW: false
Update available: false
Obsolete: false
Shared: false
Repository: https://example.com/extensions/repo
```