### PR TITLE
Fix MAL search results not showing start dates

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -129,12 +129,7 @@ class MyAnimeListApi(
                                 obj["status"]!!.jsonPrimitive.content.replace("_", " ")
                             publishing_type =
                                 obj["media_type"]!!.jsonPrimitive.content.replace("_", " ")
-                            start_date = try {
-                                val outputDf = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-                                outputDf.format(obj["start_date"]!!)
-                            } catch (e: Exception) {
-                                ""
-                            }
+                            start_date = obj["start_date"]?.jsonPrimitive?.content ?: ""
                         }
                     }
             }


### PR DESCRIPTION
The previous approach would always throw an Exception because `SimpleDateFormat.format()` expects the input to be of type `Date` or `Number`, not `String`.