### PR TITLE
Fix DelayedTrackingUpdateJob spam on update errors

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
@@ -21,7 +21,7 @@ class TrackChapter(
     private val delayedTrackingStore: DelayedTrackingStore,
 ) {
 
-    suspend fun await(context: Context, mangaId: Long, chapterNumber: Double, isRetry: Boolean = false) {
+    suspend fun await(context: Context, mangaId: Long, chapterNumber: Double, setupJobOnFailure: Boolean = true) {
         withNonCancellableContext {
             val tracks = getTracks.await(mangaId)
             if (tracks.isEmpty()) return@withNonCancellableContext
@@ -43,7 +43,7 @@ class TrackChapter(
                             delayedTrackingStore.remove(track.id)
                         } catch (e: Exception) {
                             delayedTrackingStore.add(track.id, chapterNumber)
-                            if (!isRetry) {
+                            if (setupJobOnFailure) {
                                 DelayedTrackingUpdateJob.setupTask(context)
                             }
                             throw e

--- a/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
@@ -21,7 +21,7 @@ class TrackChapter(
     private val delayedTrackingStore: DelayedTrackingStore,
 ) {
 
-    suspend fun await(context: Context, mangaId: Long, chapterNumber: Double) {
+    suspend fun await(context: Context, mangaId: Long, chapterNumber: Double, isRetry: Boolean = false) {
         withNonCancellableContext {
             val tracks = getTracks.await(mangaId)
             if (tracks.isEmpty()) return@withNonCancellableContext
@@ -43,7 +43,9 @@ class TrackChapter(
                             delayedTrackingStore.remove(track.id)
                         } catch (e: Exception) {
                             delayedTrackingStore.add(track.id, chapterNumber)
-                            DelayedTrackingUpdateJob.setupTask(context)
+                            if (!isRetry) {
+                                DelayedTrackingUpdateJob.setupTask(context)
+                            }
                             throw e
                         }
                     }

--- a/app/src/main/java/eu/kanade/domain/track/service/DelayedTrackingUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/DelayedTrackingUpdateJob.kt
@@ -45,7 +45,7 @@ class DelayedTrackingUpdateJob(private val context: Context, workerParams: Worke
                     logcat(LogPriority.DEBUG) {
                         "Updating delayed track item: ${track.mangaId}, last chapter read: ${track.lastChapterRead}"
                     }
-                    trackChapter.await(context, track.mangaId, track.lastChapterRead)
+                    trackChapter.await(context, track.mangaId, track.lastChapterRead, isRetry = true)
                 }
         }
 

--- a/app/src/main/java/eu/kanade/domain/track/service/DelayedTrackingUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/DelayedTrackingUpdateJob.kt
@@ -45,7 +45,7 @@ class DelayedTrackingUpdateJob(private val context: Context, workerParams: Worke
                     logcat(LogPriority.DEBUG) {
                         "Updating delayed track item: ${track.mangaId}, last chapter read: ${track.lastChapterRead}"
                     }
-                    trackChapter.await(context, track.mangaId, track.lastChapterRead, isRetry = true)
+                    trackChapter.await(context, track.mangaId, track.lastChapterRead, setupJobOnFailure = false)
                 }
         }
 


### PR DESCRIPTION
DelayedTrackingUpdateJob would start spamming when it encountered an error (e.g. a tracker has an issue) and never stop. This seems to stem from a circular dependency between the Job's `doWork` and TrackChapter's `await`.

TrackChapter sets up a completely new instance of the DelayedTrackingUpdateJob if any Exception was thrown during the track update.

This causes the Job to get replaced (as per the WorkManager's set ExistingWorkPolicy).

Because of this, the guard clause at the start of doWork would never trigger, as all instances of the Job would report being the 0th try (because they were completely new instances).

This simple fix introduces a boolean `isRetry` parameter to TrackChapter's await method, which is set to `false` by default. DelayedTrackingUpdateJob however sets this parameter to `true`, which means TrackChapter won't try to set up the Job again.


There is almost certainly a better solution, but this seems to work as expected and cause the Job to get created once, then follow the exponential backoff specified.