### PR TITLE
Fix some migrations never running

### DIFF
--- a/app/src/main/java/mihon/core/migration/migrations/SetupBackupCreateMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/SetupBackupCreateMigration.kt
@@ -1,6 +1,6 @@
 package mihon.core.migration.migrations
 
-import eu.kanade.tachiyomi.App
+import android.app.Application
 import eu.kanade.tachiyomi.data.backup.create.BackupCreateJob
 import mihon.core.migration.Migration
 import mihon.core.migration.MigrationContext
@@ -9,7 +9,7 @@ class SetupBackupCreateMigration : Migration {
     override val version: Float = Migration.ALWAYS
 
     override suspend fun invoke(migrationContext: MigrationContext): Boolean {
-        val context = migrationContext.get<App>() ?: return false
+        val context = migrationContext.get<Application>() ?: return false
         BackupCreateJob.setupTask(context)
         return true
     }

--- a/app/src/main/java/mihon/core/migration/migrations/SetupLibraryUpdateMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/SetupLibraryUpdateMigration.kt
@@ -1,6 +1,6 @@
 package mihon.core.migration.migrations
 
-import eu.kanade.tachiyomi.App
+import android.app.Application
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import mihon.core.migration.Migration
 import mihon.core.migration.MigrationContext
@@ -9,7 +9,7 @@ class SetupLibraryUpdateMigration : Migration {
     override val version: Float = Migration.ALWAYS
 
     override suspend fun invoke(migrationContext: MigrationContext): Boolean {
-        val context = migrationContext.get<App>() ?: return false
+        val context = migrationContext.get<Application>() ?: return false
         LibraryUpdateJob.setupTask(context)
         return true
     }


### PR DESCRIPTION
Both `SetupBackupCreateMigration` and `SetupLibraryUpdateMigration` were trying to get the `App` class from Injekt which is never provided via the `AppModule`. This caused them to always return `false` and never actually setting up the jobs,

 Using `Application` instead works since the `workManager` property used by the respective `setupTask` functions is an extension property on `Context`.