### PR TITLE
Fix new extension install not registering in app.

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -338,12 +338,14 @@ class ExtensionManager(
         }
 
         override fun onExtensionUntrusted(extension: Extension.Untrusted) {
-            _installedExtensionsFlow.value
+            val installedExtension = _installedExtensionsFlow.value
                 .find { it.pkgName == extension.pkgName }
-                ?.also {
-                    _installedExtensionsFlow.value -= it
-                }
-            _untrustedExtensionsFlow.value += extension
+
+            if (installedExtension != null) {
+                _installedExtensionsFlow.value -= installedExtension
+            } else {
+                _untrustedExtensionsFlow.value += extension
+            }
         }
 
         override fun onPackageUninstalled(pkgName: String) {

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -338,10 +338,11 @@ class ExtensionManager(
         }
 
         override fun onExtensionUntrusted(extension: Extension.Untrusted) {
-            val installedExtension = _installedExtensionsFlow.value
+            _installedExtensionsFlow.value
                 .find { it.pkgName == extension.pkgName }
-                ?: return
-            _installedExtensionsFlow.value -= installedExtension
+                ?.also {
+                    _installedExtensionsFlow.value -= it
+                }
             _untrustedExtensionsFlow.value += extension
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -94,7 +94,7 @@ class ExtensionsScreenModel(
                 val installed = _installed.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 val untrusted = _untrusted.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
-                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = (installed + untrusted)
+                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = installed + untrusted
                 }
 
                 val languagesWithExtensions = _available

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -94,7 +94,7 @@ class ExtensionsScreenModel(
                 val installed = _installed.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 val untrusted = _untrusted.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
-                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = (installed + untrusted).distinctBy { it.extension }
+                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = (installed + untrusted)
                 }
 
                 val languagesWithExtensions = _available

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -94,7 +94,7 @@ class ExtensionsScreenModel(
                 val installed = _installed.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 val untrusted = _untrusted.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
-                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = installed + untrusted
+                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = (installed + untrusted).distinctBy { it.extension }
                 }
 
                 val languagesWithExtensions = _available


### PR DESCRIPTION
closes #246

The problem mainly was that `_untrustedExtensionsFlow` wasn't updated with the new extension due to early return.

~But fixing that caused crashes due to duplicate key in LazyColumn. workaround for this was to remove duplicates for installed + untrusted extensions in `ExtensionsScreenModel`.~

~Now there is another bug, after updating and trusting an extension, it shows up two times. idk how to fix this~
