### PR TITLE
Adding bottom padding to Page Indicator to avoid phone's frame hide it

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
@@ -1,16 +1,19 @@
 package eu.kanade.presentation.reader
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 
@@ -35,6 +38,7 @@ fun PageIndicatorText(
     )
 
     Box(
+        modifier = Modifier.padding(bottom = 12.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(


### PR DESCRIPTION
This fixes #1105 

The Page Indicator at the bottom of the page was being cut in half because of Samsung's Phone Frame, and it is not possible to read the page number.

The padding I'm using is based on other places in the app that use the same padding at the bottom to avoid this.

note: This is my first PR to Mihon repository

### Images
| Image 1 | Image 2 |
| ------- | ------- |
![mihon-no-padding](https://github.com/user-attachments/assets/ee61ab95-fe46-4e35-af22-46b709fd99cb) | ![](https://github.com/user-attachments/assets/b5b267b9-38eb-47cc-ac45-ebb7846864db) |

