### PR TITLE
Action Refactoring - Migrating Actions to Use Node 20

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -35,6 +35,6 @@ jobs:
           distribution: adopt
 
       - name: Build app and run unit tests
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: detekt assembleStandardRelease testReleaseUnitTest

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 8
 
       - name: Build app and run unit tests
         run: ./gradlew detekt assembleStandardRelease testReleaseUnitTest

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -34,7 +34,10 @@ jobs:
           java-version: 17
           distribution: adopt
 
-      - name: Build app and run unit tests
+      - name: Set up gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: detekt assembleStandardRelease testReleaseUnitTest
+          gradle-version: 8
+
+      - name: Build app and run unit tests
+        run: ./gradlew detekt assembleStandardRelease testReleaseUnitTest

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
 
       - name: Setup Android SDK
         run: |
@@ -33,7 +33,7 @@ jobs:
           distribution: adopt
 
       - name: Build app and run unit tests
-        uses: gradle/gradle-command-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: detekt assembleStandardRelease testReleaseUnitTest
 

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 8
 
       - name: Build app and run unit tests
         run: ./gradlew detekt assembleStandardRelease testReleaseUnitTest

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -32,10 +32,13 @@ jobs:
           java-version: 17
           distribution: adopt
 
-      - name: Build app and run unit tests
+      - name: Set up gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: detekt assembleStandardRelease testReleaseUnitTest
+          gradle-version: 8
+
+      - name: Build app and run unit tests
+        run: ./gradlew detekt assembleStandardRelease testReleaseUnitTest
 
       # Sign APK and create release for tags
 

--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Moderate issues
-        uses: tachiyomiorg/issue-moderator-action@v2
+        uses: tachiyomiorg/issue-moderator-action@v2.6.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-label: Duplicate


### PR DESCRIPTION
### Migration to updated actions
As stated in this [post](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), GitHub Actions will transition from Node 16, which has reached its EOL, to Node 20.
A couple of actions still need to be updated to Node 20, but PRs have already been opened in the relevant repositories.
- r0adkll/sign-android-release@v1 [[USE]](https://github.com/mihonapp/mihon/blob/139663acfca72b89bd9f560bf4c0c8a9155ce108/.github/workflows/build_push.yml#L50) [[PR]](https://github.com/r0adkll/sign-android-release/pull/86)
- softprops/action-gh-release@v1 [[USE]](https://github.com/mihonapp/mihon/blob/139663acfca72b89bd9f560bf4c0c8a9155ce108/.github/workflows/build_push.yml#L85) [[PR]](https://github.com/softprops/action-gh-release/pull/406)