### PR TITLE
Fix: Split wide pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ZipPageLoader.kt
@@ -3,6 +3,11 @@ package eu.kanade.tachiyomi.ui.reader.loader
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import mihon.core.common.extensions.toZipFile
 import tachiyomi.core.common.util.system.ImageUtil
 import java.nio.channels.SeekableByteChannel
@@ -21,8 +26,14 @@ internal class ZipPageLoader(channel: SeekableByteChannel) : PageLoader() {
             .filter { !it.isDirectory && ImageUtil.isImage(it.name) { zip.getInputStream(it) } }
             .sortedWith { f1, f2 -> f1.name.compareToCaseInsensitiveNaturalOrder(f2.name) }
             .mapIndexed { i, entry ->
+                val imageBytesDeferred: Deferred<ByteArray> = CoroutineScope(Dispatchers.IO).async {
+                    zip.getInputStream(entry).buffered().use { stream ->
+                        stream.readBytes()
+                    }
+                }
+                val imageBytes by lazy { runBlocking { imageBytesDeferred.await() } }
                 ReaderPage(i).apply {
-                    stream = { zip.getInputStream(entry) }
+                    stream = { imageBytes.copyOf().inputStream() }
                     status = Page.State.READY
                 }
             }


### PR DESCRIPTION
Fixes  #479

`Apache Commons Compress` archives do not support mark and reset, this causes problems when functions like "Split wide pages" are used, that rely on these functions working. More info in  #479.

I fixed it by loading the images into a `ByteArray` instead of reading them directly from file.

Someone should test the performance in `Long strip` mode before merging this PR, because my emulator is too laggy too tell whether or not this approach degrades reader performance.
