### PR TITLE
Format Category String on Subtitle Display

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -71,15 +71,11 @@ object SettingsLibraryScreen : SearchableSettings {
         val scope = rememberCoroutineScope()
         val userCategoriesCount = allCategories.filterNot(Category::isSystemCategory).size
 
-        val defaultCategory by libraryPreferences.defaultCategory().collectAsState()
-        val selectedCategory = allCategories.find { it.id == defaultCategory.toLong() }
-
         // For default category
         val ids = listOf(libraryPreferences.defaultCategory().defaultValue()) +
             allCategories.fastMap { it.id.toInt() }
         val labels = listOf(stringResource(MR.strings.default_category_summary)) +
             allCategories.fastMap { it.visualName }
-        val selectedCategoryName = selectedCategory?.visualName?.replace("%", "%%")
 
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.categories),
@@ -96,7 +92,6 @@ object SettingsLibraryScreen : SearchableSettings {
                 Preference.PreferenceItem.ListPreference(
                     pref = libraryPreferences.defaultCategory(),
                     title = stringResource(MR.strings.default_category),
-                    subtitle = selectedCategoryName ?: stringResource(MR.strings.default_category_summary),
                     entries = ids.zip(labels).toMap().toImmutableMap(),
                 ),
                 Preference.PreferenceItem.SwitchPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -79,6 +79,7 @@ object SettingsLibraryScreen : SearchableSettings {
             allCategories.fastMap { it.id.toInt() }
         val labels = listOf(stringResource(MR.strings.default_category_summary)) +
             allCategories.fastMap { it.visualName }
+        val selectedCategoryName = selectedCategory?.visualName?.replace("%", "%%")
 
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.categories),
@@ -95,7 +96,7 @@ object SettingsLibraryScreen : SearchableSettings {
                 Preference.PreferenceItem.ListPreference(
                     pref = libraryPreferences.defaultCategory(),
                     title = stringResource(MR.strings.default_category),
-                    subtitle = selectedCategory?.visualName?.replace("%", "%%") ?: stringResource(MR.strings.default_category_summary),
+                    subtitle = selectedCategoryName ?: stringResource(MR.strings.default_category_summary),
                     entries = ids.zip(labels).toMap().toImmutableMap(),
                 ),
                 Preference.PreferenceItem.SwitchPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -95,7 +95,7 @@ object SettingsLibraryScreen : SearchableSettings {
                 Preference.PreferenceItem.ListPreference(
                     pref = libraryPreferences.defaultCategory(),
                     title = stringResource(MR.strings.default_category),
-                    subtitle = selectedCategory?.visualName ?: stringResource(MR.strings.default_category_summary),
+                    subtitle = selectedCategory?.visualName?.replace("%", "%%") ?: stringResource(MR.strings.default_category_summary),
                     entries = ids.zip(labels).toMap().toImmutableMap(),
                 ),
                 Preference.PreferenceItem.SwitchPreference(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,7 +91,7 @@ sqldelight-gradle = { module = "app.cash.sqldelight:gradle-plugin", version.ref 
 
 junit = "org.junit.jupiter:junit-jupiter:5.10.3"
 kotest-assertions = "io.kotest:kotest-assertions-core:5.9.1"
-mockk = "io.mockk:mockk:1.13.11"
+mockk = "io.mockk:mockk:1.13.12"
 
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }


### PR DESCRIPTION
Category Names that cause crashes Fixes #1029 
- Anything that ends in %
- %c
- %d
- %e
- %f
- %g
- %o
- %t
- %x
- `%` displays `crashes`
- `%%` displays `%`
- `%%%` displays `crashes`
- `%%%%` displays `%%`
- so on and so forth xD

Category Names that cause weird behavior
- %b - Displays `True`
![image](https://github.com/user-attachments/assets/9f2acd9e-8372-4f1f-b00d-9d7abe1b3cc8)
- %h - Displays `4e3`
![image](https://github.com/user-attachments/assets/c35b9ade-144a-406d-9728-6416ad51d1e4)
- %n - Adds a newline
![image](https://github.com/user-attachments/assets/7c6bbb8d-d240-4a5b-8a1a-62481c02c5bd)
![image](https://github.com/user-attachments/assets/1d1900cb-fb70-4d00-a125-f110db4f6bfd)
![image](https://github.com/user-attachments/assets/f59f25e9-23e0-4faa-8bac-54f2bb2bd35e)

Category Names that work
- %s

Crash occurs when category with said name is set as default category.


## 2 Possible Fixes
### SettingsLibraryScreen.kt - Only for Default Category
```diff
      Preference.PreferenceItem.ListPreference(
          pref = libraryPreferences.defaultCategory(),
          title = stringResource(MR.strings.default_category),
-         subtitle = selectedCategory?.visualName ?: stringResource(MR.strings.default_category_summary),
+         subtitle = selectedCategory?.visualName?.replace("%", "%%") ?: stringResource(MR.strings.default_category_summary),  
          entries = ids.zip(labels).toMap().toImmutableMap(),
      ),
```

### Preferences.kt - For any future ListPreference as well
```diff
data class ListPreference<T>(
            val pref: PreferenceData<T>,
            override val title: String,
            override val subtitle: String? = "%s",
            val subtitleProvider: @Composable (value: T, entries: ImmutableMap<T, String>) -> String? =
-                { v, e -> subtitle?.format(e[v]) },
+                { v, e -> subtitle?.replace("%", "%%")?.format(e[v]) },
            override val icon: ImageVector? = null,
            override val enabled: Boolean = true,
            override val onValueChanged: suspend (newValue: T) -> Boolean = { true },

            val entries: ImmutableMap<T, String>,
        ) : PreferenceItem<T>() {
            internal fun internalSet(newValue: Any) = pref.set(newValue as T)
            internal suspend fun internalOnValueChanged(newValue: Any) = onValueChanged(newValue as T)

            @Composable
            internal fun internalSubtitleProvider(value: Any?, entries: ImmutableMap<out Any?, String>) =
                subtitleProvider(value as T, entries as ImmutableMap<T, String>)
        }
```