### PR TITLE
Ignore "intent://" urls on webview

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -104,6 +104,11 @@ fun WebViewScreenContent(
                         return false
                     }
 
+                    // Ignore intents urls
+                    if (it.url.toString().startsWith("intent://")) {
+                        return true
+                    }
+
                     // Continue with request, but with custom headers
                     view?.loadUrl(it.url.toString(), headers)
                 }


### PR DESCRIPTION
Webview can't handle `intent://` urls, returning `true` cancels the request.
Issue example: https://github.com/keiyoushi/extensions-source/issues/3810