### PR TITLE
Fix: wrong calculation of nextUpdate when setting custom fetchInterval

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -107,7 +107,7 @@ class FetchInterval(
             interval.absoluteValue.takeIf { interval < 0 }
                 ?: increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
         )
-        return latestDate.plusDays((cycle + 1) * interval.toLong()).toEpochSecond(dateTime.offset) * 1000
+        return latestDate.plusDays((cycle + 1) * interval.absoluteValue.toLong()).toEpochSecond(dateTime.offset) * 1000
     }
 
     private fun increaseInterval(delta: Int, timeSinceLatest: Int, increaseWhenOver: Int): Int {


### PR DESCRIPTION
it was using the negative value of custom fetchInterval to calculate nextUpdate and causing a nextUpdate date in the past