### PR TITLE
Log exceptions in dumped crash logs

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/crash/CrashScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/crash/CrashScreen.kt
@@ -37,7 +37,7 @@ fun CrashScreen(
         acceptText = stringResource(MR.strings.pref_dump_crash_logs),
         onAcceptClick = {
             scope.launch {
-                CrashLogUtil(context).dumpLogs()
+                CrashLogUtil(context).dumpLogs(exception)
             }
         },
         rejectText = stringResource(MR.strings.crash_screen_restart_application),

--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -19,12 +19,13 @@ class CrashLogUtil(
     private val extensionManager: ExtensionManager = Injekt.get(),
 ) {
 
-    suspend fun dumpLogs() = withNonCancellableContext {
+    suspend fun dumpLogs(exception: Throwable? = null) = withNonCancellableContext {
         try {
             val file = context.createFileInCacheDir("mihon_crash_logs.txt")
 
             file.appendText(getDebugInfo() + "\n\n")
             getExtensionsInfo()?.let { file.appendText("$it\n\n") }
+            exception?.let { file.appendText("$it\n\n") }
 
             Runtime.getRuntime().exec("logcat *:E -d -f ${file.absolutePath}").waitFor()
 


### PR DESCRIPTION
So the user won't need to screenshot the crash screen.