### PR TITLE
Fix R8 version configuration not working

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,5 @@
 buildscript {
-    // https://issuetracker.google.com/344363457
-    // TODO: Remove when AGP's bundled R8 is updated
-    repositories {
-        maven("https://storage.googleapis.com/r8-releases/raw")
-    }
     dependencies {
-        classpath("com.android.tools:r8:8.5.21")
         classpath(libs.android.shortcut.gradle)
         classpath(libs.google.services.gradle)
         classpath(libs.aboutLibraries.gradle)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,16 @@ pluginManagement {
         mavenCentral()
         maven(url = "https://www.jitpack.io")
     }
+    // https://issuetracker.google.com/344363457
+    // TODO: Remove when AGP's bundled R8 is updated
+    buildscript {
+        repositories {
+            maven("https://storage.googleapis.com/r8-releases/raw")
+        }
+        dependencies {
+            classpath("com.android.tools:r8:8.5.21")
+        }
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This reverts commit f3226fb278cab87422255e04e647c50095b61529.

Somehow it was still using the bundled R8, see https://github.com/FooIbar/mihon/actions/runs/9534770159 and https://github.com/FooIbar/mihon/actions/runs/9534906033

Closes #915