### PR TITLE
Improve error message if restoring from JSON file

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
@@ -11,6 +11,7 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.IOException
 
 class BackupDecoder(
     private val context: Context,
@@ -32,7 +33,7 @@ class BackupDecoder(
                 0x1f8b -> source.gzip().buffer() // 0x1f8b is gzip magic bytes
                 0x7b7d, 0x7b22, 0x7b0a -> {
                     // `{}` OR `{"` OR `{\n`
-                    throw Exception(context.stringResource(MR.strings.invalid_backup_file_json))
+                    throw IOException(context.stringResource(MR.strings.invalid_backup_file_json))
                 }
                 else -> source
             }.use { it.readByteArray() }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
@@ -18,7 +18,6 @@ class BackupDecoder(
     private val context: Context,
     private val parser: ProtoBuf = Injekt.get(),
 ) {
-
     /**
      * Decode a potentially-gzipped backup.
      */
@@ -30,10 +29,9 @@ class BackupDecoder(
                 require(2)
             }
             val id1id2 = peeked.readShort()
-            val backupString = when(id1id2.toInt()) {
+            val backupString = when (id1id2.toInt()) {
                 0x1f8b -> source.gzip().buffer() // 0x1f8b is gzip magic bytes
-                0x7b7d, 0x7b22, 0x7b0a -> {
-                    // `{}` OR `{"` OR `{\n`
+                MAGIC_JSON_SIGNATURE1, MAGIC_JSON_SIGNATURE2, MAGIC_JSON_SIGNATURE3 -> {
                     throw IOException(context.stringResource(MR.strings.invalid_backup_file_json))
                 }
                 else -> source
@@ -44,7 +42,12 @@ class BackupDecoder(
             } catch (_: SerializationException) {
                 throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
             }
-
         }
+    }
+
+    companion object {
+        private const val MAGIC_JSON_SIGNATURE1 = 0x7b7d // `{}`
+        private const val MAGIC_JSON_SIGNATURE2 = 0x7b22 // `{"`
+        private const val MAGIC_JSON_SIGNATURE3 = 0x7b0a // `{\n`
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupDecoder.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.backup
 import android.content.Context
 import android.net.Uri
 import eu.kanade.tachiyomi.data.backup.models.Backup
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.protobuf.ProtoBuf
 import okio.buffer
 import okio.gzip
@@ -38,7 +39,12 @@ class BackupDecoder(
                 else -> source
             }.use { it.readByteArray() }
 
-            parser.decodeFromByteArray(Backup.serializer(), backupString)
+            try {
+                parser.decodeFromByteArray(Backup.serializer(), backupString)
+            } catch (_: SerializationException) {
+                throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+            }
+
         }
     }
 }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -519,6 +519,7 @@
     <string name="invalid_backup_file_error">Full error:</string>
     <string name="invalid_backup_file_missing_manga">Backup does not contain any library entries.</string>
     <string name="invalid_backup_file_json">JSON backup not supported</string>
+    <string name="invalid_backup_file_unknown">Backup file is corrupted</string>
     <string name="backup_restore_missing_sources">Missing sources:</string>
     <string name="backup_restore_missing_trackers">Trackers not logged into:</string>
     <string name="backup_restore_content_full">You may need to install any missing extensions and log in to tracking services afterwards to use them.</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -518,6 +518,7 @@
     <string name="invalid_backup_file">Invalid backup file:</string>
     <string name="invalid_backup_file_error">Full error:</string>
     <string name="invalid_backup_file_missing_manga">Backup does not contain any library entries.</string>
+    <string name="invalid_backup_file_json">JSON backup not supported</string>
     <string name="backup_restore_missing_sources">Missing sources:</string>
     <string name="backup_restore_missing_trackers">Trackers not logged into:</string>
     <string name="backup_restore_content_full">You may need to install any missing extensions and log in to tracking services afterwards to use them.</string>


### PR DESCRIPTION
### Current state
Older versions of Tachiyomi support backing up and restoring from JSON files. If a user tries to restore from such a backup they should be nudged in correct direction. Currently the error message is very cryptic and leads to a support burden:
> kotlinx.serialization.protobuf.internal.ProtobufDecodingException: Unsupported start group or end group wire type: 3

### Proposed change
Users are likely to expect old JSON backups to still be usable in Mihon, unless told directly. With the proposed change there is a de minimis maintenance/performance burden as it hooks into the existing gzip signature check. The new error message:
> java.lang.Exception: JSON backup not supported

### Limitations
If the user picks a JSON file that is not a backup file from Tachiyomi the error message will falsely imply that the file is a valid Tachiyomi JSON backup file. Accounting for this would be non-feasible, and an unlikely scenario.

**[!]** I do not have an actual JSON backup file from Tachiyomi at hand, I assume it looks like a regular JSON file.

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![before](https://github.com/user-attachments/assets/690225e5-52b7-40cb-b9d3-cf659947c051) | ![after](https://github.com/user-attachments/assets/c3c993eb-77cd-4622-97ad-b8c3d0ac8a34) |

