### PR TITLE
Moves upcoming requirement from existence to current day or later.

### DIFF
--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -67,6 +67,7 @@ class MangaRepositoryImpl(
         }
     }
 
+    @Suppress("MagicNumber")
     override suspend fun getUpcomingManga(statuses: Set<Long>): Flow<List<Manga>> {
         val epochMillis = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toEpochSecond() * 1000
         return handler.subscribeToList {

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -10,6 +10,8 @@ import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.repository.MangaRepository
+import java.time.LocalDate
+import java.time.ZoneId
 
 class MangaRepositoryImpl(
     private val handler: DatabaseHandler,
@@ -66,8 +68,9 @@ class MangaRepositoryImpl(
     }
 
     override suspend fun getUpcomingManga(statuses: Set<Long>): Flow<List<Manga>> {
+        val epochMillis = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toEpochSecond() * 1000
         return handler.subscribeToList {
-            mangasQueries.getUpcomingManga(statuses, MangaMapper::mapManga)
+            mangasQueries.getUpcomingManga(epochMillis, statuses, MangaMapper::mapManga)
         }
     }
 

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -115,7 +115,7 @@ AND _id != :id;
 getUpcomingManga:
 SELECT *
 FROM mangas
-WHERE next_update > 0
+WHERE next_update >= :startOfDay
 AND favorite = 1
 AND status IN :statuses
 ORDER BY next_update ASC;


### PR DESCRIPTION
Super quick fix for @Soitora to ensure that manga with update dates in the future don't display in the upcoming page.