### PR TITLE
Fix recycled item's height being 0 in webtoon mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -118,6 +118,7 @@ class WebtoonPageHolder(
         removeErrorLayout()
         frame.recycle()
         progressIndicator.setProgress(0)
+        progressContainer.isVisible = true
     }
 
     /**


### PR DESCRIPTION
Which will prevent the new image from being decoded until it's visible.

Fixes #556 