### PR TITLE
Add a button to select all scanlators

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
@@ -108,15 +108,14 @@ fun ScanlatorFilterDialog(
                 }
             } else {
                 FlowRow {
-                    TextButton(onClick = mutableExcludedScanlators::clear) {
-                        Text(text = stringResource(MR.strings.action_reset))
-                    }
-                    Spacer(modifier = Modifier.weight(1f))
                     TextButton(onClick = {
-                        mutableExcludedScanlators.clear() // clear items already in the collection
-                        mutableExcludedScanlators.addAll(elements = availableScanlators) // add all items from list
+                        if (mutableExcludedScanlators.isEmpty()) {
+                            mutableExcludedScanlators.addAll(elements = availableScanlators)
+                        } else {
+                            mutableExcludedScanlators.clear()
+                        }
                     }) {
-                        Text(text = stringResource(MR.strings.action_select_all))
+                        Text(text = stringResource(MR.strings.action_toggle_all))
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     TextButton(onClick = onDismissRequest) {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
@@ -112,6 +112,13 @@ fun ScanlatorFilterDialog(
                         Text(text = stringResource(MR.strings.action_reset))
                     }
                     Spacer(modifier = Modifier.weight(1f))
+                    TextButton(onClick = {
+                        mutableExcludedScanlators.clear() // clear items already in the collection
+                        mutableExcludedScanlators.addAll(elements = availableScanlators) // add all items from list
+                    }) {
+                        Text(text = stringResource(MR.strings.action_select_all))
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
                     TextButton(onClick = onDismissRequest) {
                         Text(text = stringResource(MR.strings.action_cancel))
                     }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -151,6 +151,7 @@
     <string name="action_save">Save</string>
     <string name="action_reset">Reset</string>
     <string name="action_revert_to_default">Revert to default</string>
+    <string name="action_toggle_all">Toggle all</string>
     <!-- missing undo feature after Compose rewrite #7454 -->
     <string name="action_undo">Undo</string>
     <string name="action_close">Close</string>


### PR DESCRIPTION
Resolves #943 

![image](https://github.com/user-attachments/assets/80f61447-6bec-4de7-a824-c3d6dfc3393c)

A new "select all" button is added to the "exclude scanlators" dialogue. Pressing it clears all selected items then adds all available items. 