### PR TITLE
Switch to seconds for DATE_MODIFIED of saved pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
@@ -79,7 +79,7 @@ class ImageSaver(
             MediaStore.Images.Media.RELATIVE_PATH to relativePath,
             MediaStore.Images.Media.DISPLAY_NAME to image.name,
             MediaStore.Images.Media.MIME_TYPE to type.mime,
-            MediaStore.Images.Media.DATE_MODIFIED to Instant.now().toEpochMilli(),
+            MediaStore.Images.Media.DATE_MODIFIED to Instant.now().epochSecond,
         )
 
         val picture = findUriOrDefault(relativePath, filename) {


### PR DESCRIPTION
While most Android skins are seemingly able to handle the millisecond format, the documentation technically specifies seconds. This seems to be causing issues on Samsung devices using the Samsung Gallery app, which renders the millisecond timestamps as if they were second ones, causing the dates to be set at some point in the year 56189.

This change should fix that issue on Samsung devices and have no real impact on the rest.

Credit to @sirlag for figuring out the core issue :)

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
