### PR TITLE
fix: storage permission request for non-conforming devices

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -120,7 +120,7 @@ object SettingsDataScreen : SearchableSettings {
                     context.contentResolver.takePersistableUriPermission(uri, flags)
                 } catch (e: SecurityException) {
                     logcat(LogPriority.ERROR, e)
-                    context.toast(MR.strings.file_picker_no_uri_permission_supported)
+                    context.toast(MR.strings.file_picker_uri_permission_unsupported)
                 }
 
                 UniFile.fromUri(context, uri)?.let {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -111,7 +111,16 @@ object SettingsDataScreen : SearchableSettings {
                 val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
                     Intent.FLAG_GRANT_WRITE_URI_PERMISSION
 
-                context.contentResolver.takePersistableUriPermission(uri, flags)
+                // For some reason InkBook devices do not implement the SAF properly. Persistable URI grants do not
+                // work. However, simply retrieving the URI and using it works fine for these devices. Access is not
+                // revoked after the app is closed or the device is restarted.
+                // This also holds for some Samsung devices. Thus, we simply execute inside of a try-catch block and
+                // ignore the exception if it is thrown.
+                try {
+                    context.contentResolver.takePersistableUriPermission(uri, flags)
+                } catch (e: RuntimeException) {
+                    logcat(LogPriority.ERROR, e)
+                }
 
                 UniFile.fromUri(context, uri)?.let {
                     storageDirPref.set(it.uri.toString())

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -118,7 +118,7 @@ object SettingsDataScreen : SearchableSettings {
                 // ignore the exception if it is thrown.
                 try {
                     context.contentResolver.takePersistableUriPermission(uri, flags)
-                } catch (e: RuntimeException) {
+                } catch (e: SecurityException) {
                     logcat(LogPriority.ERROR, e)
                 }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -120,6 +120,7 @@ object SettingsDataScreen : SearchableSettings {
                     context.contentResolver.takePersistableUriPermission(uri, flags)
                 } catch (e: SecurityException) {
                     logcat(LogPriority.ERROR, e)
+                    context.toast(MR.strings.file_picker_no_uri_permission_supported)
                 }
 
                 UniFile.fromUri(context, uri)?.let {

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -869,7 +869,7 @@
     <string name="file_select_cover">Select cover image</string>
     <string name="file_select_backup">Select backup file</string>
     <string name="file_picker_error">No file picker app found</string>
-    <string name="file_picker_no_uri_permission_supported">Your device does not support persistent folder access. The app might still work without it.</string>
+    <string name="file_picker_uri_permission_unsupported">Failed to acquire persistent folder access. The app may behave unexpectedly.</string>
     <string name="file_null_uri_error">No file selected</string>
 
     <!--UpdateCheck-->

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -869,6 +869,7 @@
     <string name="file_select_cover">Select cover image</string>
     <string name="file_select_backup">Select backup file</string>
     <string name="file_picker_error">No file picker app found</string>
+    <string name="file_picker_no_uri_permission_supported">Your device does not support persistent folder access. The app might still work without them.</string>
     <string name="file_null_uri_error">No file selected</string>
 
     <!--UpdateCheck-->

--- a/i18n/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n/src/commonMain/resources/MR/base/strings.xml
@@ -869,7 +869,7 @@
     <string name="file_select_cover">Select cover image</string>
     <string name="file_select_backup">Select backup file</string>
     <string name="file_picker_error">No file picker app found</string>
-    <string name="file_picker_no_uri_permission_supported">Your device does not support persistent folder access. The app might still work without them.</string>
+    <string name="file_picker_no_uri_permission_supported">Your device does not support persistent folder access. The app might still work without it.</string>
     <string name="file_null_uri_error">No file selected</string>
 
     <!--UpdateCheck-->


### PR DESCRIPTION
Re-opened #645 due to me doing a wrong `rebase`.
Fixes #395.

I had the same issue with a news app I've programmed.

These devices run a custom Android OS that does not correctly implement the SAF. The `FileProvider` that is responsible for handling the `OPEN_DOCUMENT_TREE` `Intent` probably does not set the `PERSISTABLE_URI` flag. Thus, the call to `takePersistableUriPermission` fails with a `SecurityException`; no valid tickets are available.

This workaround gets the user passed the onboarding screen. I have tested this using manga I bought online and the default file path of `/Mihon`. 

I want to note that, after selecting the file path during the onboarding experience, the app would still tell me `No folder has been selected`, but the next button was clickable. I think the issue is that the selected path is the default path, thus the validation logic assumes no (custom) path has been selected.

To make this work with @rpr13 's device, one would have to add the model name to the list.