### PR TITLE
Update image-decoder

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ coil-gif = { module = "io.coil-kt:coil-gif" }
 coil-compose = { module = "io.coil-kt:coil-compose" }
 
 subsamplingscaleimageview = "com.github.tachiyomiorg:subsampling-scale-image-view:7e57335"
-image-decoder = "com.github.tachiyomiorg:image-decoder:fbd6601290"
+image-decoder = "com.github.tachiyomiorg:image-decoder:398d3c074f"
 
 natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 


### PR DESCRIPTION
fixes crashing when trying to load corrupt images below 12 bytes in size