### PR TITLE
Fix Kitsu `ratingTwenty` being typed as String

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
@@ -40,7 +40,7 @@ data class KitsuListSearchResult(
                 "planned" -> Kitsu.PLAN_TO_READ
                 else -> throw Exception("Unknown status")
             }
-            score = userDataAttrs.ratingTwenty?.let { it.toInt() / 2.0 } ?: 0.0
+            score = userDataAttrs.ratingTwenty?.let { it / 2.0 } ?: 0.0
             last_chapter_read = userDataAttrs.progress.toDouble()
         }
     }
@@ -57,7 +57,7 @@ data class KitsuListSearchItemDataAttributes(
     val status: String,
     val startedAt: String?,
     val finishedAt: String?,
-    val ratingTwenty: String?,
+    val ratingTwenty: Int?,
     val progress: Int,
 )
 


### PR DESCRIPTION
The [Kitsu API docs](https://kitsu.docs.apiary.io/#reference/user-libraries/library-entries) (and the responses) type `ratingTwenty` as a "number" (Int in Kotlin, it's divided by 2 for a .5 step scale 0-10). It's nullable because an entry without a user rating returns `null` in that field.

This caused crashes when a user would attempt to add Kitsu as a tracker for an entry in Mihon while already having the entry tracked in Kitsu through some other means AND having assigned the entry a score on Kitsu.