### PR TITLE
Fix dual page split for local source

### DIFF
--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -551,7 +551,7 @@ object ImageUtil {
         imageStream: InputStream,
         resetAfterExtraction: Boolean = true,
     ): BitmapFactory.Options {
-        imageStream.mark(imageStream.available() + 1)
+        imageStream.mark(Int.MAX_VALUE)
 
         val imageBytes = imageStream.readBytes()
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }


### PR DESCRIPTION
`InputStream.available()` is implementation-dependent, should never assume it will return the total number of bytes in the stream.

Fixes #479