### PR TITLE
Minor refactor of theming when expressions

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -63,9 +63,10 @@ private fun getThemeColorScheme(
     appTheme: AppTheme,
     isAmoled: Boolean,
 ): ColorScheme {
-    val colorScheme = when (appTheme) {
-        AppTheme.MONET -> MonetColorScheme(LocalContext.current)
-        else -> colorSchemes.getOrDefault(appTheme, TachiyomiColorScheme)
+    val colorScheme = if (appTheme == AppTheme.MONET) {
+        MonetColorScheme(LocalContext.current)
+    } else {
+        colorSchemes.getOrDefault(appTheme, TachiyomiColorScheme)
     }
     return colorScheme.getColorScheme(
         isSystemInDarkTheme(),

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalContext
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.presentation.theme.colorscheme.BaseColorScheme
 import eu.kanade.presentation.theme.colorscheme.GreenAppleColorScheme
 import eu.kanade.presentation.theme.colorscheme.LavenderColorScheme
 import eu.kanade.presentation.theme.colorscheme.MidnightDuskColorScheme
@@ -63,22 +64,25 @@ private fun getThemeColorScheme(
     isAmoled: Boolean,
 ): ColorScheme {
     val colorScheme = when (appTheme) {
-        AppTheme.DEFAULT -> TachiyomiColorScheme
         AppTheme.MONET -> MonetColorScheme(LocalContext.current)
-        AppTheme.GREEN_APPLE -> GreenAppleColorScheme
-        AppTheme.LAVENDER -> LavenderColorScheme
-        AppTheme.MIDNIGHT_DUSK -> MidnightDuskColorScheme
-        AppTheme.NORD -> NordColorScheme
-        AppTheme.STRAWBERRY_DAIQUIRI -> StrawberryColorScheme
-        AppTheme.TAKO -> TakoColorScheme
-        AppTheme.TEALTURQUOISE -> TealTurqoiseColorScheme
-        AppTheme.TIDAL_WAVE -> TidalWaveColorScheme
-        AppTheme.YINYANG -> YinYangColorScheme
-        AppTheme.YOTSUBA -> YotsubaColorScheme
-        else -> TachiyomiColorScheme
+        else -> colorSchemes.getOrDefault(appTheme, TachiyomiColorScheme)
     }
     return colorScheme.getColorScheme(
         isSystemInDarkTheme(),
         isAmoled,
     )
 }
+
+private val colorSchemes: Map<AppTheme, BaseColorScheme> = mapOf(
+    AppTheme.DEFAULT to TachiyomiColorScheme,
+    AppTheme.GREEN_APPLE to GreenAppleColorScheme,
+    AppTheme.LAVENDER to LavenderColorScheme,
+    AppTheme.MIDNIGHT_DUSK to MidnightDuskColorScheme,
+    AppTheme.NORD to NordColorScheme,
+    AppTheme.STRAWBERRY_DAIQUIRI to StrawberryColorScheme,
+    AppTheme.TAKO to TakoColorScheme,
+    AppTheme.TEALTURQUOISE to TealTurqoiseColorScheme,
+    AppTheme.TIDAL_WAVE to TidalWaveColorScheme,
+    AppTheme.YINYANG to YinYangColorScheme,
+    AppTheme.YOTSUBA to YotsubaColorScheme,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
@@ -11,20 +11,6 @@ interface ThemingDelegate {
     fun applyAppTheme(activity: Activity)
 
     companion object {
-        private val themeResources: Map<AppTheme, Int> = mapOf(
-            AppTheme.MONET to R.style.Theme_Tachiyomi_Monet,
-            AppTheme.GREEN_APPLE to R.style.Theme_Tachiyomi_GreenApple,
-            AppTheme.LAVENDER to R.style.Theme_Tachiyomi_Lavender,
-            AppTheme.MIDNIGHT_DUSK to R.style.Theme_Tachiyomi_MidnightDusk,
-            AppTheme.NORD to R.style.Theme_Tachiyomi_Nord,
-            AppTheme.STRAWBERRY_DAIQUIRI to R.style.Theme_Tachiyomi_StrawberryDaiquiri,
-            AppTheme.TAKO to R.style.Theme_Tachiyomi_Tako,
-            AppTheme.TEALTURQUOISE to R.style.Theme_Tachiyomi_TealTurquoise,
-            AppTheme.YINYANG to R.style.Theme_Tachiyomi_YinYang,
-            AppTheme.YOTSUBA to R.style.Theme_Tachiyomi_Yotsuba,
-            AppTheme.TIDAL_WAVE to R.style.Theme_Tachiyomi_TidalWave,
-        )
-
         fun getThemeResIds(appTheme: AppTheme, isAmoled: Boolean): List<Int> {
             return buildList(2) {
                 add(themeResources.getOrDefault(appTheme, R.style.Theme_Tachiyomi))
@@ -41,3 +27,17 @@ class ThemingDelegateImpl : ThemingDelegate {
             .forEach(activity::setTheme)
     }
 }
+
+private val themeResources: Map<AppTheme, Int> = mapOf(
+    AppTheme.MONET to R.style.Theme_Tachiyomi_Monet,
+    AppTheme.GREEN_APPLE to R.style.Theme_Tachiyomi_GreenApple,
+    AppTheme.LAVENDER to R.style.Theme_Tachiyomi_Lavender,
+    AppTheme.MIDNIGHT_DUSK to R.style.Theme_Tachiyomi_MidnightDusk,
+    AppTheme.NORD to R.style.Theme_Tachiyomi_Nord,
+    AppTheme.STRAWBERRY_DAIQUIRI to R.style.Theme_Tachiyomi_StrawberryDaiquiri,
+    AppTheme.TAKO to R.style.Theme_Tachiyomi_Tako,
+    AppTheme.TEALTURQUOISE to R.style.Theme_Tachiyomi_TealTurquoise,
+    AppTheme.YINYANG to R.style.Theme_Tachiyomi_YinYang,
+    AppTheme.YOTSUBA to R.style.Theme_Tachiyomi_Yotsuba,
+    AppTheme.TIDAL_WAVE to R.style.Theme_Tachiyomi_TidalWave,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
@@ -11,52 +11,25 @@ interface ThemingDelegate {
     fun applyAppTheme(activity: Activity)
 
     companion object {
+        private val themeResources: Map<AppTheme, Int> = mapOf(
+            AppTheme.MONET to R.style.Theme_Tachiyomi_Monet,
+            AppTheme.GREEN_APPLE to R.style.Theme_Tachiyomi_GreenApple,
+            AppTheme.LAVENDER to R.style.Theme_Tachiyomi_Lavender,
+            AppTheme.MIDNIGHT_DUSK to R.style.Theme_Tachiyomi_MidnightDusk,
+            AppTheme.NORD to R.style.Theme_Tachiyomi_Nord,
+            AppTheme.STRAWBERRY_DAIQUIRI to R.style.Theme_Tachiyomi_StrawberryDaiquiri,
+            AppTheme.TAKO to R.style.Theme_Tachiyomi_Tako,
+            AppTheme.TEALTURQUOISE to R.style.Theme_Tachiyomi_TealTurquoise,
+            AppTheme.YINYANG to R.style.Theme_Tachiyomi_YinYang,
+            AppTheme.YOTSUBA to R.style.Theme_Tachiyomi_Yotsuba,
+            AppTheme.TIDAL_WAVE to R.style.Theme_Tachiyomi_TidalWave,
+        )
+
         fun getThemeResIds(appTheme: AppTheme, isAmoled: Boolean): List<Int> {
-            val resIds = mutableListOf<Int>()
-            when (appTheme) {
-                AppTheme.MONET -> {
-                    resIds += R.style.Theme_Tachiyomi_Monet
-                }
-                AppTheme.GREEN_APPLE -> {
-                    resIds += R.style.Theme_Tachiyomi_GreenApple
-                }
-                AppTheme.LAVENDER -> {
-                    resIds += R.style.Theme_Tachiyomi_Lavender
-                }
-                AppTheme.MIDNIGHT_DUSK -> {
-                    resIds += R.style.Theme_Tachiyomi_MidnightDusk
-                }
-                AppTheme.NORD -> {
-                    resIds += R.style.Theme_Tachiyomi_Nord
-                }
-                AppTheme.STRAWBERRY_DAIQUIRI -> {
-                    resIds += R.style.Theme_Tachiyomi_StrawberryDaiquiri
-                }
-                AppTheme.TAKO -> {
-                    resIds += R.style.Theme_Tachiyomi_Tako
-                }
-                AppTheme.TEALTURQUOISE -> {
-                    resIds += R.style.Theme_Tachiyomi_TealTurquoise
-                }
-                AppTheme.YINYANG -> {
-                    resIds += R.style.Theme_Tachiyomi_YinYang
-                }
-                AppTheme.YOTSUBA -> {
-                    resIds += R.style.Theme_Tachiyomi_Yotsuba
-                }
-                AppTheme.TIDAL_WAVE -> {
-                    resIds += R.style.Theme_Tachiyomi_TidalWave
-                }
-                else -> {
-                    resIds += R.style.Theme_Tachiyomi
-                }
+            return buildList(2) {
+                add(themeResources.getOrDefault(appTheme, R.style.Theme_Tachiyomi))
+                if (isAmoled) add(R.style.ThemeOverlay_Tachiyomi_Amoled)
             }
-
-            if (isAmoled) {
-                resIds += R.style.ThemeOverlay_Tachiyomi_Amoled
-            }
-
-            return resIds
         }
     }
 }


### PR DESCRIPTION
Avoids triggering detekt's CyclomaticComplexMethod warning because of too many when branches, which would happen with one more theme being added in these two locations.

In TachiyomiTheme, the Monet theme is separated because it requires the current Compose context to function. The other themes do not and are delegated to a Map.