### PR TITLE
fix: check order before restore from backup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -17,14 +17,18 @@ class CategoriesRestorer(
         if (backupCategories.isNotEmpty()) {
             val dbCategories = getCategories.await()
             val dbCategoriesByName = dbCategories.associateBy { it.name }
+            var nextOrder = dbCategories.maxOfOrNull { it.order }?.plus(1) ?: 0
 
-            val categories = backupCategories.map {
-                dbCategoriesByName[it.name]
-                    ?: handler.awaitOneExecutable {
-                        categoriesQueries.insert(it.name, it.order, it.flags)
-                        categoriesQueries.selectLastInsertedRowId()
-                    }.let { id -> it.toCategory(id) }
-            }
+            val categories = backupCategories
+                .sortedBy { it.order }
+                .map {
+                    val newOrder = nextOrder++
+                    dbCategoriesByName[it.name]
+                        ?: handler.awaitOneExecutable {
+                            categoriesQueries.insert(it.name, newOrder, it.flags)
+                            categoriesQueries.selectLastInsertedRowId()
+                        }.let { id -> it.toCategory(id).copy(order = newOrder) }
+                }
 
             libraryPreferences.categorizedDisplaySettings().set(
                 (dbCategories + categories)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -21,6 +21,7 @@ class CategoriesRestorer(
 
             val categories = backupCategories
                 .sortedBy { it.order }
+                .distinctBy { it.name }
                 .map {
                     val newOrder = nextOrder++
                     dbCategoriesByName[it.name]


### PR DESCRIPTION
When categories have the same order in the database, the export feature and the restore feature won't work because they use `order` as the key for manga categories.

Close #632 