### PR TITLE
Enable 'Split Tall Images' by default

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -13,7 +13,7 @@ class DownloadPreferences(
 
     fun saveChaptersAsCBZ() = preferenceStore.getBoolean("save_chapter_as_cbz", true)
 
-    fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", false)
+    fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", true)
 
     fun autoDownloadWhileReading() = preferenceStore.getInt("auto_download_while_reading", 0)
 


### PR DESCRIPTION
Set to `true` to make 'Split tall images" enabled by default
