### PR TITLE
Disable predictive back gesture for Android 13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
     <application
         android:name=".App"
         android:allowBackup="false"
-        android:enableOnBackInvokedCallback="true"
+        android:enableOnBackInvokedCallback="@bool/enablePredictiveBack"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/res/values-v34/bools.xml
+++ b/app/src/main/res/values-v34/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enablePredictiveBack">true</bool>
+</resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -3,4 +3,5 @@
     <bool name="lightStatusBar">true</bool>
     <bool name="lightNavigationBar">false</bool>
     <bool name="elevationOverlayEnabled">false</bool>
+    <bool name="enablePredictiveBack">false</bool>
 </resources>


### PR DESCRIPTION
It causes flickering on some (e.g. MIUI) devices.

Closes #34