### PR TITLE
Add MyAnimeList issue autoclose

### DIFF
--- a/.github/workflows/issue_moderator.yml
+++ b/.github/workflows/issue_moderator.yml
@@ -30,6 +30,12 @@ jobs:
                 "ignoreCase": true,
                 "labels": ["Cloudflare protected"],
                 "message": "Refer to the **Solving Cloudflare issues** section at https://mihon.app/docs/guides/troubleshooting/#cloudflare. If it doesn't work, migrate to other sources or wait until they lower their protection."
+              },
+              {
+                "type": "both",
+                "regex": "^.*(myanimelist|mal).*$",
+                "ignoreCase": true,
+                "message": "For issues with linking MyAnimeList, please follow these steps:\n1. Update Mihon to version 0.16.4 or newer\n2. Change your default User-Agent (`More → Settings → Advanced → Default user agent string`)\n3. Close and restart Mihon\n4. Attempt to link MyAnimeList again\n\nIf you had MyAnimeList linked before, try to unlink it first before trying these steps."
               }
             ]
           auto-close-ignore-label: do-not-autoclose


### PR DESCRIPTION
This rule is intended to automatically close issues that report problems with linking MAL that would be solved with the standard solution of updating & changing the default UA.

The RegEx might be too general, but there isn't any neat pattern in the previously filed issues.

Also not sure if the listed version should stay as "0.16.4 or newer" or if it should be changed to the latest version when cutting a release.

The response would look like this:

For issues with linking MyAnimeList, please follow these steps:
1. Update Mihon to version 0.16.4 or newer
2. Change your default User-Agent (`More → Settings → Advanced → Default user agent string`)
3. Close and restart Mihon
4. Attempt to link MyAnimeList again

If you had MyAnimeList linked before, try to unlink it first before trying these steps.