### PR TITLE
Separate Header for untrusted extensions on top

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -91,10 +91,14 @@ class ExtensionsScreenModel(
                     itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_updates_pending)] = updates
                 }
 
-                val installed = _installed.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
                 val untrusted = _untrusted.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
-                if (installed.isNotEmpty() || untrusted.isNotEmpty()) {
-                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = installed + untrusted
+                if (untrusted.isNotEmpty()) {
+                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_untrusted)] = untrusted
+                }
+
+                val installed = _installed.filter(queryFilter(searchQuery)).map(extensionMapper(downloads))
+                if (installed.isNotEmpty()) {
+                    itemsGroups[ExtensionUiModel.Header.Resource(MR.strings.ext_installed)] = installed
                 }
 
                 val languagesWithExtensions = _available


### PR DESCRIPTION
closes #66

![image](https://github.com/mihonapp/mihon/assets/48650614/9da7aaff-5fd2-4625-b568-ee9105277c0f)
