### PR TITLE
Add safeguard to prevent ArchiveInputStream from being closed twice

### DIFF
--- a/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
+++ b/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
@@ -9,6 +9,7 @@ import kotlin.concurrent.Volatile
 
 class ArchiveInputStream(buffer: Long, size: Long) : InputStream() {
     private val lock = Any()
+    
     @Volatile
     private var isClosed = false
 

--- a/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
+++ b/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
@@ -9,7 +9,7 @@ import kotlin.concurrent.Volatile
 
 class ArchiveInputStream(buffer: Long, size: Long) : InputStream() {
     private val lock = Any()
-    
+
     @Volatile
     private var isClosed = false
 

--- a/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
+++ b/core/common/src/main/kotlin/mihon/core/common/archive/ArchiveInputStream.kt
@@ -5,8 +5,13 @@ import me.zhanghai.android.libarchive.ArchiveEntry
 import me.zhanghai.android.libarchive.ArchiveException
 import java.io.InputStream
 import java.nio.ByteBuffer
+import kotlin.concurrent.Volatile
 
 class ArchiveInputStream(buffer: Long, size: Long) : InputStream() {
+    private val lock = Any()
+    @Volatile
+    private var isClosed = false
+
     private val archive = Archive.readNew()
 
     init {
@@ -41,6 +46,11 @@ class ArchiveInputStream(buffer: Long, size: Long) : InputStream() {
     }
 
     override fun close() {
+        synchronized(lock) {
+            if (isClosed) return
+            isClosed = true
+        }
+
         Archive.readFree(archive)
     }
 


### PR DESCRIPTION
In case something try to close it twice or library change their behaviour to auto-close the InputStream (e.g. [Jsoup](https://github.com/jhy/jsoup/blob/1f1f72d1e89821c630dcfc35e1a0a7f653cc877b/src/main/java/org/jsoup/helper/DataUtil.java#L233)).

Closes GH-966