### PR TITLE
Refactor the ExtensionRepoService to use DTOs

### DIFF
--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
@@ -1,13 +1,11 @@
 package mihon.domain.extensionrepo.service
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import mihon.domain.extensionrepo.model.ExtensionRepo
 
 @Serializable
 data class ExtensionRepoMetaDto(
-    @SerialName("meta")
-    val repo: ExtensionRepoDto,
+    val meta: ExtensionRepoDto,
 )
 
 @Serializable
@@ -21,9 +19,9 @@ data class ExtensionRepoDto(
 fun ExtensionRepoMetaDto.toExtensionRepo(baseUrl: String): ExtensionRepo {
     return ExtensionRepo(
         baseUrl = baseUrl,
-        name = repo.name,
-        shortName = repo.shortName,
-        website = repo.website,
-        signingKeyFingerprint = repo.signingKeyFingerprint,
+        name = meta.name,
+        shortName = meta.shortName,
+        website = meta.website,
+        signingKeyFingerprint = meta.signingKeyFingerprint,
     )
 }

--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoDto.kt
@@ -1,0 +1,29 @@
+package mihon.domain.extensionrepo.service
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import mihon.domain.extensionrepo.model.ExtensionRepo
+
+@Serializable
+data class ExtensionRepoMetaDto(
+    @SerialName("meta")
+    val repo: ExtensionRepoDto,
+)
+
+@Serializable
+data class ExtensionRepoDto(
+    val name: String,
+    val shortName: String?,
+    val website: String,
+    val signingKeyFingerprint: String,
+)
+
+fun ExtensionRepoMetaDto.toExtensionRepo(baseUrl: String): ExtensionRepo {
+    return ExtensionRepo(
+        baseUrl = baseUrl,
+        name = repo.name,
+        shortName = repo.shortName,
+        website = repo.website,
+        signingKeyFingerprint = repo.signingKeyFingerprint,
+    )
+}

--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
@@ -2,13 +2,14 @@ package mihon.domain.extensionrepo.service
 
 import androidx.core.net.toUri
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
 import kotlinx.serialization.json.Json
+import logcat.LogPriority
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import okhttp3.OkHttpClient
 import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.injectLazy
 
 class ExtensionRepoService(
@@ -17,6 +18,7 @@ class ExtensionRepoService(
 
     private val json: Json by injectLazy()
 
+    @Suppress("TooGenericExceptionCaught")
     suspend fun fetchRepoDetails(
         repo: String,
     ): ExtensionRepo? {
@@ -30,7 +32,8 @@ class ExtensionRepoService(
                         .parseAs<ExtensionRepoMetaDto>()
                         .toExtensionRepo(baseUrl = repo)
                 }
-            } catch (_: HttpException) {
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to fetch repo details" }
                 null
             }
         }

--- a/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/service/ExtensionRepoService.kt
@@ -6,9 +6,6 @@ import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import okhttp3.OkHttpClient
 import tachiyomi.core.common.util.lang.withIOContext
@@ -27,31 +24,15 @@ class ExtensionRepoService(
             val url = "$repo/repo.json".toUri()
 
             try {
-                val response = with(json) {
+                with(json) {
                     client.newCall(GET(url.toString()))
                         .awaitSuccess()
-                        .parseAs<JsonObject>()
+                        .parseAs<ExtensionRepoMetaDto>()
+                        .toExtensionRepo(baseUrl = repo)
                 }
-                response["meta"]
-                    ?.jsonObject
-                    ?.let { jsonToExtensionRepo(baseUrl = repo, it) }
             } catch (_: HttpException) {
                 null
             }
-        }
-    }
-
-    private fun jsonToExtensionRepo(baseUrl: String, obj: JsonObject): ExtensionRepo? {
-        return try {
-            ExtensionRepo(
-                baseUrl = baseUrl,
-                name = obj["name"]!!.jsonPrimitive.content,
-                shortName = obj["shortName"]?.jsonPrimitive?.content,
-                website = obj["website"]!!.jsonPrimitive.content,
-                signingKeyFingerprint = obj["signingKeyFingerprint"]!!.jsonPrimitive.content,
-            )
-        } catch (_: NullPointerException) {
-            null
         }
     }
 }


### PR DESCRIPTION
Slightly refactored the `ExtensionRepoService` so it uses DTO data classes with `parseAs` to avoid parsing the JSON response by hand.

The default Json instance Injekt provides here has `ignoreUnknownKeys` enabled, so the `ExtensionRepoMetaDto` only specifies the meta key of the response content.

The extension function `toExtensionRepo` allows for mapping the new DTO to the `domain`'s `ExtensionRepo` data class.