### PR TITLE
Fix MigratorTest after update to io.mockk v1.13.11

### DIFF
--- a/app/src/test/java/mihon/core/migration/MigratorTest.kt
+++ b/app/src/test/java/mihon/core/migration/MigratorTest.kt
@@ -1,6 +1,5 @@
 package mihon.core.migration
 
-import io.mockk.Called
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify

--- a/app/src/test/java/mihon/core/migration/MigratorTest.kt
+++ b/app/src/test/java/mihon/core/migration/MigratorTest.kt
@@ -59,7 +59,7 @@ class MigratorTest {
         val result = execute.await()
         assertFalse(result)
 
-        verify { migrationJobFactory.create(any()) wasNot Called }
+        verify(exactly = 0) { migrationJobFactory.create(any()) }
     }
 
     @Test
@@ -72,7 +72,7 @@ class MigratorTest {
         val result = execute.await()
         assertFalse(result)
 
-        verify { migrationJobFactory.create(any()) wasNot Called }
+        verify(exactly = 0) { migrationJobFactory.create(any()) }
     }
 
     @Test


### PR DESCRIPTION
Causing error: io.mockk.MockKException: was not can only be called on a mocked object
