### PR TITLE
Respect privacy settings in extension update notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extension trust system ([@AntsyLich](https://github.com/AntsyLich), [@Animeboynz](https://github.com/Animeboynz) ([#570](https://github.com/mihonapp/mihon/pull/570), [#1057](https://github.com/mihonapp/mihon/pull/1057))
 - Make category backup/restore not dependant on library backup ([@AntsyLich](https://github.com/AntsyLich)) ([`56fb4f6`](https://github.com/mihonapp/mihon/commit/56fb4f62a152e87a71892aa68c78cac51a2c8596))
 - Kitsu domain to `kitsu.app` ([@MajorTanya](https://github.com/MajorTanya)) ([#1106](https://github.com/mihonapp/mihon/pull/1106))
+- Respect privacy settings in extension update notification ([@Animeboynz](https://github.com/Animeboynz)) ([#1156](https://github.com/mihonapp/mihon/pull/1156))
 
 ### Improvement
 - Long strip reader performance ([@FooIbar](https://github.com/FooIbar), [@wwww-wwww](https://github.com/wwww-wwww)) ([#687](https://github.com/mihonapp/mihon/pull/687))

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionUpdateNotifier.kt
@@ -3,15 +3,20 @@ package eu.kanade.tachiyomi.extension.api
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notify
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
-class ExtensionUpdateNotifier(private val context: Context) {
-
+class ExtensionUpdateNotifier(
+    private val context: Context,
+    private val securityPreferences: SecurityPreferences = Injekt.get(),
+) {
     fun promptUpdates(names: List<String>) {
         context.notify(
             Notifications.ID_UPDATES_TO_EXTS,
@@ -25,8 +30,10 @@ class ExtensionUpdateNotifier(private val context: Context) {
                 ),
             )
             val extNames = names.joinToString(", ")
-            setContentText(extNames)
-            setStyle(NotificationCompat.BigTextStyle().bigText(extNames))
+            if (!securityPreferences.hideNotificationContent().get()) {
+                setContentText(extNames)
+                setStyle(NotificationCompat.BigTextStyle().bigText(extNames))
+            }
             setSmallIcon(R.drawable.ic_extension_24dp)
             setContentIntent(NotificationReceiver.openExtensionsPendingActivity(context))
             setAutoCancel(true)

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionUpdateNotifier.kt
@@ -29,8 +29,8 @@ class ExtensionUpdateNotifier(
                     names.size,
                 ),
             )
-            val extNames = names.joinToString(", ")
             if (!securityPreferences.hideNotificationContent().get()) {
+                val extNames = names.joinToString(", ")
                 setContentText(extNames)
                 setStyle(NotificationCompat.BigTextStyle().bigText(extNames))
             }


### PR DESCRIPTION
Removes the extension names from the notification when hide notification content is turned on.
Fixes #1022 
### Images
| Before | After |
| ------- | ------- |
| ![Before](https://github.com/user-attachments/assets/995789f4-63d2-48ed-9878-477fa996b7d3) | ![After](https://github.com/user-attachments/assets/3a3f85a0-2476-491e-81e8-da5c93bc3a95) |

