### PR TITLE
Add Copy Tracker URL on icon long press

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
@@ -183,6 +183,7 @@ private fun TrackInfoItem(
             TrackInfoItemMenu(
                 onOpenInBrowser = onOpenInBrowser,
                 onRemoved = onRemoved,
+                onCopyLink = onCopyLink,
             )
         }
 
@@ -291,6 +292,7 @@ private fun TrackInfoItemEmpty(
 private fun TrackInfoItemMenu(
     onOpenInBrowser: () -> Unit,
     onRemoved: () -> Unit,
+    onCopyLink: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     Box(modifier = Modifier.wrapContentSize(Alignment.TopStart)) {
@@ -308,6 +310,13 @@ private fun TrackInfoItemMenu(
                 text = { Text(stringResource(MR.strings.action_open_in_browser)) },
                 onClick = {
                     onOpenInBrowser()
+                    expanded = false
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(MR.strings.action_copy_to_clipboard)) },
+                onClick = {
+                    onCopyLink()
                     expanded = false
                 },
             )

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
@@ -72,6 +72,7 @@ fun TrackInfoDialogHome(
     onNewSearch: (TrackItem) -> Unit,
     onOpenInBrowser: (TrackItem) -> Unit,
     onRemoved: (TrackItem) -> Unit,
+    onCopyLink: (TrackItem) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -116,6 +117,7 @@ fun TrackInfoDialogHome(
                     onNewSearch = { onNewSearch(item) },
                     onOpenInBrowser = { onOpenInBrowser(item) },
                     onRemoved = { onRemoved(item) },
+                    onCopyLink = { onCopyLink(item) },
                 )
             } else {
                 TrackInfoItemEmpty(
@@ -144,6 +146,7 @@ private fun TrackInfoItem(
     onNewSearch: () -> Unit,
     onOpenInBrowser: () -> Unit,
     onRemoved: () -> Unit,
+    onCopyLink: () -> Unit,
 ) {
     val context = LocalContext.current
     Column {
@@ -153,6 +156,7 @@ private fun TrackInfoItem(
             TrackLogoIcon(
                 tracker = tracker,
                 onClick = onOpenInBrowser,
+                onLongClick = onCopyLink,
             )
             Box(
                 modifier = Modifier

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
@@ -314,7 +314,7 @@ private fun TrackInfoItemMenu(
                 },
             )
             DropdownMenuItem(
-                text = { Text(stringResource(MR.strings.action_copy_to_clipboard)) },
+                text = { Text(stringResource(MR.strings.action_copy_link)) },
                 onClick = {
                     onCopyLink()
                     expanded = false

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHomePreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHomePreviewProvider.kt
@@ -56,6 +56,7 @@ internal class TrackInfoDialogHomePreviewProvider :
             onNewSearch = {},
             onOpenInBrowser = {},
             onRemoved = {},
+            onCopyLink = {},
         )
     }
 
@@ -71,6 +72,7 @@ internal class TrackInfoDialogHomePreviewProvider :
             onNewSearch = {},
             onOpenInBrowser = {},
             onRemoved = {},
+            onCopyLink = {},
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
@@ -22,11 +22,13 @@ import tachiyomi.presentation.core.util.clickableNoIndication
 fun TrackLogoIcon(
     tracker: Tracker,
     onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
 ) {
-    val modifier = if (onClick != null) {
-        Modifier.clickableNoIndication(onClick = onClick)
-    } else {
-        Modifier
+    val modifier = when {
+        onLongClick != null && onClick != null ->
+            Modifier.clickableNoIndication(onLongClick = onLongClick, onClick = onClick)
+        onClick != null -> Modifier.clickableNoIndication(onClick = onClick)
+        else -> Modifier
     }
 
     Box(
@@ -53,6 +55,7 @@ private fun TrackLogoIconPreviews(
         TrackLogoIcon(
             tracker = tracker,
             onClick = null,
+            onLongClick = null,
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
@@ -24,11 +24,10 @@ fun TrackLogoIcon(
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
-    val modifier = when {
-        onLongClick != null && onClick != null ->
-            Modifier.clickableNoIndication(onLongClick = onLongClick, onClick = onClick)
-        onClick != null -> Modifier.clickableNoIndication(onClick = onClick)
-        else -> Modifier
+    val modifier = if (onClick != null) {
+        Modifier.clickableNoIndication(onLongClick = onLongClick, onClick = onClick)
+    } else {
+        Modifier
     }
 
     Box(

--- a/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/components/TrackLogoIcon.kt
@@ -25,7 +25,7 @@ fun TrackLogoIcon(
     onLongClick: (() -> Unit)? = null,
 ) {
     val modifier = if (onClick != null) {
-        Modifier.clickableNoIndication(onLongClick = onLongClick, onClick = onClick)
+        Modifier.clickableNoIndication(onClick = onClick, onLongClick = onLongClick)
     } else {
         Modifier
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
@@ -171,7 +171,7 @@ data class TrackInfoDialogHomeScreen(
                     ),
                 )
             },
-            onCopyLink = { copyTrackerLink(context, it) },
+            onCopyLink = { context.copyTrackerLink(it) },
         )
     }
 
@@ -185,10 +185,10 @@ data class TrackInfoDialogHomeScreen(
         }
     }
 
-    private fun copyTrackerLink(context: Context, trackItem: TrackItem) {
+    private fun Context.copyTrackerLink(trackItem: TrackItem) {
         val url = trackItem.track?.remoteUrl ?: return
         if (url.isNotBlank()) {
-            context.copyToClipboard(url, url)
+            copyToClipboard(url, url)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
@@ -54,6 +54,7 @@ import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.util.lang.convertEpochMillisZone
+import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.ImmutableList
@@ -170,6 +171,7 @@ data class TrackInfoDialogHomeScreen(
                     ),
                 )
             },
+            onCopyLink = { copyTrackerLink(context, it) },
         )
     }
 
@@ -180,6 +182,13 @@ data class TrackInfoDialogHomeScreen(
         val url = trackItem.track?.remoteUrl ?: return
         if (url.isNotBlank()) {
             context.openInBrowser(url)
+        }
+    }
+
+    private fun copyTrackerLink(context: Context, trackItem: TrackItem) {
+        val url = trackItem.track?.remoteUrl ?: return
+        if (url.isNotBlank()) {
+            context.copyToClipboard(url, url)
         }
     }
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -110,6 +110,7 @@
     <string name="action_open_in_browser">Open in browser</string>
     <string name="action_show_manga">Show entry</string>
     <string name="action_copy_to_clipboard">Copy to clipboard</string>
+    <string name="action_copy_link">Copy link</string>
     <!-- Do not translate "WebView" -->
     <string name="action_open_in_web_view">Open in WebView</string>
     <string name="action_web_view" translatable="false">WebView</string>


### PR DESCRIPTION
resolves #1087. 

When the icon for a tracker is held down, the tracker URL is copied to the clipboard, if it exists. 

From @BrutuZ's comment, I have also added it to the menu:
![image](https://github.com/user-attachments/assets/043285b1-ffb5-46fb-abd9-3ae1557478e5)


