### PR TITLE
feat: Komga page-based sync

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/SyncChapterProgressWithTrack.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/SyncChapterProgressWithTrack.kt
@@ -49,7 +49,7 @@ class SyncChapterProgressWithTrack(
                     if (page >= 0) chapter.toDomainChapter()?.copy(lastPageRead = page.toLong())?.toChapterUpdate() else null
                 }
         }?.getOrNull() ?: listOf()
-        if (pageReadProgressUpdates.isNotEmpty()) logcat(LogPriority.ERROR) { pageReadProgressUpdates.toString() }
+        if (pageReadProgressUpdates.isNotEmpty()) logcat(LogPriority.INFO) { pageReadProgressUpdates.toString() }
         try {
             tracker.update(updatedTrack.toDbTrack())
             updateChapter.awaitAll(chapterUpdates + pageReadProgressUpdates)

--- a/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
@@ -58,14 +58,14 @@ class TrackChapter(
         }
     }
 
-    suspend fun reportPageProgress(mangaId: Long, chapterNumber: Double, chapterUrl: String, pageIndex: Int) {
+    suspend fun reportPageProgress(mangaId: Long, chapterUrl: String, pageIndex: Int) {
         withNonCancellableContext {
             val tracks = getTracks.await(mangaId)
             if (tracks.isEmpty()) return@withNonCancellableContext
 
             tracks.mapNotNull { track ->
                 val service = trackerManager.get(track.trackerId)
-                if (service == null || !service.isLoggedIn || chapterNumber <= track.lastChapterRead || service !is PageTracker) {
+                if (service == null || !service.isLoggedIn || service !is PageTracker) {
                     return@mapNotNull null
                 }
                 async {

--- a/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
@@ -5,6 +5,7 @@ import eu.kanade.domain.track.model.toDbTrack
 import eu.kanade.domain.track.model.toDomainTrack
 import eu.kanade.domain.track.service.DelayedTrackingUpdateJob
 import eu.kanade.domain.track.store.DelayedTrackingStore
+import eu.kanade.tachiyomi.data.track.PageTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -48,6 +49,29 @@ class TrackChapter(
                             }
                             throw e
                         }
+                    }
+                }
+            }
+                .awaitAll()
+                .mapNotNull { it.exceptionOrNull() }
+                .forEach { logcat(LogPriority.WARN, it) }
+        }
+    }
+
+    suspend fun reportPageProgress(mangaId: Long, chapterNumber: Double, chapterUrl: String, pageIndex: Int) {
+        withNonCancellableContext {
+            val tracks = getTracks.await(mangaId)
+            if (tracks.isEmpty()) return@withNonCancellableContext
+
+            tracks.mapNotNull { track ->
+                val service = trackerManager.get(track.trackerId)
+                if (service == null || !service.isLoggedIn || chapterNumber <= track.lastChapterRead || service !is PageTracker) {
+                    return@mapNotNull null
+                }
+                async {
+                    runCatching {
+                        (service as PageTracker).update(track, pageIndex)
+                        (service as PageTracker).updateWithUrl(chapterUrl, pageIndex)
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/PageTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/PageTracker.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.data.track
+
+import eu.kanade.tachiyomi.data.database.models.Chapter
+
+
+/**
+ *
+ */
+interface PageTracker {
+    suspend fun update(track: tachiyomi.domain.track.model.Track, page: Int) {}
+    suspend fun updateWithUrl(chapterUrl:String, page: Int)
+
+    /**
+     * If completed it would be 0, since complete status should already be handled by EnhancedTrackers
+     */
+    suspend fun getChapterProgress(chapter: Chapter): Int
+    suspend fun batchGetChapterProgress(chapters: List<Chapter>): Map<Chapter, Int> {
+        return chapters.associateWith { getChapterProgress(it) }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
@@ -3,9 +3,11 @@ package eu.kanade.tachiyomi.data.track.komga
 import android.graphics.Color
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.EnhancedTracker
+import eu.kanade.tachiyomi.data.track.PageTracker
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.source.Source
 import kotlinx.collections.immutable.ImmutableList
@@ -16,7 +18,7 @@ import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.domain.track.model.Track as DomainTrack
 
-class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker {
+class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker, PageTracker {
 
     companion object {
         const val UNREAD = 1L
@@ -111,4 +113,28 @@ class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker {
         } else {
             null
         }
+
+    override suspend fun updateWithUrl(chapterUrl: String, page: Int) {
+        api.updateBookProgress(chapterUrl, page)
+    }
+
+    override suspend fun getChapterProgress(chapter: Chapter): Int {
+        val book = api.getBookInfo(chapter)
+        return if (book.readProgress?.completed == false) book.readProgress.page - 1 else -1
+    }
+
+    override suspend fun batchGetChapterProgress(chapters: List<Chapter>): Map<Chapter, Int> {
+        if (chapters.isEmpty()) return mapOf()
+        val seriesId = api.getBookInfo(chapters[0]).seriesId
+        val urlBase = chapters[0].url.split("/books")[0]
+        val books = api.getAllBooksOfSeries(urlBase, seriesId)
+        return chapters.associateWith { chapter ->
+            val book = books.find { chapter.url.toBookId() == it.id }
+            return@associateWith if (book?.readProgress?.completed == false) book.readProgress.page - 1 else -1
+        }
+    }
+
+    private fun String.toBookId():String? {
+        return Regex("/api/v1/books/(\\S+)").find(this)?.destructured?.let { (id) -> id }
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -132,6 +132,6 @@ class KomgaApi(
                 .patch("{\"page\": ${pageIndex + 1}}".toRequestBody("Application/json".toMediaType()))
                 .build()
         ).awaitSuccess()
-        logcat(LogPriority.ERROR) { "update progress to ${pageIndex + 1} with $resp"  }
+        logcat(LogPriority.DEBUG) { "update progress to ${pageIndex + 1} with $resp"  }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.source.model.SChapter
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
@@ -106,5 +107,31 @@ class KomgaApi(
 
     private fun ReadListDto.toTrack(): TrackSearch = TrackSearch.create(trackId).also {
         it.title = name
+    }
+
+    internal suspend fun getBookInfo(chapter: SChapter):BookDtoPartial {
+        with(json){
+            return client.newCall(GET(chapter.url, headers)).awaitSuccess().parseAs<BookDtoPartial>()
+        }
+    }
+
+    internal suspend fun getAllBooksOfSeries(v1UrlBase: String, seriesId: String): List<BookDtoPartial> {
+        with(json) {
+            return client.newCall(GET("$v1UrlBase/series/$seriesId/books?unpaged=true", headers)).awaitSuccess().parseAs<SeriesBookListDtoPartial>().content ?: listOf()
+        }
+    }
+
+    /**
+     * Komga book progress starts from 1
+     */
+    internal suspend fun updateBookProgress(bookUrl: String, pageIndex: Int) {
+        //TODO: rate limit
+        val resp = client.newCall(
+            Request.Builder()
+                .url("${bookUrl}/read-progress")
+                .patch("{\"page\": ${pageIndex + 1}}".toRequestBody("Application/json".toMediaType()))
+                .build()
+        ).awaitSuccess()
+        logcat(LogPriority.ERROR) { "update progress to ${pageIndex + 1} with $resp"  }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
@@ -105,3 +105,34 @@ data class ReadProgressV2Dto(
     val lastReadContinuousNumberSort: Double,
     val maxNumberSort: Float,
 )
+
+@Serializable
+data class BookReadProgressDto(
+    val page: Int,
+    val completed: Boolean,
+    val readDate: String?,
+    val created: String?,
+    val lastModified: String?,
+    val deviceId: String?,
+    val deviceName: String?
+)
+
+@Serializable
+data class BookDtoPartial(
+    val id: String,
+    val seriesId: String,
+    val seriesTitle: String,
+    val name: String,
+    val url: String,
+    val readProgress: BookReadProgressDto?,
+    val fileHash: String
+)
+
+@Serializable
+data class SeriesBookListDtoPartial(
+    val totalElements: Long?,
+    val totalPages: Int?,
+    val size: Int?,
+    val content: List<BookDtoPartial>?,
+    val empty: Boolean?
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -540,6 +540,7 @@ class ReaderViewModel @JvmOverloads constructor(
                 ),
             )
         }
+        updatePageReadProgress(readerChapter)
     }
 
     fun restartReadTimer() {
@@ -884,6 +885,16 @@ class ReaderViewModel @JvmOverloads constructor(
 
         viewModelScope.launchNonCancellable {
             trackChapter.await(context, manga.id, readerChapter.chapter.chapter_number.toDouble())
+        }
+    }
+
+    private fun updatePageReadProgress(readerChapter: ReaderChapter) {
+        if (incognitoMode) return
+        if (!trackPreferences.autoUpdateTrack().get()) return
+
+        val manga = manga ?: return
+        viewModelScope.launchNonCancellable {
+            trackChapter.reportPageProgress(manga.id, readerChapter.chapter.chapter_number.toDouble(), readerChapter.chapter.url, chapterPageIndex)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -894,7 +894,7 @@ class ReaderViewModel @JvmOverloads constructor(
 
         val manga = manga ?: return
         viewModelScope.launchNonCancellable {
-            trackChapter.reportPageProgress(manga.id, readerChapter.chapter.chapter_number.toDouble(), readerChapter.chapter.url, chapterPageIndex)
+            trackChapter.reportPageProgress(manga.id, readerChapter.chapter.url, chapterPageIndex)
         }
     }
 


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

As mentioned in issue #236 
Page-level read progress sync for Komga based on the current Komga tracker. This is a preliminary implementation, every page turn would be reported to Komga (just like the Komga web app, no rate limit); to sync page progress from Komga, users have to refresh tracker manually (and to ensure the request completes with in the lifecycle of the dialog window).

<details>
<summary></summary>
 I was really suprised to see unlike the web app, progress syncing does not work with page indeces when I tried to use Mihon as reader for my Komga server. As I read the code I have doubts on whether multi-device progress syncing should be implemented as a type of tracker or if we need to design new solutions for syncing, e.g. within the extension. I would really like to see your opinions on this feature. 
</details>

