### PR TITLE
Update image-decoder revision

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp" }
 
 subsamplingscaleimageview = "com.github.tachiyomiorg:subsampling-scale-image-view:b8e1b0ed2b"
-image-decoder = "com.github.tachiyomiorg:image-decoder:e08e9be535"
+image-decoder = "com.github.tachiyomiorg:image-decoder:41c059e540"
 
 natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 


### PR DESCRIPTION
Enables >8-bit AVIF decoding. (for real this time)
Closes https://github.com/mihonapp/mihon/issues/946