### PR TITLE
Fix repo name used for URL instead of baseUrl

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
@@ -47,7 +47,7 @@ fun ExtensionReposContent(
             item {
                 ExtensionRepoListItem(
                     modifier = Modifier.animateItemPlacement(),
-                    repo = it.name,
+                    repo = it.baseUrl,
                     onOpenWebsite = { onOpenWebsite(it) },
                     onDelete = { onClickDelete(it.baseUrl) },
                 )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposContent.kt
@@ -47,7 +47,7 @@ fun ExtensionReposContent(
             item {
                 ExtensionRepoListItem(
                     modifier = Modifier.animateItemPlacement(),
-                    repo = it.baseUrl,
+                    repo = it,
                     onOpenWebsite = { onOpenWebsite(it) },
                     onDelete = { onClickDelete(it.baseUrl) },
                 )
@@ -58,7 +58,7 @@ fun ExtensionReposContent(
 
 @Composable
 private fun ExtensionRepoListItem(
-    repo: String,
+    repo: ExtensionRepo,
     onOpenWebsite: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
@@ -80,7 +80,7 @@ private fun ExtensionRepoListItem(
         ) {
             Icon(imageVector = Icons.AutoMirrored.Outlined.Label, contentDescription = null)
             Text(
-                text = repo,
+                text = repo.name,
                 modifier = Modifier.padding(start = MaterialTheme.padding.medium),
                 style = MaterialTheme.typography.titleMedium,
             )
@@ -99,7 +99,7 @@ private fun ExtensionRepoListItem(
 
             IconButton(
                 onClick = {
-                    val url = "$repo/index.min.json"
+                    val url = "${repo.baseUrl}/index.min.json"
                     context.copyToClipboard(url, url)
                 },
             ) {


### PR DESCRIPTION
This applies to both the item being shown in the screen as well as the “copy to clipboard” button. Before, copying a repo URL would return “The Repo Name/index.json.min”. This PR fixes that.

Edit: I misunderstood the original intent, now the whole ExtensionRepo is passed to the item display, which uses the name for displaying and the baseUrl for copying the URL.