### PR TITLE
Fix Kitsu `synopsis` nullability

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
@@ -25,7 +25,7 @@ data class KitsuListSearchResult(
             title = manga.canonicalTitle
             total_chapters = manga.chapterCount ?: 0
             cover_url = manga.posterImage?.original ?: ""
-            summary = manga.synopsis
+            summary = manga.synopsis ?: ""
             tracking_url = KitsuApi.mangaUrl(remote_id)
             publishing_status = manga.status
             publishing_type = manga.mangaType ?: ""
@@ -73,7 +73,7 @@ data class KitsuListSearchItemIncludedAttributes(
     val chapterCount: Long?,
     val mangaType: String?,
     val posterImage: KitsuSearchItemCover?,
-    val synopsis: String,
+    val synopsis: String?,
     val startDate: String?,
     val status: String,
 )


### PR DESCRIPTION
This time, the Kitsu API docs are silent on whether this field (or any other field) can be null/undefined/etc, but it can happen and caused an error during search and update. This change just ensures the attribute is nullable and is set to an empty String when it is null.

I hope this will be the last of the Kitsu fixes but honestly, I don't know anymore.