### PR TITLE
Add Dependencies label to Renovate Dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     "config:base"
   ],
   "schedule": ["every sunday"],
+  "labels": ["Dependencies"],
   "packageRules": [
     {
       // Compiler plugins are tightly coupled to Kotlin version


### PR DESCRIPTION
By using labels, not only does it look cleaner with some organization, but it also allows you to filter out the PRs when, for example, having a link for the user to check if something is PR'd already. Much less clutter to look at

P.S: Don't forget to actually add the label as well, preferably with proper casing, "Dependencies"