### PR TITLE
Massively improve findFile performance

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -57,7 +57,7 @@ class DownloadProvider(
      * @param source the source to query.
      */
     fun findSourceDir(source: Source): UniFile? {
-        return downloadsDir?.findFile(getSourceDirName(source), true)
+        return downloadsDir?.findFile(getSourceDirName(source))
     }
 
     /**
@@ -68,7 +68,7 @@ class DownloadProvider(
      */
     fun findMangaDir(mangaTitle: String, source: Source): UniFile? {
         val sourceDir = findSourceDir(source)
-        return sourceDir?.findFile(getMangaDirName(mangaTitle), true)
+        return sourceDir?.findFile(getMangaDirName(mangaTitle))
     }
 
     /**
@@ -82,7 +82,7 @@ class DownloadProvider(
     fun findChapterDir(chapterName: String, chapterScanlator: String?, mangaTitle: String, source: Source): UniFile? {
         val mangaDir = findMangaDir(mangaTitle, source)
         return getValidChapterDirNames(chapterName, chapterScanlator).asSequence()
-            .mapNotNull { mangaDir?.findFile(it, true) }
+            .mapNotNull { mangaDir?.findFile(it) }
             .firstOrNull()
     }
 
@@ -97,7 +97,7 @@ class DownloadProvider(
         val mangaDir = findMangaDir(manga.title, source) ?: return null to emptyList()
         return mangaDir to chapters.mapNotNull { chapter ->
             getValidChapterDirNames(chapter.name, chapter.scanlator).asSequence()
-                .mapNotNull { mangaDir.findFile(it, true) }
+                .mapNotNull { mangaDir.findFile(it) }
                 .firstOrNull()
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -645,7 +645,7 @@ class Downloader(
         )
 
         // Remove the old file
-        dir.findFile(COMIC_INFO_FILE, true)?.delete()
+        dir.findFile(COMIC_INFO_FILE)?.delete()
         dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {
             val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
             it.write(comicInfoString.toByteArray())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ quickjs-android = "app.cash.quickjs:quickjs-android:0.9.2"
 jsoup = "org.jsoup:jsoup:1.17.2"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
-unifile = "com.github.tachiyomiorg:unifile:7c257e1c64"
+unifile = "com.github.raxod502:unifile:65c24368c6"  # TODO: update to mihonapp org after PR merge
 common-compress = "org.apache.commons:commons-compress:1.26.1"
 junrar = "com.github.junrar:junrar:7.5.5"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ quickjs-android = "app.cash.quickjs:quickjs-android:0.9.2"
 jsoup = "org.jsoup:jsoup:1.17.2"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
-unifile = "com.github.raxod502:unifile:65c24368c6"  # TODO: update to mihonapp org after PR merge
+unifile = "com.github.tachiyomiorg:unifile:e0def6b3dc"
 common-compress = "org.apache.commons:commons-compress:1.26.1"
 junrar = "com.github.junrar:junrar:7.5.5"
 

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -300,8 +300,8 @@ actual class LocalSource(
         try {
             val (mangaDirName, chapterName) = chapter.url.split('/', limit = 2)
             return fileSystem.getBaseDirectory()
-                ?.findFile(mangaDirName, true)
-                ?.findFile(chapterName, true)
+                ?.findFile(mangaDirName)
+                ?.findFile(chapterName)
                 ?.let(Format.Companion::valueOf)
                 ?: throw Exception(context.stringResource(MR.strings.chapter_not_found))
         } catch (e: Format.UnknownFormatException) {

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/io/LocalSourceFileSystem.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/io/LocalSourceFileSystem.kt
@@ -17,7 +17,7 @@ actual class LocalSourceFileSystem(
 
     actual fun getMangaDirectory(name: String): UniFile? {
         return getBaseDirectory()
-            ?.findFile(name, true)
+            ?.findFile(name)
             ?.takeIf { it.isDirectory }
     }
 


### PR DESCRIPTION
Please see https://github.com/mihonapp/mihon/issues/705 for a technical discussion of the issue being solved here. This is a follow-on to https://github.com/tachiyomiorg/UniFile/pull/2, which uses the newly optimized version of UniFile and adjusts `findFile` callsites to adapt to the removed `ignoreCase` argument.

As per standard development procedure, this branch can be compiled using `./gradlew assembleDevDebug` and installed for testing. I have temporarily configured `libs.versions.toml` to pull the specific commit from my UniFile branch via [JitPack](https://jitpack.io/), but this will of course be updated to point to the official repository master branch once the other pull request is merged (and/or the repository, which still lives under the legacy `tachiyomiorg` organization, is moved under `mihonapp`).

If you wish to test your own changes to UniFile without pushing to GitHub, the following procedure can be used:

1. Compile UniFile debug build with `./gradlew assembleDebug`, using Java 11 because Java 17 is too recent (e.g. on Ubuntu with the relevant packages installed set `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64`).
2. Comment out the `unifile` version pin in `libs.versions.toml` to ensure that no part of the build accidentally pulls from the published version.
3. Find all occurrences of `implementation(libs.unifile)` in project `build.gradle.kts` files and replace them with `implementation(files("/path/to/UniFile/library/build/outputs/aar/library-debug.aar"))` based on your dev environment's setup.
4. Compile as usual with `./gradlew assembleDevDebug`, using this time Java 21.
5. (optional) Re-sign APK with `uber-apk-signer --overwrite --allowResign -a app/build/outputs/apk/dev/debug/app-dev-arm64-v8a-debug.apk` or equivalent, I found that this was necessary because for some reason the default Gradle APK signing would change signature every time the UniFile dependency JAR was rebuilt, leading to a wipe of user data on each app installation.
6. Install and test per usual. I added logging locally to the download provider and queue management to verify performance metrics.

DCO statement: The contribution was created in whole by [Radian LLC](https://radian.codes/), which attests its right to submit it to the project under the terms of the Apache License.
