### PR TITLE
Fix #197 - Scroll crashing

### DIFF
--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 compiler = "1.5.8"
-compose-bom = "2023.12.00-alpha04"
+compose-bom = "2024.01.00-alpha01"
 accompanist = "0.33.2-alpha"
 
 [libraries]


### PR DESCRIPTION
## Description

This PR closes #197 

We are using Chris Bane's compose BOM to manage the compose versions. This BOM differs from the official for using the latest non-stable versions of the libraries. This crash was caused by a bug in the compose-ui.
I could not update to the latest version because we are using several deprecated APIs that are not present in the latest version, so to update to it would not be worth the effort. Ideally, we would use the official stable version to avoid this type of crash.

## How to test
Please checkout and try to reproduce the issue before merging it. I could only test it in two physical devices.

1- Go to the browser
2- Extensions tab
3- Scroll down as fast as possible
4- change tab while scrolling
5- it should not crash


### Video

https://github.com/mihonapp/mihon/assets/9647399/7bec08b0-b061-47bd-b2a4-6287c07d5935

