### PR TITLE
Improve tag search from MangaScreen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -201,6 +201,18 @@ class BrowseSourceScreenModel(
                 }
             }
         }
+        if (!genreExists) {
+            filter@ for (sourceFilter in defaultFilters) {
+                if (sourceFilter is SourceModelFilter.Text) {
+                    val pattern = "Tags".toRegex()
+                    if (pattern.matches(sourceFilter.name)) {
+                        sourceFilter.state = genreName
+                        genreExists = true
+                        break@filter
+                    }
+                }
+            }
+        }
 
         mutableState.update {
             val listing = if (genreExists) {


### PR DESCRIPTION
If you click on a tag while on a MangaScreen you would normally be redirected back to the BrowseSourceScreen with the filter being adjusted correctly. But on some extensions the filter will be left untouched and the search query set to the tag instead.

This happens because those extensions use a text filter for their tags like "tag1,tag2,-negativetag". And that is not picked up by BrowseSourceScreenModel:searchGenre due to its messy way of searching for the tag filter.

The fix I have used is to search for text filters named "Tags" to give such extensions the possibility to have a correctly working tag search.

This is really is just a stopgap solution until you potentially add some way to uniquely identify filters based on their purpose, which would require the extensions to be changed as well.
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
