### PR TITLE
Add an "open in browser" button to reader menu

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -45,6 +45,7 @@ fun ReaderAppBars(
     onClickTopAppBar: () -> Unit,
     bookmarked: Boolean,
     onToggleBookmarked: () -> Unit,
+    onOpenInBrowser: (() -> Unit)?,
     onOpenInWebView: (() -> Unit)?,
     onShare: (() -> Unit)?,
 
@@ -119,6 +120,14 @@ fun ReaderAppBars(
                                         onClick = onToggleBookmarked,
                                     ),
                                 )
+                                onOpenInBrowser?.let {
+                                    add(
+                                        AppBar.OverflowAction(
+                                            title = stringResource(MR.strings.action_open_in_browser),
+                                            onClick = it,
+                                        ),
+                                    )
+                                }
                                 onOpenInWebView?.let {
                                     add(
                                         AppBar.OverflowAction(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -75,6 +75,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
 import eu.kanade.tachiyomi.util.system.isNightMode
+import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.setComposeContent
@@ -389,6 +390,7 @@ class ReaderActivity : BaseActivity() {
                 onClickTopAppBar = ::openMangaScreen,
                 bookmarked = state.bookmarked,
                 onToggleBookmarked = viewModel::toggleChapterBookmark,
+                onOpenInBrowser = ::openChapterInBrowser.takeIf { isHttpSource },
                 onOpenInWebView = ::openChapterInWebView.takeIf { isHttpSource },
                 onShare = ::shareChapter.takeIf { isHttpSource },
 
@@ -560,6 +562,14 @@ class ReaderActivity : BaseActivity() {
                     addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 },
             )
+        }
+    }
+
+    private fun openChapterInBrowser(){
+        assistUrl?.let {
+            openInBrowser(it.toUri(),forceDefaultBrowser = false)
+            //val intent =
+            //startActivity(Intent.createChooser(intent, stringResource(MR.strings.action_open_in_browser)))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -565,11 +565,9 @@ class ReaderActivity : BaseActivity() {
         }
     }
 
-    private fun openChapterInBrowser(){
+    private fun openChapterInBrowser() {
         assistUrl?.let {
-            openInBrowser(it.toUri(),forceDefaultBrowser = false)
-            //val intent =
-            //startActivity(Intent.createChooser(intent, stringResource(MR.strings.action_open_in_browser)))
+            openInBrowser(it.toUri(), forceDefaultBrowser = false)
         }
     }
 


### PR DESCRIPTION
Resolves #1077 by adding an "open in browser" button to the menu

![image](https://github.com/user-attachments/assets/32d465d9-22ad-4285-bd62-f6b5e318af25)

Clicking it opens the chapter in the default browser. 