### PR TITLE
Made some changes to ComicInfo metadata

### DIFF
--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -98,7 +98,7 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 fun getComicInfo(
     manga: Manga,
     chapter: Chapter,
-    urls: String,
+    urls: List<String>,
     categories: List<String>?,
     sourceName: String,
 ) = ComicInfo(

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -111,7 +111,7 @@ fun getComicInfo(
             ComicInfo.Number(it.toString())
         }
     },
-    web = ComicInfo.Web(urls),
+    web = ComicInfo.Web(urls.joinToString(" ")),
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -95,7 +95,13 @@ fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {
 /**
  * Creates a ComicInfo instance based on the manga and chapter metadata.
  */
-fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories: List<String>?) = ComicInfo(
+fun getComicInfo(
+    manga: Manga,
+    chapter: Chapter,
+    urls: String,
+    categories: List<String>?,
+    translator: String?,
+) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
     number = chapter.chapterNumber.takeIf { it >= 0 }?.let {
@@ -105,11 +111,11 @@ fun getComicInfo(manga: Manga, chapter: Chapter, chapterUrl: String, categories:
             ComicInfo.Number(it.toString())
         }
     },
-    web = ComicInfo.Web(chapterUrl),
+    web = ComicInfo.Web(urls),
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },
-    translator = chapter.scanlator?.let { ComicInfo.Translator(it) },
+    translator = translator?.let { ComicInfo.Translator(it) },
     genre = manga.genre?.let { ComicInfo.Genre(it.joinToString()) },
     publishingStatus = ComicInfo.PublishingStatusTachiyomi(
         ComicInfoPublishingStatus.toComicInfoValue(manga.status),

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -100,7 +100,7 @@ fun getComicInfo(
     chapter: Chapter,
     urls: String,
     categories: List<String>?,
-    translator: String?,
+    translator: String,
 ) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
@@ -115,7 +115,7 @@ fun getComicInfo(
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },
-    translator = translator?.let { ComicInfo.Translator(it) },
+    translator = ComicInfo.Translator(translator),
     genre = manga.genre?.let { ComicInfo.Genre(it.joinToString()) },
     publishingStatus = ComicInfo.PublishingStatusTachiyomi(
         ComicInfoPublishingStatus.toComicInfoValue(manga.status),

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -100,7 +100,7 @@ fun getComicInfo(
     chapter: Chapter,
     urls: String,
     categories: List<String>?,
-    translator: String,
+    sourceName: String,
 ) = ComicInfo(
     title = ComicInfo.Title(chapter.name),
     series = ComicInfo.Series(manga.title),
@@ -115,12 +115,13 @@ fun getComicInfo(
     summary = manga.description?.let { ComicInfo.Summary(it) },
     writer = manga.author?.let { ComicInfo.Writer(it) },
     penciller = manga.artist?.let { ComicInfo.Penciller(it) },
-    translator = ComicInfo.Translator(translator),
+    translator = chapter.scanlator?.let { ComicInfo.Translator(it) },
     genre = manga.genre?.let { ComicInfo.Genre(it.joinToString()) },
     publishingStatus = ComicInfo.PublishingStatusTachiyomi(
         ComicInfoPublishingStatus.toComicInfoValue(manga.status),
     ),
     categories = categories?.let { ComicInfo.CategoriesTachiyomi(it.joinToString()) },
+    source = ComicInfo.SourceMihon(sourceName),
     inker = null,
     colorist = null,
     letterer = null,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -54,6 +54,7 @@ import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.track.interactor.GetTracks
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -78,6 +79,7 @@ class Downloader(
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
     private val xml: XML = Injekt.get(),
     private val getCategories: GetCategories = Injekt.get(),
+    private val getTracks: GetTracks = Injekt.get(),
 ) {
 
     /**
@@ -626,9 +628,24 @@ class Downloader(
         chapter: Chapter,
         source: HttpSource,
     ) {
-        val chapterUrl = source.getChapterUrl(chapter.toSChapter())
+
         val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-        val comicInfo = getComicInfo(manga, chapter, chapterUrl, categories)
+        val translator = chapter.scanlator ?: sourceManager.get(manga.source)?.name
+        val urls = listOf(source.getChapterUrl(chapter.toSChapter()))
+            .plus(getTracks.await(manga.id).mapNotNull { it.remoteUrl.takeUnless { url -> url.isEmpty() } })
+            .map { it.trim() }
+            .distinct()
+            .joinToString(" ")
+            .trim()
+
+        val comicInfo = getComicInfo(
+            manga,
+            chapter,
+            urls,
+            categories,
+            translator,
+        )
+
         // Remove the old file
         dir.findFile(COMIC_INFO_FILE, true)?.delete()
         dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -629,7 +629,6 @@ class Downloader(
         source: HttpSource,
     ) {
         val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-        val translator = chapter.scanlator ?: source.name
         val urls = listOf(source.getChapterUrl(chapter.toSChapter()))
             .plus(getTracks.await(manga.id).mapNotNull { it.remoteUrl.takeUnless { url -> url.isEmpty() } })
             .map { it.trim() }
@@ -642,7 +641,7 @@ class Downloader(
             chapter,
             urls,
             categories,
-            translator,
+            source.name
         )
 
         // Remove the old file

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -629,12 +629,12 @@ class Downloader(
         source: HttpSource,
     ) {
         val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-        val urls = listOf(source.getChapterUrl(chapter.toSChapter()))
-            .plus(getTracks.await(manga.id).mapNotNull { it.remoteUrl.takeUnless { url -> url.isEmpty() } })
-            .map { it.trim() }
+        val urls = getTracks.await(manga.id)
+            .mapNotNull { track ->
+                track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
+             }
+            .plus(source.getChapterUrl(chapter.toSChapter()).trim())
             .distinct()
-            .joinToString(" ")
-            .trim()
 
         val comicInfo = getComicInfo(
             manga,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -629,7 +629,7 @@ class Downloader(
         source: HttpSource,
     ) {
         val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-        val translator = chapter.scanlator ?: sourceManager.get(manga.source)?.name
+        val translator = chapter.scanlator ?: source.name
         val urls = listOf(source.getChapterUrl(chapter.toSChapter()))
             .plus(getTracks.await(manga.id).mapNotNull { it.remoteUrl.takeUnless { url -> url.isEmpty() } })
             .map { it.trim() }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -628,7 +628,6 @@ class Downloader(
         chapter: Chapter,
         source: HttpSource,
     ) {
-
         val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
         val translator = chapter.scanlator ?: sourceManager.get(manga.source)?.name
         val urls = listOf(source.getChapterUrl(chapter.toSChapter()))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -632,7 +632,7 @@ class Downloader(
         val urls = getTracks.await(manga.id)
             .mapNotNull { track ->
                 track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
-             }
+            }
             .plus(source.getChapterUrl(chapter.toSChapter()).trim())
             .distinct()
 

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -158,7 +158,7 @@ data class ComicInfo(
     data class CategoriesTachiyomi(@XmlValue(true) val value: String = "")
 
     @Serializable
-    @XmlSerialName("SourceMihon", "http://www.w3.org/2001/XMLSchema", "ty")
+    @XmlSerialName("SourceMihon", "http://www.w3.org/2001/XMLSchema", "mh")
     data class SourceMihon(@XmlValue(true) val value: String = "")
 }
 

--- a/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
+++ b/core-metadata/src/main/java/tachiyomi/core/metadata/comicinfo/ComicInfo.kt
@@ -27,6 +27,7 @@ fun SManga.getComicInfo() = ComicInfo(
     coverArtist = null,
     tags = null,
     categories = null,
+    source = null,
 )
 
 fun SManga.copyFromComicInfo(comicInfo: ComicInfo) {
@@ -81,6 +82,7 @@ data class ComicInfo(
     val web: Web?,
     val publishingStatus: PublishingStatusTachiyomi?,
     val categories: CategoriesTachiyomi?,
+    val source: SourceMihon?,
 ) {
     @XmlElement(false)
     @XmlSerialName("xmlns:xsd", "", "")
@@ -154,6 +156,10 @@ data class ComicInfo(
     @Serializable
     @XmlSerialName("Categories", "http://www.w3.org/2001/XMLSchema", "ty")
     data class CategoriesTachiyomi(@XmlValue(true) val value: String = "")
+
+    @Serializable
+    @XmlSerialName("SourceMihon", "http://www.w3.org/2001/XMLSchema", "ty")
+    data class SourceMihon(@XmlValue(true) val value: String = "")
 }
 
 enum class ComicInfoPublishingStatus(


### PR DESCRIPTION
I made some changes to `ComicInfo` metadata generation:

The `web field` had a schema change and can now contain multiple space separated reference website links. Therefore ComicInfo metadata will from now on include the `source URL` and all available `tracker URLs`.
For more information look at this issue https://github.com/anansi-project/comicinfo/issues/56 and this PR https://github.com/anansi-project/comicinfo/pull/57

I changed the `translator field` to use the source name if no `scanlator` name is available.