### PR TITLE
Fix some issues when reading/saving images

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -17,6 +17,7 @@ import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.chapter.model.Chapter
@@ -160,7 +161,7 @@ class DownloadManager(
     fun buildPageList(source: Source, manga: Manga, chapter: Chapter): List<Page> {
         val chapterDir = provider.findChapterDir(chapter.name, chapter.scanlator, manga.title, source)
         val files = chapterDir?.listFiles().orEmpty()
-            .filter { "image" in it.type.orEmpty() }
+            .filter { it.isFile && ImageUtil.isImage(it.name) { it.openInputStream() } }
 
         if (files.isEmpty()) {
             throw Exception(context.stringResource(MR.strings.page_list_empty_error))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -523,14 +523,8 @@ class Downloader(
      * @param file the file where the image is already downloaded.
      */
     private fun getImageExtension(response: Response, file: UniFile): String {
-        // Read content type if available.
         val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
-            // Else guess from the uri.
-            ?: context.contentResolver.getType(file.uri)
-            // Else read magic numbers.
-            ?: ImageUtil.findImageType { file.openInputStream() }?.mime
-
-        return ImageUtil.getExtensionFromMimeType(mime)
+        return ImageUtil.getExtensionFromMimeType(mime) { file.openInputStream() }
     }
 
     private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.webkit.MimeTypeMap
 import androidx.annotation.RequiresApi
 import androidx.core.content.contentValuesOf
 import androidx.core.net.toUri
@@ -65,21 +66,26 @@ class ImageSaver(
         filename: String,
         data: () -> InputStream,
     ): Uri {
-        val pictureDir =
+        val isMimeTypeSupported = MimeTypeMap.getSingleton().hasMimeType(type.mime)
+
+        val pictureDir = if (isMimeTypeSupported) {
             MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        } else {
+            MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        }
 
         val imageLocation = (image.location as Location.Pictures).relativePath
         val relativePath = listOf(
-            Environment.DIRECTORY_PICTURES,
+            if (isMimeTypeSupported) Environment.DIRECTORY_PICTURES else Environment.DIRECTORY_DOCUMENTS,
             context.stringResource(MR.strings.app_name),
             imageLocation,
         ).joinToString(File.separator)
 
         val contentValues = contentValuesOf(
-            MediaStore.Images.Media.RELATIVE_PATH to relativePath,
-            MediaStore.Images.Media.DISPLAY_NAME to image.name,
-            MediaStore.Images.Media.MIME_TYPE to type.mime,
-            MediaStore.Images.Media.DATE_MODIFIED to Instant.now().epochSecond,
+            MediaStore.MediaColumns.RELATIVE_PATH to relativePath,
+            MediaStore.MediaColumns.DISPLAY_NAME to if (isMimeTypeSupported) image.name else filename,
+            MediaStore.MediaColumns.MIME_TYPE to type.mime,
+            MediaStore.MediaColumns.DATE_MODIFIED to Instant.now().epochSecond,
         )
 
         val picture = findUriOrDefault(relativePath, filename) {

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -63,8 +63,9 @@ object ImageUtil {
         }
     }
 
-    fun getExtensionFromMimeType(mime: String?): String {
-        return mime?.let { ImageType.entries.firstOrNull { it.mime == mime }?.extension } ?: "jpg"
+    fun getExtensionFromMimeType(mime: String?, openStream: () -> InputStream): String {
+        val type = mime?.let { ImageType.entries.find { it.mime == mime } } ?: findImageType(openStream)
+        return type?.extension ?: "jpg"
     }
 
     fun isAnimatedAndSupported(source: BufferedSource): Boolean {


### PR DESCRIPTION
Avoid using platform mime type map to get extensions as it may not have all mime types we support.

This also fixes the performance issue of reading jxl archives, wrong file extensions and can't open downloaded files.

Fixes #566 