### PR TITLE
Continue Reading Button Update

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -50,7 +50,13 @@ object CommonMangaItemDefaults {
     const val BrowseFavoriteCoverAlpha = 0.34f
 }
 
-private val ContinueReadingButtonSize = 28.dp
+private val ContinueReadingButtonSize = mapOf(
+    "Compact" to 28.dp,
+    "Comfortable" to 35.dp,
+    "CoverOnly" to 35.dp,
+    "List" to 28.dp
+)
+
 private val ContinueReadingButtonGridPadding = 6.dp
 private val ContinueReadingButtonListSpacing = 8.dp
 
@@ -98,7 +104,8 @@ fun MangaCompactGridItem(
                     ContinueReadingButton(
                         modifier = Modifier
                             .padding(ContinueReadingButtonGridPadding)
-                            .align(Alignment.BottomEnd),
+                            .align(Alignment.BottomEnd)
+                            .size(ContinueReadingButtonSize["CoverOnly"] ?: 28.dp),
                         onClickContinueReading = onClickContinueReading,
                     )
                 }
@@ -148,10 +155,13 @@ private fun BoxScope.CoverTextOverlay(
         )
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier.padding(
-                    end = ContinueReadingButtonGridPadding,
-                    bottom = ContinueReadingButtonGridPadding,
-                ),
+                modifier = Modifier
+                    .padding(
+                        end = ContinueReadingButtonGridPadding,
+                        bottom = ContinueReadingButtonGridPadding,
+                    )
+                .size(ContinueReadingButtonSize["Compact"] ?: 28.dp),  // Default to 28.dp if key not found),
+
                 onClickContinueReading = onClickContinueReading,
             )
         }
@@ -196,7 +206,8 @@ fun MangaComfortableGridItem(
                         ContinueReadingButton(
                             modifier = Modifier
                                 .padding(ContinueReadingButtonGridPadding)
-                                .align(Alignment.BottomEnd),
+                                .align(Alignment.BottomEnd)
+                                .size(ContinueReadingButtonSize["Comfortable"] ?: 28.dp),
                             onClickContinueReading = onClickContinueReading,
                         )
                     }
@@ -354,7 +365,9 @@ fun MangaListItem(
         BadgeGroup(content = badge)
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier.padding(start = ContinueReadingButtonListSpacing),
+                modifier = Modifier
+                    .padding(start = ContinueReadingButtonListSpacing)
+                    .size(ContinueReadingButtonSize["List"] ?: 28.dp),
                 onClickContinueReading = onClickContinueReading,
             )
         }
@@ -369,7 +382,6 @@ private fun ContinueReadingButton(
     Box(modifier = modifier) {
         FilledIconButton(
             onClick = onClickContinueReading,
-            modifier = Modifier.size(ContinueReadingButtonSize),
             shape = MaterialTheme.shapes.small,
             colors = IconButtonDefaults.filledIconButtonColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.9f),

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -50,12 +50,8 @@ object CommonMangaItemDefaults {
     const val BrowseFavoriteCoverAlpha = 0.34f
 }
 
-private val ContinueReadingButtonSize = mapOf(
-    "Compact" to 28.dp,
-    "Comfortable" to 35.dp,
-    "CoverOnly" to 35.dp,
-    "List" to 28.dp
-)
+private val ContinueReadingButtonSizeSmall = 28.dp //Used for Compact and List View Modes
+private val ContinueReadingButtonSizeLarge = 32.dp //Used for Comfortable and Cover Only View Modes
 
 private val ContinueReadingButtonGridPadding = 6.dp
 private val ContinueReadingButtonListSpacing = 8.dp
@@ -102,10 +98,10 @@ fun MangaCompactGridItem(
                     )
                 } else if (onClickContinueReading != null) {
                     ContinueReadingButton(
-                        modifier = Modifier
+                        modifier = Modifier //Modifiers of ContinueReadingButton() for Cover Only Display Mode
                             .padding(ContinueReadingButtonGridPadding)
                             .align(Alignment.BottomEnd)
-                            .size(ContinueReadingButtonSize["CoverOnly"] ?: 28.dp),
+                            .size(ContinueReadingButtonSizeLarge),
                         onClickContinueReading = onClickContinueReading,
                     )
                 }
@@ -155,12 +151,12 @@ private fun BoxScope.CoverTextOverlay(
         )
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier
+                modifier = Modifier //Modifiers of ContinueReadingButton() for Compact Display Mode
                     .padding(
                         end = ContinueReadingButtonGridPadding,
                         bottom = ContinueReadingButtonGridPadding,
                     )
-                .size(ContinueReadingButtonSize["Compact"] ?: 28.dp),  // Default to 28.dp if key not found),
+                .size(ContinueReadingButtonSizeSmall),
 
                 onClickContinueReading = onClickContinueReading,
             )
@@ -204,10 +200,10 @@ fun MangaComfortableGridItem(
                 content = {
                     if (onClickContinueReading != null) {
                         ContinueReadingButton(
-                            modifier = Modifier
+                            modifier = Modifier //Modifiers of ContinueReadingButton() for Comfortable Display Mode
                                 .padding(ContinueReadingButtonGridPadding)
                                 .align(Alignment.BottomEnd)
-                                .size(ContinueReadingButtonSize["Comfortable"] ?: 28.dp),
+                                .size(ContinueReadingButtonSizeLarge),
                             onClickContinueReading = onClickContinueReading,
                         )
                     }
@@ -365,9 +361,9 @@ fun MangaListItem(
         BadgeGroup(content = badge)
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier
+                modifier = Modifier //Modifiers of ContinueReadingButton() for List Display Mode
                     .padding(start = ContinueReadingButtonListSpacing)
-                    .size(ContinueReadingButtonSize["List"] ?: 28.dp),
+                    .size(ContinueReadingButtonSizeSmall), //List
                 onClickContinueReading = onClickContinueReading,
             )
         }

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -50,8 +50,8 @@ object CommonMangaItemDefaults {
     const val BrowseFavoriteCoverAlpha = 0.34f
 }
 
-private val ContinueReadingButtonSizeSmall = 28.dp //Used for Compact and List View Modes
-private val ContinueReadingButtonSizeLarge = 32.dp //Used for Comfortable and Cover Only View Modes
+private val ContinueReadingButtonSizeSmall = 28.dp // Used for Compact and List View Modes
+private val ContinueReadingButtonSizeLarge = 32.dp // Used for Comfortable and Cover Only View Modes
 
 private val ContinueReadingButtonGridPadding = 6.dp
 private val ContinueReadingButtonListSpacing = 8.dp
@@ -98,7 +98,7 @@ fun MangaCompactGridItem(
                     )
                 } else if (onClickContinueReading != null) {
                     ContinueReadingButton(
-                        modifier = Modifier //Modifiers of ContinueReadingButton() for Cover Only Display Mode
+                        modifier = Modifier // Modifiers of ContinueReadingButton() for Cover Only Display Mode
                             .padding(ContinueReadingButtonGridPadding)
                             .align(Alignment.BottomEnd)
                             .size(ContinueReadingButtonSizeLarge),
@@ -151,13 +151,12 @@ private fun BoxScope.CoverTextOverlay(
         )
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier //Modifiers of ContinueReadingButton() for Compact Display Mode
+                modifier = Modifier // Modifiers of ContinueReadingButton() for Compact Display Mode
                     .padding(
                         end = ContinueReadingButtonGridPadding,
                         bottom = ContinueReadingButtonGridPadding,
                     )
-                .size(ContinueReadingButtonSizeSmall),
-
+                    .size(ContinueReadingButtonSizeSmall),
                 onClickContinueReading = onClickContinueReading,
             )
         }
@@ -200,7 +199,7 @@ fun MangaComfortableGridItem(
                 content = {
                     if (onClickContinueReading != null) {
                         ContinueReadingButton(
-                            modifier = Modifier //Modifiers of ContinueReadingButton() for Comfortable Display Mode
+                            modifier = Modifier // Modifiers of ContinueReadingButton() for Comfortable Display Mode
                                 .padding(ContinueReadingButtonGridPadding)
                                 .align(Alignment.BottomEnd)
                                 .size(ContinueReadingButtonSizeLarge),
@@ -361,9 +360,9 @@ fun MangaListItem(
         BadgeGroup(content = badge)
         if (onClickContinueReading != null) {
             ContinueReadingButton(
-                modifier = Modifier //Modifiers of ContinueReadingButton() for List Display Mode
+                modifier = Modifier // Modifiers of ContinueReadingButton() for List Display Mode
                     .padding(start = ContinueReadingButtonListSpacing)
-                    .size(ContinueReadingButtonSizeSmall), //List
+                    .size(ContinueReadingButtonSizeSmall),
                 onClickContinueReading = onClickContinueReading,
             )
         }


### PR DESCRIPTION
Allows the Continue Reading Button to have different sized for each Display Modes to fix #19.
I have done this specifically so that the Continue Reading buttons are larger, but not on the **Compact** display mode so that it does not cover too much of the title.

Testes on Phone and Tablet, with different Grid Sizes

### Images
| Image 1: OLD | Image 2: NEW |
| ------- | ------- |
| ![Tachiyomi_OLD](https://github.com/mihonapp/mihon/assets/40583749/90ef6700-e5c0-4681-aca5-71ac62d89088) | ![Tachiyomi_NEW](https://github.com/mihonapp/mihon/assets/40583749/c328fdba-6145-40d3-9b02-21b7923c4da3) |
