### PR TITLE
Rework Duplicate Dialog and Allow Migration

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.outlined.Book
 import androidx.compose.material.icons.outlined.SwapVert
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -62,7 +63,7 @@ fun DuplicateMangaDialog(
                 style = MaterialTheme.typography.bodyMedium,
             )
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(PaddingSize))
 
             TextPreferenceWidget(
                 title = stringResource(MR.strings.action_show_manga),
@@ -73,6 +74,8 @@ fun DuplicateMangaDialog(
                 },
             )
 
+            HorizontalDivider()
+
             TextPreferenceWidget(
                 title = stringResource(MR.strings.action_migrate_duplicate),
                 icon = Icons.Outlined.SwapVert,
@@ -81,6 +84,8 @@ fun DuplicateMangaDialog(
                     onMigrate()
                 },
             )
+
+            HorizontalDivider()
 
             TextPreferenceWidget(
                 title = stringResource(MR.strings.action_add_anyway),
@@ -91,27 +96,31 @@ fun DuplicateMangaDialog(
                 },
             )
 
-            HorizontalDivider()
-
             Row(
                 modifier = Modifier
                     .sizeIn(minHeight = minHeight)
                     .clickable { onDismissRequest.invoke() }
+                    .padding(ButtonPadding)
                     .fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center,
             ) {
-                Text(
-                    modifier = Modifier
-                        .padding(vertical = 16.dp),
-                    text = stringResource(MR.strings.action_cancel),
-                    color = MaterialTheme.colorScheme.primary,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontSize = 16.sp,
-                )
+                OutlinedButton(onClick = onDismissRequest, modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        modifier = Modifier
+                            .padding(vertical = 8.dp),
+                        text = stringResource(MR.strings.action_cancel),
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontSize = 16.sp,
+                    )
+                }
             }
         }
     }
 }
 
+private val PaddingSize = 16.dp
+
+private val ButtonPadding = PaddingValues(top = 16.dp, bottom = 16.dp)
 private val TitlePadding = PaddingValues(bottom = 16.dp, top = 8.dp)

--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -1,16 +1,32 @@
 package eu.kanade.presentation.manga
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Book
+import androidx.compose.material.icons.outlined.SwapVert
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.kanade.presentation.components.AdaptiveSheet
+import eu.kanade.presentation.components.TabbedDialogPaddings
+import eu.kanade.presentation.more.settings.LocalPreferenceMinHeight
+import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
@@ -18,42 +34,84 @@ fun DuplicateMangaDialog(
     onDismissRequest: () -> Unit,
     onConfirm: () -> Unit,
     onOpenManga: () -> Unit,
+    onMigrate: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    AlertDialog(
+    val minHeight = LocalPreferenceMinHeight.current
+
+    AdaptiveSheet(
+        modifier = modifier,
         onDismissRequest = onDismissRequest,
-        title = {
-            Text(text = stringResource(MR.strings.are_you_sure))
-        },
-        text = {
-            Text(text = stringResource(MR.strings.confirm_add_duplicate_manga))
-        },
-        confirmButton = {
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(
+                    vertical = TabbedDialogPaddings.Vertical,
+                    horizontal = TabbedDialogPaddings.Horizontal,
+                )
+                .fillMaxWidth(),
+        ) {
+            Text(
+                modifier = Modifier.padding(TitlePadding),
+                text = stringResource(MR.strings.are_you_sure),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+
+            Text(
+                text = stringResource(MR.strings.confirm_add_duplicate_manga),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            TextPreferenceWidget(
+                title = stringResource(MR.strings.action_show_manga),
+                icon = Icons.Outlined.Book,
+                onPreferenceClick = {
+                    onDismissRequest()
+                    onOpenManga()
+                },
+            )
+
+            TextPreferenceWidget(
+                title = stringResource(MR.strings.action_migrate_duplicate),
+                icon = Icons.Outlined.SwapVert,
+                onPreferenceClick = {
+                    onDismissRequest()
+                    onMigrate()
+                },
+            )
+
+            TextPreferenceWidget(
+                title = stringResource(MR.strings.action_add_anyway),
+                icon = Icons.Outlined.Add,
+                onPreferenceClick = {
+                    onDismissRequest()
+                    onConfirm()
+                },
+            )
+
+            HorizontalDivider()
+
+            Row(
+                modifier = Modifier
+                    .sizeIn(minHeight = minHeight)
+                    .clickable { onDismissRequest.invoke() }
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
             ) {
-                TextButton(
-                    onClick = {
-                        onDismissRequest()
-                        onOpenManga()
-                    },
-                ) {
-                    Text(text = stringResource(MR.strings.action_show_manga))
-                }
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                TextButton(onClick = onDismissRequest) {
-                    Text(text = stringResource(MR.strings.action_cancel))
-                }
-                TextButton(
-                    onClick = {
-                        onDismissRequest()
-                        onConfirm()
-                    },
-                ) {
-                    Text(text = stringResource(MR.strings.action_add))
-                }
+                Text(
+                    modifier = Modifier
+                        .padding(vertical = 16.dp),
+                    text = stringResource(MR.strings.action_cancel),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontSize = 16.sp,
+                )
             }
-        },
-    )
+        }
+    }
 }
+
+private val TitlePadding = PaddingValues(bottom = 16.dp, top = 8.dp)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -76,7 +76,7 @@ data class SourceSearchScreen(
         ) { paddingValues ->
             val pagingFlow by screenModel.mangaPagerFlowFlow.collectAsState()
             val openMigrateDialog: (Manga) -> Unit = {
-                screenModel.setDialog(BrowseSourceScreenModel.Dialog.Migrate(it))
+                screenModel.setDialog(BrowseSourceScreenModel.Dialog.Migrate(newManga = it, oldManga = oldManga))
             }
             BrowseSourceContent(
                 source = screenModel.source,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -262,7 +262,6 @@ data class BrowseSourceScreen(
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
                     onPopScreen = {
                         onDismissRequest()
-//                        navigator.push(MangaScreen(dialog.newManga.id))
                     },
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.NewReleases
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -47,6 +46,8 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.browse.extension.details.SourcePreferencesScreen
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialogScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel.Listing
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -253,7 +254,17 @@ data class BrowseSourceScreen(
             }
 
             is BrowseSourceScreenModel.Dialog.Migrate -> {
-                AlertDialog(onDismissRequest = { /*TODO*/ }, confirmButton = { /*TODO*/ })
+                MigrateDialog(
+                    oldManga = dialog.oldManga,
+                    newManga = dialog.newManga,
+                    screenModel = MigrateDialogScreenModel(),
+                    onDismissRequest = onDismissRequest,
+                    onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
+                    onPopScreen = {
+                        onDismissRequest()
+//                        navigator.push(MangaScreen(dialog.newManga.id))
+                    },
+                )
             }
             is BrowseSourceScreenModel.Dialog.RemoveManga -> {
                 RemoveMangaDialog(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.NewReleases
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -245,7 +246,14 @@ data class BrowseSourceScreen(
                     onDismissRequest = onDismissRequest,
                     onConfirm = { screenModel.addFavorite(dialog.manga) },
                     onOpenManga = { navigator.push(MangaScreen(dialog.duplicate.id)) },
+                    onMigrate = {
+                        screenModel.setDialog(BrowseSourceScreenModel.Dialog.Migrate(dialog.manga, dialog.duplicate))
+                    },
                 )
+            }
+
+            is BrowseSourceScreenModel.Dialog.Migrate -> {
+                AlertDialog(onDismissRequest = { /*TODO*/ }, confirmButton = { /*TODO*/ })
             }
             is BrowseSourceScreenModel.Dialog.RemoveManga -> {
                 RemoveMangaDialog(
@@ -267,7 +275,6 @@ data class BrowseSourceScreen(
                     },
                 )
             }
-            is BrowseSourceScreenModel.Dialog.Migrate -> {}
             else -> {}
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -345,7 +345,6 @@ class BrowseSourceScreenModel(
             val manga: Manga,
             val initialSelection: ImmutableList<CheckboxState.State<Category>>,
         ) : Dialog
-
         data class Migrate(val newManga: Manga, val oldManga: Manga) : Dialog
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -345,7 +345,8 @@ class BrowseSourceScreenModel(
             val manga: Manga,
             val initialSelection: ImmutableList<CheckboxState.State<Category>>,
         ) : Dialog
-        data class Migrate(val newManga: Manga) : Dialog
+
+        data class Migrate(val newManga: Manga, val oldManga: Manga) : Dialog
     }
 
     @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -40,6 +40,8 @@ import eu.kanade.presentation.util.isTabletUi
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isLocalOrStub
 import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialogScreenModel
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
@@ -185,11 +187,29 @@ class MangaScreen(
                     },
                 )
             }
-            is MangaScreenModel.Dialog.DuplicateManga -> DuplicateMangaDialog(
-                onDismissRequest = onDismissRequest,
-                onConfirm = { screenModel.toggleFavorite(onRemoved = {}, checkDuplicate = false) },
-                onOpenManga = { navigator.push(MangaScreen(dialog.duplicate.id)) },
-            )
+
+            is MangaScreenModel.Dialog.DuplicateManga -> {
+                DuplicateMangaDialog(
+                    onDismissRequest = onDismissRequest,
+                    onConfirm = { screenModel.toggleFavorite(onRemoved = {}, checkDuplicate = false) },
+                    onOpenManga = { navigator.push(MangaScreen(dialog.duplicate.id)) },
+                    onMigrate = {
+                        logcat(priority = LogPriority.ERROR) { "MADDIE3: The fox jumps over smaller foxes" }
+                        screenModel.showMigrateDialog(dialog.duplicate)
+                    },
+                )
+            }
+
+            is MangaScreenModel.Dialog.Migrate -> {
+                MigrateDialog(
+                    oldManga = dialog.oldManga,
+                    newManga = dialog.newManga,
+                    screenModel = MigrateDialogScreenModel(),
+                    onDismissRequest = onDismissRequest,
+                    onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
+                    onPopScreen = { navigator.replace(MangaScreen(dialog.newManga.id)) },
+                )
+            }
             MangaScreenModel.Dialog.SettingsSheet -> ChapterSettingsDialog(
                 onDismissRequest = onDismissRequest,
                 manga = successState.manga,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -194,7 +194,6 @@ class MangaScreen(
                     onConfirm = { screenModel.toggleFavorite(onRemoved = {}, checkDuplicate = false) },
                     onOpenManga = { navigator.push(MangaScreen(dialog.duplicate.id)) },
                     onMigrate = {
-                        logcat(priority = LogPriority.ERROR) { "MADDIE3: The fox jumps over smaller foxes" }
                         screenModel.showMigrateDialog(dialog.duplicate)
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1003,6 +1003,7 @@ class MangaScreenModel(
         ) : Dialog
         data class DeleteChapters(val chapters: List<Chapter>) : Dialog
         data class DuplicateManga(val manga: Manga, val duplicate: Manga) : Dialog
+        data class Migrate(val newManga: Manga, val oldManga: Manga) : Dialog
         data class SetFetchInterval(val manga: Manga) : Dialog
         data object SettingsSheet : Dialog
         data object TrackSheet : Dialog
@@ -1027,6 +1028,11 @@ class MangaScreenModel(
 
     fun showCoverDialog() {
         updateSuccessState { it.copy(dialog = Dialog.FullCover) }
+    }
+
+    fun showMigrateDialog(duplicate: Manga) {
+        val manga = successState?.manga ?: return
+        updateSuccessState { it.copy(dialog = Dialog.Migrate(newManga = manga, oldManga = duplicate)) }
     }
 
     fun setExcludedScanlators(excludedScanlators: Set<String>) {

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -160,6 +160,8 @@
     <string name="action_webview_refresh">Refresh</string>
     <string name="action_start_downloading_now">Start downloading now</string>
     <string name="action_not_now">Not now</string>
+    <string name="action_add_anyway">Add anyway</string>
+    <string name="action_migrate_duplicate">Migrate existing entry</string>
 
     <!-- Operations -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
Added the option to migrate a manga to a different source directly from the Duplicate found dialog. Because of the additional options, the dialog has been reworked into a sheet.
Behavior works on both locations for the Duplicate dialog to appear (Manga page and Source Browser). 
There is a small graphical anomaly when migrating on the Manga screen where the dialog persists on screen very briefly.

Closes #489 

### Images
| Phone UI | Tablet UI |
| ------- | ------ |
| ![image](https://github.com/mihonapp/mihon/assets/1882979/66502a22-f4d1-4317-974d-ecc72e675c8d?width=540&height=1200) | ![image](https://github.com/mihonapp/mihon/assets/1882979/498f8afc-cdc7-4f45-ab60-30355eaedac3) |
