### PR TITLE
Fix unexpected skips in strong skipping mode

### DIFF
--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -8,6 +8,7 @@ bom = { group = "dev.chrisbanes.compose", name = "compose-bom", version.ref = "c
 foundation = { module = "androidx.compose.foundation:foundation" }
 animation = { module = "androidx.compose.animation:animation" }
 animation-graphics = { module = "androidx.compose.animation:animation-graphics" }
+runtime = { module = "androidx.compose.runtime:runtime" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 ui-util = { module = "androidx.compose.ui:ui-util" }

--- a/source-api/build.gradle.kts
+++ b/source-api/build.gradle.kts
@@ -13,6 +13,9 @@ kotlin {
                 api(libs.injekt.core)
                 api(libs.rxjava)
                 api(libs.jsoup)
+
+                implementation(project.dependencies.platform(compose.bom))
+                implementation(compose.runtime)
             }
         }
         val androidMain by getting {

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/FilterList.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/FilterList.kt
@@ -1,5 +1,8 @@
 package eu.kanade.tachiyomi.source.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 data class FilterList(val list: List<Filter<*>>) : List<Filter<*>> by list {
 
     constructor(vararg fs: Filter<*>) : this(if (fs.isNotEmpty()) fs.asList() else emptyList())


### PR DESCRIPTION
In strong skipping mode, Composables with unstable parameters become skippable and unstable parameters are compared using instance equality (`===`).

Since all parameters are unchanged, [`SourceFilterDialog`](https://github.com/mihonapp/mihon/blob/b37357f9097730edb1d72f1297461e580286856c/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/SourceFilterDialog.kt#L34) will be skipped.
This PR marks `FilterList` as stable to use object equality ([`Object.equals()`](https://github.com/mihonapp/mihon/blob/b37357f9097730edb1d72f1297461e580286856c/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/FilterList.kt#L8)) to compare so they will never be equal.


There are probably some similar bugs introduced by strong skipping mode unspotted.

Fixes #893 