### PR TITLE
Update compose bom and fix renovate config for it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,11 +7,19 @@
   "labels": ["Dependencies"],
   "packageRules": [
     {
+      "groupName": "Compose BOM",
+      "matchPackageNames": [
+        "dev.chrisbanes.compose:compose-bom"
+      ],
+      "ignoreUnstable": false
+    },
+    {
       // Compiler plugins are tightly coupled to Kotlin version
       "groupName": "Kotlin",
       "matchPackagePrefixes": [
         "androidx.compose.compiler",
-        "org.jetbrains.kotlin",
+        "org.jetbrains.kotlin.",
+        "org.jetbrains.kotlin:"
       ],
     }
   ]

--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 compiler = "1.5.11"
-compose-bom = "2024.02.00-alpha02"
+# 2024.04.00-alpha01 has several bugs with the new animateItem() modifier
+compose-bom = "2024.03.00-alpha02"
 accompanist = "0.35.0-alpha"
 
 [libraries]

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
@@ -122,7 +122,7 @@ fun AdaptiveSheet(
             )
         }
         val internalOnDismissRequest = {
-            if (anchoredDraggableState.currentValue == 0) {
+            if (anchoredDraggableState.settledValue == 0) {
                 scope.launch { anchoredDraggableState.animateTo(1) }
             }
         }
@@ -192,7 +192,7 @@ fun AdaptiveSheet(
 
             LaunchedEffect(anchoredDraggableState) {
                 scope.launch { anchoredDraggableState.animateTo(0) }
-                snapshotFlow { anchoredDraggableState.currentValue }
+                snapshotFlow { anchoredDraggableState.settledValue }
                     .drop(1)
                     .filter { it == 1 }
                     .collectLatest {


### PR DESCRIPTION
* This PR is not to update to the latest Compose BOM due to regressions found in Compose Foundation `1.7.0-alpha06`.
* Chris Banes' Compose BOM is always unstable so renovate won't update it.
* `org.jetbrains.kotlin` prefix is too permissive and will match kotlinx dependencies.
* `AnchoredDraggable`'s `currentValue` has its behaviour changed in Compose Foundation [`1.7.0-alpha05`](https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.7.0-alpha05).
* Compose Material 3 [`1.3.0-alpha02`](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.3.0-alpha02) fixed the RTL issue with `Slider`, and [`1.3.0-alpha03`](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.3.0-alpha03) updated `Slider` specs.

Fixes #651