### PR TITLE
Add "show entry" action to download notifications 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
 import java.util.regex.Pattern
@@ -82,6 +83,12 @@ internal class DownloadNotifier(private val context: Context) {
                     R.drawable.ic_pause_24dp,
                     context.stringResource(MR.strings.action_pause),
                     NotificationReceiver.pauseDownloadsPendingBroadcast(context),
+                )
+                addAction(
+                    R.drawable.ic_book_24dp,
+                    context.stringResource(MR.strings.action_show_manga),
+
+                    NotificationReceiver.openEntryPendingActivity(context, download.manga.id),
                 )
             }
 
@@ -160,9 +167,10 @@ internal class DownloadNotifier(private val context: Context) {
      *
      * @param reason the text to show.
      * @param timeout duration after which to automatically dismiss the notification.
+     * @param mangaId the id of the entry being warned about
      * Only works on Android 8+.
      */
-    fun onWarning(reason: String, timeout: Long? = null, contentIntent: PendingIntent? = null) {
+    fun onWarning(reason: String, timeout: Long? = null, contentIntent: PendingIntent? = null, mangaId: Long? = null) {
         with(errorNotificationBuilder) {
             setContentTitle(context.stringResource(MR.strings.download_notifier_downloader_title))
             setStyle(NotificationCompat.BigTextStyle().bigText(reason))
@@ -170,6 +178,14 @@ internal class DownloadNotifier(private val context: Context) {
             setAutoCancel(true)
             clearActions()
             setContentIntent(NotificationHandler.openDownloadManagerPendingActivity(context))
+            if (mangaId != null) {
+                addAction(
+                    R.drawable.ic_book_24dp,
+                    context.stringResource(MR.strings.action_show_manga),
+
+                    NotificationReceiver.openEntryPendingActivity(context, mangaId),
+                )
+            }
             setProgress(0, 0, false)
             timeout?.let { setTimeoutAfter(it) }
             contentIntent?.let { setContentIntent(it) }
@@ -187,8 +203,9 @@ internal class DownloadNotifier(private val context: Context) {
      *
      * @param error string containing error information.
      * @param chapter string containing chapter title.
+     * @param mangaId the id of the entry that was errored on
      */
-    fun onError(error: String? = null, chapter: String? = null, mangaTitle: String? = null) {
+    fun onError(error: String? = null, chapter: String? = null, mangaTitle: String? = null, mangaId: Long? = null) {
         // Create notification
         with(errorNotificationBuilder) {
             setContentTitle(
@@ -198,6 +215,14 @@ internal class DownloadNotifier(private val context: Context) {
             setSmallIcon(R.drawable.ic_warning_white_24dp)
             clearActions()
             setContentIntent(NotificationHandler.openDownloadManagerPendingActivity(context))
+            if (mangaId != null) {
+                addAction(
+                    R.drawable.ic_book_24dp,
+                    context.stringResource(MR.strings.action_show_manga),
+
+                    NotificationReceiver.openEntryPendingActivity(context, mangaId),
+                )
+            }
             setProgress(0, 0, false)
 
             show(Notifications.ID_DOWNLOAD_CHAPTER_ERROR)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -86,7 +86,6 @@ internal class DownloadNotifier(private val context: Context) {
                 addAction(
                     R.drawable.ic_book_24dp,
                     context.stringResource(MR.strings.action_show_manga),
-
                     NotificationReceiver.openEntryPendingActivity(context, download.manga.id),
                 )
             }
@@ -181,7 +180,6 @@ internal class DownloadNotifier(private val context: Context) {
                 addAction(
                     R.drawable.ic_book_24dp,
                     context.stringResource(MR.strings.action_show_manga),
-
                     NotificationReceiver.openEntryPendingActivity(context, mangaId),
                 )
             }
@@ -218,7 +216,6 @@ internal class DownloadNotifier(private val context: Context) {
                 addAction(
                     R.drawable.ic_book_24dp,
                     context.stringResource(MR.strings.action_show_manga),
-
                     NotificationReceiver.openEntryPendingActivity(context, mangaId),
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -15,7 +15,6 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
 import java.util.regex.Pattern
@@ -203,7 +202,7 @@ internal class DownloadNotifier(private val context: Context) {
      *
      * @param error string containing error information.
      * @param chapter string containing chapter title.
-     * @param mangaId the id of the entry that was errored on
+     * @param mangaId the id of the entry that the error occurred on
      */
     fun onError(error: String? = null, chapter: String? = null, mangaTitle: String? = null, mangaId: Long? = null) {
         // Create notification

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -302,7 +302,6 @@ class Downloader(
                         context.stringResource(MR.strings.download_queue_size_warning),
                         WARNING_NOTIF_TIMEOUT_MS,
                         NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
-                        manga.id,
                     )
                 }
                 DownloadJob.start(context)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -302,6 +302,7 @@ class Downloader(
                         context.stringResource(MR.strings.download_queue_size_warning),
                         WARNING_NOTIF_TIMEOUT_MS,
                         NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
+                        manga.id,
                     )
                 }
                 DownloadJob.start(context)
@@ -324,6 +325,7 @@ class Downloader(
                 context.stringResource(MR.strings.download_insufficient_space),
                 download.chapter.name,
                 download.manga.title,
+                download.manga.id,
             )
             return
         }
@@ -407,7 +409,7 @@ class Downloader(
             // If the page list threw, it will resume here
             logcat(LogPriority.ERROR, error)
             download.status = Download.State.ERROR
-            notifier.onError(error.message, download.chapter.name, download.manga.title)
+            notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
         }
     }
 
@@ -457,7 +459,7 @@ class Downloader(
             // Mark this page as error and allow to download the remaining
             page.progress = 0
             page.status = Page.State.ERROR
-            notifier.onError(e.message, download.chapter.name, download.manga.title)
+            notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -110,11 +110,6 @@ class NotificationReceiver : BroadcastReceiver() {
                     downloadChapters(urls, mangaId)
                 }
             }
-            // Open an entry's page
-//            ACTION_OPEN_ENTRY -> {
-//                val mangaId = intent.getLongExtra(EXTRA_MANGA_ID, -1)
-//                openEntry(context, mangaId)
-//            }
         }
     }
 
@@ -166,19 +161,6 @@ class NotificationReceiver : BroadcastReceiver() {
             context.toast(MR.strings.chapter_error)
         }
     }
-
-//    private fun openEntry(context: Context, mangaId: Long){ // TODO: open manga
-//        val manga = runBlocking { getManga.await(mangaId) }
-//        if (manga != null){
-//            val intent = Intent(context,MainActivity::class.java).apply {
-//                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-//            }
-//            context.startActivity(intent)
-//        }
-//        else{
-//            context.toast(MR.strings.error_no_match)
-//        }
-//    }
 
     /**
      * Method called when user wants to stop a backup restore job.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -493,11 +493,11 @@ class NotificationReceiver : BroadcastReceiver() {
          * @param mangaId id of the entry to open
          */
         internal fun openEntryPendingActivity(context: Context, mangaId: Long): PendingIntent {
-            val newIntent =
-                Intent(context, MainActivity::class.java).setAction(Constants.SHORTCUT_MANGA)
-                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    .putExtra(Constants.MANGA_EXTRA, mangaId)
-                    .putExtra("notificationId", mangaId.hashCode())
+            val newIntent = Intent(context, MainActivity::class.java).setAction(Constants.SHORTCUT_MANGA)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                .putExtra(Constants.MANGA_EXTRA, mangaId)
+                .putExtra("notificationId", mangaId.hashCode())
+                    
             return PendingIntent.getActivity(
                 context,
                 mangaId.hashCode(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -497,7 +497,7 @@ class NotificationReceiver : BroadcastReceiver() {
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 .putExtra(Constants.MANGA_EXTRA, mangaId)
                 .putExtra("notificationId", mangaId.hashCode())
-                    
+
             return PendingIntent.getActivity(
                 context,
                 mangaId.hashCode(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -18,10 +18,8 @@ import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.runBlocking
-import logcat.LogPriority
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.Chapter

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -18,8 +18,10 @@ import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.runBlocking
+import logcat.LogPriority
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.Chapter
@@ -108,6 +110,11 @@ class NotificationReceiver : BroadcastReceiver() {
                     downloadChapters(urls, mangaId)
                 }
             }
+            // Open an entry's page
+//            ACTION_OPEN_ENTRY -> {
+//                val mangaId = intent.getLongExtra(EXTRA_MANGA_ID, -1)
+//                openEntry(context, mangaId)
+//            }
         }
     }
 
@@ -159,6 +166,19 @@ class NotificationReceiver : BroadcastReceiver() {
             context.toast(MR.strings.chapter_error)
         }
     }
+
+//    private fun openEntry(context: Context, mangaId: Long){ // TODO: open manga
+//        val manga = runBlocking { getManga.await(mangaId) }
+//        if (manga != null){
+//            val intent = Intent(context,MainActivity::class.java).apply {
+//                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+//            }
+//            context.startActivity(intent)
+//        }
+//        else{
+//            context.toast(MR.strings.error_no_match)
+//        }
+//    }
 
     /**
      * Method called when user wants to stop a backup restore job.
@@ -247,6 +267,8 @@ class NotificationReceiver : BroadcastReceiver() {
         private const val ACTION_MARK_AS_READ = "$ID.$NAME.MARK_AS_READ"
         private const val ACTION_OPEN_CHAPTER = "$ID.$NAME.ACTION_OPEN_CHAPTER"
         private const val ACTION_DOWNLOAD_CHAPTER = "$ID.$NAME.ACTION_DOWNLOAD_CHAPTER"
+
+        private const val ACTION_OPEN_ENTRY = "$ID.$NAME.ACTION_OPEN_ENTRY"
 
         private const val ACTION_RESUME_DOWNLOADS = "$ID.$NAME.ACTION_RESUME_DOWNLOADS"
         private const val ACTION_PAUSE_DOWNLOADS = "$ID.$NAME.ACTION_PAUSE_DOWNLOADS"
@@ -479,6 +501,26 @@ class NotificationReceiver : BroadcastReceiver() {
             return PendingIntent.getBroadcast(
                 context,
                 manga.id.hashCode(),
+                newIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
+
+        /**
+         * Returns [PendingIntent] that opens the manga info controller
+         *
+         * @param context context of application
+         * @param mangaId id of the entry to open
+         */
+        internal fun openEntryPendingActivity(context: Context, mangaId: Long): PendingIntent {
+            val newIntent =
+                Intent(context, MainActivity::class.java).setAction(Constants.SHORTCUT_MANGA)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra(Constants.MANGA_EXTRA, mangaId)
+                    .putExtra("notificationId", mangaId.hashCode())
+            return PendingIntent.getActivity(
+                context,
+                mangaId.hashCode(),
                 newIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )


### PR DESCRIPTION
Adds a "Show entry" action to the following download notifications, allowing user to restart the download or view the entry:
- Normal: When showing download progress 
- Errors:
  - insufficient space
  - generic chapter error
  - generic image error
- Warnings: None

Provides a meaningful way to address the root cause, and resolve #1129