### PR TITLE
Add option to opt out of Analytics and Crashlytics

### DIFF
--- a/app/src/dev/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/dev/java/mihon/core/firebase/Firebase.kt
@@ -1,7 +1,7 @@
 
 import android.content.Context
-import eu.kanade.domain.base.BasePreferences
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
 
 object Firebase {
-    fun setup(context: Context, preference: BasePreferences) = Unit
+    fun setup(context: Context, preference: SecurityPreferences) = Unit
 }

--- a/app/src/dev/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/dev/java/mihon/core/firebase/Firebase.kt
@@ -1,7 +1,8 @@
 
 import android.content.Context
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import kotlinx.coroutines.CoroutineScope
 
 object Firebase {
-    fun setup(context: Context, preference: SecurityPreferences) = Unit
+    fun setup(context: Context, preference: SecurityPreferences, scope: CoroutineScope) = Unit
 }

--- a/app/src/dev/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/dev/java/mihon/core/firebase/Firebase.kt
@@ -1,9 +1,9 @@
 package mihon.core.firebase
 
 import android.content.Context
-import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import kotlinx.coroutines.CoroutineScope
 
 object Firebase {
-    fun setup(context: Context, preference: SecurityPreferences, scope: CoroutineScope) = Unit
+    fun setup(context: Context, preference: PrivacyPreferences, scope: CoroutineScope) = Unit
 }

--- a/app/src/dev/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/dev/java/mihon/core/firebase/Firebase.kt
@@ -1,3 +1,4 @@
+package mihon.core.firebase
 
 import android.content.Context
 import eu.kanade.tachiyomi.core.security.SecurityPreferences

--- a/app/src/dev/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/dev/java/mihon/core/firebase/Firebase.kt
@@ -1,0 +1,7 @@
+
+import android.content.Context
+import eu.kanade.domain.base.BasePreferences
+
+object Firebase {
+    fun setup(context: Context, preference: BasePreferences) = Unit
+}

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -117,8 +117,8 @@ internal class PermissionStep : OnboardingStep {
             )
 
             PermissionItem(
-                title = "Send crash logs",//i18n later
-                subtitle = "Send anonymised crash logs to the developers",
+                title = stringResource(MR.strings.onboarding_permission_crashlytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
                 granted = allowCrashLogs,
                 onButtonClick = {
                     // Toggle the granted state
@@ -128,8 +128,8 @@ internal class PermissionStep : OnboardingStep {
             )
 
             PermissionItem(
-                title = "Allow analytics",//i18n later
-                subtitle = "Send anonymized usage data to improve app features.",
+                title = stringResource(MR.strings.onboarding_permission_analytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
                 granted = allowAnalytics,
                 onButtonClick = {
                     // Toggle the granted state

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -34,15 +34,21 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.kanade.presentation.util.rememberRequestPackageInstallsPermissionState
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.util.system.launchRequestPackageInstallsPermission
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.secondaryItemAlpha
+import uy.kohesive.injekt.injectLazy
 
 internal class PermissionStep : OnboardingStep {
 
+    private val securityPreferences: SecurityPreferences by injectLazy()
+
     private var notificationGranted by mutableStateOf(false)
     private var batteryGranted by mutableStateOf(false)
+    private var allowCrashLogs by mutableStateOf(false)
+    private var allowAnalytics by mutableStateOf(false)
 
     override val isComplete: Boolean = true
 
@@ -109,6 +115,28 @@ internal class PermissionStep : OnboardingStep {
                     context.startActivity(intent)
                 },
             )
+
+            PermissionItem(
+                title = "Send crash logs",//i18n later
+                subtitle = "Send anonymised crash logs to the developers",
+                granted = allowCrashLogs,
+                onButtonClick = {
+                    // Toggle the granted state
+                    allowCrashLogs = !allowCrashLogs
+                    securityPreferences.crashlytics().set(allowCrashLogs)
+                }
+            )
+
+            PermissionItem(
+                title = "Allow analytics",//i18n later
+                subtitle = "Send anonymized usage data to improve app features.",
+                granted = allowAnalytics,
+                onButtonClick = {
+                    // Toggle the granted state
+                    allowAnalytics = !allowAnalytics
+                    securityPreferences.analytics().set(allowAnalytics)
+                }
+            )
         }
     }
 
@@ -140,7 +168,6 @@ internal class PermissionStep : OnboardingStep {
             supportingContent = { Text(text = subtitle) },
             trailingContent = {
                 OutlinedButton(
-                    enabled = !granted,
                     onClick = onButtonClick,
                 ) {
                     if (granted) {

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -14,11 +14,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -79,7 +81,7 @@ internal class PermissionStep : OnboardingStep {
         }
 
         Column {
-            PermissionItem(
+            PermissionCheckbox(
                 title = stringResource(MR.strings.onboarding_permission_install_apps),
                 subtitle = stringResource(MR.strings.onboarding_permission_install_apps_description),
                 granted = installGranted,
@@ -95,7 +97,7 @@ internal class PermissionStep : OnboardingStep {
                         // no-op. resulting checks is being done on resume
                     },
                 )
-                PermissionItem(
+                PermissionCheckbox(
                     title = stringResource(MR.strings.onboarding_permission_notifications),
                     subtitle = stringResource(MR.strings.onboarding_permission_notifications_description),
                     granted = notificationGranted,
@@ -103,7 +105,7 @@ internal class PermissionStep : OnboardingStep {
                 )
             }
 
-            PermissionItem(
+            PermissionCheckbox(
                 title = stringResource(MR.strings.onboarding_permission_ignore_battery_opts),
                 subtitle = stringResource(MR.strings.onboarding_permission_ignore_battery_opts_description),
                 granted = batteryGranted,
@@ -116,26 +118,33 @@ internal class PermissionStep : OnboardingStep {
                 },
             )
 
-            PermissionItem(
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+
+            PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_crashlytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
                 granted = allowCrashLogs,
-                onButtonClick = {
-                    allowCrashLogs = !allowCrashLogs
+                onToggleChange = {
+                    allowCrashLogs = it
                     securityPreferences.crashlytics().set(allowCrashLogs)
                 },
             )
 
-            PermissionItem(
+            PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_analytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
                 granted = allowAnalytics,
-                onButtonClick = {
-                    allowAnalytics = !allowAnalytics
+                onToggleChange = {
+                    allowAnalytics = it
                     securityPreferences.analytics().set(allowAnalytics)
                 },
             )
+
         }
+
     }
 
     @Composable
@@ -153,7 +162,7 @@ internal class PermissionStep : OnboardingStep {
     }
 
     @Composable
-    private fun PermissionItem(
+    private fun PermissionCheckbox(
         title: String,
         subtitle: String,
         granted: Boolean,
@@ -166,6 +175,7 @@ internal class PermissionStep : OnboardingStep {
             supportingContent = { Text(text = subtitle) },
             trailingContent = {
                 OutlinedButton(
+                    enabled = !granted,
                     onClick = onButtonClick,
                 ) {
                     if (granted) {
@@ -182,4 +192,27 @@ internal class PermissionStep : OnboardingStep {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         )
     }
+
+    @Composable
+    private fun PermissionSwitch(
+        title: String,
+        subtitle: String,
+        granted: Boolean,
+        modifier: Modifier = Modifier,
+        onToggleChange: (Boolean) -> Unit,
+    ) {
+        ListItem(
+            modifier = modifier,
+            headlineContent = { Text(text = title) },
+            supportingContent = { Text(text = subtitle) },
+            trailingContent = {
+                Switch(
+                    checked = granted,
+                    onCheckedChange = onToggleChange,
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        )
+    }
+
 }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -49,8 +49,8 @@ internal class PermissionStep : OnboardingStep {
 
     private var notificationGranted by mutableStateOf(false)
     private var batteryGranted by mutableStateOf(false)
-    private var allowCrashLogs by mutableStateOf(false)
-    private var allowAnalytics by mutableStateOf(false)
+    private var allowCrashLogs by mutableStateOf(true)
+    private var allowAnalytics by mutableStateOf(true)
 
     override val isComplete: Boolean = true
 
@@ -119,7 +119,7 @@ internal class PermissionStep : OnboardingStep {
             )
 
             HorizontalDivider(
-                modifier = Modifier.padding(vertical = 8.dp),
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
             )
 

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -36,21 +36,20 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.kanade.presentation.util.rememberRequestPackageInstallsPermissionState
-import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.util.system.launchRequestPackageInstallsPermission
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.presentation.core.util.secondaryItemAlpha
 import uy.kohesive.injekt.injectLazy
 
 internal class PermissionStep : OnboardingStep {
 
-    private val securityPreferences: SecurityPreferences by injectLazy()
+    private val privacyPreferences: PrivacyPreferences by injectLazy()
 
     private var notificationGranted by mutableStateOf(false)
     private var batteryGranted by mutableStateOf(false)
-    private var allowCrashLogs by mutableStateOf(true)
-    private var allowAnalytics by mutableStateOf(true)
 
     override val isComplete: Boolean = true
 
@@ -123,24 +122,24 @@ internal class PermissionStep : OnboardingStep {
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
             )
 
+            val crashlyticsPref = privacyPreferences.crashlytics()
+            val crashlytics by crashlyticsPref.collectAsState()
+
             PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_crashlytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
-                granted = allowCrashLogs,
-                onToggleChange = {
-                    allowCrashLogs = it
-                    securityPreferences.crashlytics().set(allowCrashLogs)
-                },
+                granted = crashlytics,
+                onToggleChange = crashlyticsPref::set,
             )
+
+            val analyticsPref = privacyPreferences.analytics()
+            val analytics by analyticsPref.collectAsState()
 
             PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_analytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
-                granted = allowAnalytics,
-                onToggleChange = {
-                    allowAnalytics = it
-                    securityPreferences.analytics().set(allowAnalytics)
-                },
+                granted = analytics,
+                onToggleChange = analyticsPref::set,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -142,9 +142,7 @@ internal class PermissionStep : OnboardingStep {
                     securityPreferences.analytics().set(allowAnalytics)
                 },
             )
-
         }
-
     }
 
     @Composable
@@ -214,5 +212,4 @@ internal class PermissionStep : OnboardingStep {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
         )
     }
-
 }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -124,7 +124,6 @@ internal class PermissionStep : OnboardingStep {
 
             val crashlyticsPref = privacyPreferences.crashlytics()
             val crashlytics by crashlyticsPref.collectAsState()
-
             PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_crashlytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
@@ -134,7 +133,6 @@ internal class PermissionStep : OnboardingStep {
 
             val analyticsPref = privacyPreferences.analytics()
             val analytics by analyticsPref.collectAsState()
-
             PermissionSwitch(
                 title = stringResource(MR.strings.onboarding_permission_analytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/PermissionStep.kt
@@ -121,10 +121,9 @@ internal class PermissionStep : OnboardingStep {
                 subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
                 granted = allowCrashLogs,
                 onButtonClick = {
-                    // Toggle the granted state
                     allowCrashLogs = !allowCrashLogs
                     securityPreferences.crashlytics().set(allowCrashLogs)
-                }
+                },
             )
 
             PermissionItem(
@@ -132,10 +131,9 @@ internal class PermissionStep : OnboardingStep {
                 subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
                 granted = allowAnalytics,
                 onButtonClick = {
-                    // Toggle the granted state
                     allowAnalytics = !allowAnalytics
                     securityPreferences.analytics().set(allowAnalytics)
-                }
+                },
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -67,11 +67,13 @@ object SettingsSecurityScreen : SearchableSettings {
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.crashlytics(),
-                title = stringResource(MR.strings.share_crash_logs),
+                title = stringResource(MR.strings.onboarding_permission_crashlytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.analytics(),
-                title = stringResource(MR.strings.share_analytics),
+                title = stringResource(MR.strings.onboarding_permission_analytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.hideNotificationContent(),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -67,11 +67,11 @@ object SettingsSecurityScreen : SearchableSettings {
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.crashlytics(),
-                title = "Allow sharing crash logs with devs",
+                title = stringResource(MR.strings.share_crash_logs),
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.analytics(),
-                title = "Allow sharing analytics data",
+                title = stringResource(MR.strings.share_analytics),
             ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.hideNotificationContent(),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
 import eu.kanade.presentation.more.settings.Preference
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.authenticate
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.isAuthenticationSupported
@@ -29,9 +30,10 @@ object SettingsSecurityScreen : SearchableSettings {
     @Composable
     override fun getPreferences(): List<Preference> {
         val securityPreferences = remember { Injekt.get<SecurityPreferences>() }
+        val privacyPreferences = remember { Injekt.get<PrivacyPreferences>() }
         return listOf(
             getSecurityGroup(securityPreferences),
-            getFirebaseGroup(securityPreferences),
+            getFirebaseGroup(privacyPreferences),
         )
     }
 }
@@ -96,18 +98,18 @@ private fun getSecurityGroup(
 
 @Composable
 private fun getFirebaseGroup(
-    securityPreferences: SecurityPreferences,
+    privacyPreferences: PrivacyPreferences,
 ): Preference.PreferenceGroup {
     return Preference.PreferenceGroup(
         title = stringResource(MR.strings.pref_firebase),
         preferenceItems = persistentListOf(
             Preference.PreferenceItem.SwitchPreference(
-                pref = securityPreferences.crashlytics(),
+                pref = privacyPreferences.crashlytics(),
                 title = stringResource(MR.strings.onboarding_permission_crashlytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
             ),
             Preference.PreferenceItem.SwitchPreference(
-                pref = securityPreferences.analytics(),
+                pref = privacyPreferences.analytics(),
                 title = stringResource(MR.strings.onboarding_permission_analytics),
                 subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
             ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -38,7 +38,7 @@ object SettingsSecurityScreen : SearchableSettings {
 
 @Composable
 private fun getSecurityGroup(
-    securityPreferences: SecurityPreferences
+    securityPreferences: SecurityPreferences,
 ): Preference.PreferenceGroup {
     val context = LocalContext.current
     val authSupported = remember { context.isAuthenticationSupported() }
@@ -96,7 +96,7 @@ private fun getSecurityGroup(
 
 @Composable
 private fun getFirebaseGroup(
-    securityPreferences: SecurityPreferences
+    securityPreferences: SecurityPreferences,
 ): Preference.PreferenceGroup {
     return Preference.PreferenceGroup(
         title = stringResource(MR.strings.pref_firebase),
@@ -115,8 +115,6 @@ private fun getFirebaseGroup(
         ),
     )
 }
-
-
 
 private val LockAfterValues = persistentListOf(
     0, // Always

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -66,6 +66,14 @@ object SettingsSecurityScreen : SearchableSettings {
                 },
             ),
             Preference.PreferenceItem.SwitchPreference(
+                pref = securityPreferences.crashlytics(),
+                title = "Allow sharing crash logs with devs",
+            ),
+            Preference.PreferenceItem.SwitchPreference(
+                pref = securityPreferences.analytics(),
+                title = "Allow sharing analytics data",
+            ),
+            Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.hideNotificationContent(),
                 title = stringResource(MR.strings.hide_notification_content),
             ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -28,14 +28,26 @@ object SettingsSecurityScreen : SearchableSettings {
 
     @Composable
     override fun getPreferences(): List<Preference> {
-        val context = LocalContext.current
         val securityPreferences = remember { Injekt.get<SecurityPreferences>() }
-        val authSupported = remember { context.isAuthenticationSupported() }
-
-        val useAuthPref = securityPreferences.useAuthenticator()
-        val useAuth by useAuthPref.collectAsState()
-
         return listOf(
+            getSecurityGroup(securityPreferences),
+            getFirebaseGroup(securityPreferences),
+        )
+    }
+}
+
+@Composable
+private fun getSecurityGroup(
+    securityPreferences: SecurityPreferences
+): Preference.PreferenceGroup {
+    val context = LocalContext.current
+    val authSupported = remember { context.isAuthenticationSupported() }
+    val useAuthPref = securityPreferences.useAuthenticator()
+    val useAuth by useAuthPref.collectAsState()
+
+    return Preference.PreferenceGroup(
+        title = stringResource(MR.strings.pref_security),
+        preferenceItems = persistentListOf(
             Preference.PreferenceItem.SwitchPreference(
                 pref = useAuthPref,
                 title = stringResource(MR.strings.lock_with_biometrics),
@@ -65,16 +77,7 @@ object SettingsSecurityScreen : SearchableSettings {
                     )
                 },
             ),
-            Preference.PreferenceItem.SwitchPreference(
-                pref = securityPreferences.crashlytics(),
-                title = stringResource(MR.strings.onboarding_permission_crashlytics),
-                subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
-            ),
-            Preference.PreferenceItem.SwitchPreference(
-                pref = securityPreferences.analytics(),
-                title = stringResource(MR.strings.onboarding_permission_analytics),
-                subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
-            ),
+
             Preference.PreferenceItem.SwitchPreference(
                 pref = securityPreferences.hideNotificationContent(),
                 title = stringResource(MR.strings.hide_notification_content),
@@ -87,9 +90,33 @@ object SettingsSecurityScreen : SearchableSettings {
                     .toImmutableMap(),
             ),
             Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.secure_screen_summary)),
-        )
-    }
+        ),
+    )
 }
+
+@Composable
+private fun getFirebaseGroup(
+    securityPreferences: SecurityPreferences
+): Preference.PreferenceGroup {
+    return Preference.PreferenceGroup(
+        title = stringResource(MR.strings.pref_firebase),
+        preferenceItems = persistentListOf(
+            Preference.PreferenceItem.SwitchPreference(
+                pref = securityPreferences.crashlytics(),
+                title = stringResource(MR.strings.onboarding_permission_crashlytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
+            ),
+            Preference.PreferenceItem.SwitchPreference(
+                pref = securityPreferences.analytics(),
+                title = stringResource(MR.strings.onboarding_permission_analytics),
+                subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
+            ),
+            Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.firebase_summary)),
+        ),
+    )
+}
+
+
 
 private val LockAfterValues = persistentListOf(
     0, // Always

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -36,86 +36,86 @@ object SettingsSecurityScreen : SearchableSettings {
             getFirebaseGroup(privacyPreferences),
         )
     }
-}
 
-@Composable
-private fun getSecurityGroup(
-    securityPreferences: SecurityPreferences,
-): Preference.PreferenceGroup {
-    val context = LocalContext.current
-    val authSupported = remember { context.isAuthenticationSupported() }
-    val useAuthPref = securityPreferences.useAuthenticator()
-    val useAuth by useAuthPref.collectAsState()
+    @Composable
+    private fun getSecurityGroup(
+        securityPreferences: SecurityPreferences,
+    ): Preference.PreferenceGroup {
+        val context = LocalContext.current
+        val authSupported = remember { context.isAuthenticationSupported() }
+        val useAuthPref = securityPreferences.useAuthenticator()
+        val useAuth by useAuthPref.collectAsState()
 
-    return Preference.PreferenceGroup(
-        title = stringResource(MR.strings.pref_security),
-        preferenceItems = persistentListOf(
-            Preference.PreferenceItem.SwitchPreference(
-                pref = useAuthPref,
-                title = stringResource(MR.strings.lock_with_biometrics),
-                enabled = authSupported,
-                onValueChanged = {
-                    (context as FragmentActivity).authenticate(
-                        title = context.stringResource(MR.strings.lock_with_biometrics),
-                    )
-                },
-            ),
-            Preference.PreferenceItem.ListPreference(
-                pref = securityPreferences.lockAppAfter(),
-                title = stringResource(MR.strings.lock_when_idle),
-                enabled = authSupported && useAuth,
-                entries = LockAfterValues
-                    .associateWith {
-                        when (it) {
-                            -1 -> stringResource(MR.strings.lock_never)
-                            0 -> stringResource(MR.strings.lock_always)
-                            else -> pluralStringResource(MR.plurals.lock_after_mins, count = it, it)
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_security),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = useAuthPref,
+                    title = stringResource(MR.strings.lock_with_biometrics),
+                    enabled = authSupported,
+                    onValueChanged = {
+                        (context as FragmentActivity).authenticate(
+                            title = context.stringResource(MR.strings.lock_with_biometrics),
+                        )
+                    },
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    pref = securityPreferences.lockAppAfter(),
+                    title = stringResource(MR.strings.lock_when_idle),
+                    enabled = authSupported && useAuth,
+                    entries = LockAfterValues
+                        .associateWith {
+                            when (it) {
+                                -1 -> stringResource(MR.strings.lock_never)
+                                0 -> stringResource(MR.strings.lock_always)
+                                else -> pluralStringResource(MR.plurals.lock_after_mins, count = it, it)
+                            }
                         }
-                    }
-                    .toImmutableMap(),
-                onValueChanged = {
-                    (context as FragmentActivity).authenticate(
-                        title = context.stringResource(MR.strings.lock_when_idle),
-                    )
-                },
-            ),
+                        .toImmutableMap(),
+                    onValueChanged = {
+                        (context as FragmentActivity).authenticate(
+                            title = context.stringResource(MR.strings.lock_when_idle),
+                        )
+                    },
+                ),
 
-            Preference.PreferenceItem.SwitchPreference(
-                pref = securityPreferences.hideNotificationContent(),
-                title = stringResource(MR.strings.hide_notification_content),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = securityPreferences.hideNotificationContent(),
+                    title = stringResource(MR.strings.hide_notification_content),
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    pref = securityPreferences.secureScreen(),
+                    title = stringResource(MR.strings.secure_screen),
+                    entries = SecurityPreferences.SecureScreenMode.entries
+                        .associateWith { stringResource(it.titleRes) }
+                        .toImmutableMap(),
+                ),
+                Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.secure_screen_summary)),
             ),
-            Preference.PreferenceItem.ListPreference(
-                pref = securityPreferences.secureScreen(),
-                title = stringResource(MR.strings.secure_screen),
-                entries = SecurityPreferences.SecureScreenMode.entries
-                    .associateWith { stringResource(it.titleRes) }
-                    .toImmutableMap(),
-            ),
-            Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.secure_screen_summary)),
-        ),
-    )
-}
+        )
+    }
 
-@Composable
-private fun getFirebaseGroup(
-    privacyPreferences: PrivacyPreferences,
-): Preference.PreferenceGroup {
-    return Preference.PreferenceGroup(
-        title = stringResource(MR.strings.pref_firebase),
-        preferenceItems = persistentListOf(
-            Preference.PreferenceItem.SwitchPreference(
-                pref = privacyPreferences.crashlytics(),
-                title = stringResource(MR.strings.onboarding_permission_crashlytics),
-                subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
+    @Composable
+    private fun getFirebaseGroup(
+        privacyPreferences: PrivacyPreferences,
+    ): Preference.PreferenceGroup {
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_firebase),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = privacyPreferences.crashlytics(),
+                    title = stringResource(MR.strings.onboarding_permission_crashlytics),
+                    subtitle = stringResource(MR.strings.onboarding_permission_crashlytics_description),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = privacyPreferences.analytics(),
+                    title = stringResource(MR.strings.onboarding_permission_analytics),
+                    subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
+                ),
+                Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.firebase_summary)),
             ),
-            Preference.PreferenceItem.SwitchPreference(
-                pref = privacyPreferences.analytics(),
-                title = stringResource(MR.strings.onboarding_permission_analytics),
-                subtitle = stringResource(MR.strings.onboarding_permission_analytics_description),
-            ),
-            Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.firebase_summary)),
-        ),
-    )
+        )
+    }
 }
 
 private val LockAfterValues = persistentListOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -26,7 +26,7 @@ import eu.kanade.domain.DomainModule
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
-import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
@@ -69,7 +69,7 @@ import java.security.Security
 class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factory {
 
     private val basePreferences: BasePreferences by injectLazy()
-    private val securityPreferences: SecurityPreferences by injectLazy()
+    private val privacyPreferences: PrivacyPreferences by injectLazy()
     private val networkPreferences: NetworkPreferences by injectLazy()
 
     private val disableIncognitoReceiver = DisableIncognitoReceiver()
@@ -96,7 +96,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(AppModule(this))
         Injekt.importModule(DomainModule())
 
-        Firebase.setup(applicationContext, securityPreferences, ProcessLifecycleOwner.get().lifecycleScope)
+        Firebase.setup(applicationContext, privacyPreferences, ProcessLifecycleOwner.get().lifecycleScope)
 
         setupNotificationChannels()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi
 
-import Firebase
 import android.annotation.SuppressLint
 import android.app.Application
 import android.app.PendingIntent
@@ -27,6 +26,7 @@ import eu.kanade.domain.DomainModule
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.onEach
 import logcat.AndroidLogcatLogger
 import logcat.LogPriority
 import logcat.LogcatLogger
+import mihon.core.firebase.Firebase
 import mihon.core.migration.Migrator
 import mihon.core.migration.migrations.migrations
 import org.conscrypt.Conscrypt
@@ -68,6 +69,7 @@ import java.security.Security
 class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factory {
 
     private val basePreferences: BasePreferences by injectLazy()
+    private val securityPreferences: SecurityPreferences by injectLazy()
     private val networkPreferences: NetworkPreferences by injectLazy()
 
     private val disableIncognitoReceiver = DisableIncognitoReceiver()
@@ -76,7 +78,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     override fun onCreate() {
         super<Application>.onCreate()
         patchInjekt()
-        Firebase.setup(applicationContext, basePreferences)
+        Firebase.setup(applicationContext, securityPreferences)
 
         GlobalExceptionHandler.initialize(applicationContext, CrashActivity::class.java)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi
 
+import Firebase
 import android.annotation.SuppressLint
 import android.app.Application
 import android.app.PendingIntent
@@ -21,13 +22,11 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
 import coil3.util.DebugLogger
-//import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dev.mihon.injekt.patchInjekt
 import eu.kanade.domain.DomainModule
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
-import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
@@ -69,7 +68,6 @@ import java.security.Security
 class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factory {
 
     private val basePreferences: BasePreferences by injectLazy()
-    private val securityPreferences: SecurityPreferences by injectLazy()
     private val networkPreferences: NetworkPreferences by injectLazy()
 
     private val disableIncognitoReceiver = DisableIncognitoReceiver()
@@ -78,7 +76,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     override fun onCreate() {
         super<Application>.onCreate()
         patchInjekt()
-        //FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(securityPreferences.crashlytics().get())
+        Firebase.setup(applicationContext, basePreferences)
 
         GlobalExceptionHandler.initialize(applicationContext, CrashActivity::class.java)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -21,11 +21,13 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
 import coil3.util.DebugLogger
+//import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dev.mihon.injekt.patchInjekt
 import eu.kanade.domain.DomainModule
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
@@ -67,6 +69,7 @@ import java.security.Security
 class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factory {
 
     private val basePreferences: BasePreferences by injectLazy()
+    private val securityPreferences: SecurityPreferences by injectLazy()
     private val networkPreferences: NetworkPreferences by injectLazy()
 
     private val disableIncognitoReceiver = DisableIncognitoReceiver()
@@ -75,6 +78,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     override fun onCreate() {
         super<Application>.onCreate()
         patchInjekt()
+        //FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(securityPreferences.crashlytics().get())
 
         GlobalExceptionHandler.initialize(applicationContext, CrashActivity::class.java)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -78,7 +78,6 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     override fun onCreate() {
         super<Application>.onCreate()
         patchInjekt()
-        Firebase.setup(applicationContext, securityPreferences)
 
         GlobalExceptionHandler.initialize(applicationContext, CrashActivity::class.java)
 
@@ -96,6 +95,8 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(PreferenceModule(this))
         Injekt.importModule(AppModule(this))
         Injekt.importModule(DomainModule())
+
+        Firebase.setup(applicationContext, securityPreferences, ProcessLifecycleOwner.get().lifecycleScope)
 
         setupNotificationChannels()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -5,6 +5,7 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
@@ -38,6 +39,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             SecurityPreferences(get())
+        }
+        addSingletonFactory {
+            PrivacyPreferences(get())
         }
         addSingletonFactory {
             LibraryPreferences(get())

--- a/app/src/standard/AndroidManifest.xml
+++ b/app/src/standard/AndroidManifest.xml
@@ -20,6 +20,15 @@
         tools:node="remove" />
 
     <application>
+        <!-- Disable for manual opt-in -->
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
+
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
+
         <!-- Disable unnecessary stuff from Firebase -->
         <meta-data
             android:name="google_analytics_adid_collection_enabled"

--- a/app/src/standard/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/standard/java/mihon/core/firebase/Firebase.kt
@@ -3,13 +3,13 @@ package mihon.core.firebase
 import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
-import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 object Firebase {
-    fun setup(context: Context, preference: SecurityPreferences, scope: CoroutineScope) {
+    fun setup(context: Context, preference: PrivacyPreferences, scope: CoroutineScope) {
         preference.analytics().changes().onEach { enabled ->
             FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(enabled)
         }.launchIn(scope)

--- a/app/src/standard/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/standard/java/mihon/core/firebase/Firebase.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 object Firebase {
     fun setup(context: Context, preference: SecurityPreferences, scope: CoroutineScope) {

--- a/app/src/standard/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/standard/java/mihon/core/firebase/Firebase.kt
@@ -2,12 +2,17 @@ package mihon.core.firebase
 
 import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
-import eu.kanade.domain.base.BasePreferences
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import kotlinx.coroutines.flow.onEach
 
 object Firebase {
-    fun setup(context: Context, preference: BasePreferences) {
-        preference.incognitoMode().changes().onEach { enabled ->
+    fun setup(context: Context, preference: SecurityPreferences) {
+        preference.analytics().changes().onEach { enabled ->
             FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(enabled)
+        }
+        preference.crashlytics().changes().onEach { enabled ->
+            FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enabled)
         }
     }
 }

--- a/app/src/standard/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/standard/java/mihon/core/firebase/Firebase.kt
@@ -5,14 +5,16 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.CoroutineScope
 
 object Firebase {
-    fun setup(context: Context, preference: SecurityPreferences) {
+    fun setup(context: Context, preference: SecurityPreferences, scope: CoroutineScope) {
         preference.analytics().changes().onEach { enabled ->
             FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(enabled)
-        }
+        }.launchIn(scope)
         preference.crashlytics().changes().onEach { enabled ->
             FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(enabled)
-        }
+        }.launchIn(scope)
     }
 }

--- a/app/src/standard/java/mihon/core/firebase/Firebase.kt
+++ b/app/src/standard/java/mihon/core/firebase/Firebase.kt
@@ -1,0 +1,13 @@
+package mihon.core.firebase
+
+import android.content.Context
+import com.google.firebase.analytics.FirebaseAnalytics
+import eu.kanade.domain.base.BasePreferences
+
+object Firebase {
+    fun setup(context: Context, preference: BasePreferences) {
+        preference.incognitoMode().changes().onEach { enabled ->
+            FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(enabled)
+        }
+    }
+}

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/PrivacyPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/PrivacyPreferences.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.core.security
+
+import tachiyomi.core.common.preference.PreferenceStore
+
+class PrivacyPreferences(
+    private val preferenceStore: PreferenceStore,
+) {
+    fun crashlytics() = preferenceStore.getBoolean("crashlytics", false)
+
+    fun analytics() = preferenceStore.getBoolean("analytics", false)
+}

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/PrivacyPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/PrivacyPreferences.kt
@@ -5,7 +5,7 @@ import tachiyomi.core.common.preference.PreferenceStore
 class PrivacyPreferences(
     private val preferenceStore: PreferenceStore,
 ) {
-    fun crashlytics() = preferenceStore.getBoolean("crashlytics", false)
+    fun crashlytics() = preferenceStore.getBoolean("crashlytics", true)
 
-    fun analytics() = preferenceStore.getBoolean("analytics", false)
+    fun analytics() = preferenceStore.getBoolean("analytics", true)
 }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/SecurityPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/SecurityPreferences.kt
@@ -18,10 +18,6 @@ class SecurityPreferences(
 
     fun hideNotificationContent() = preferenceStore.getBoolean("hide_notification_content", false)
 
-    fun crashlytics() = preferenceStore.getBoolean("crashlytics", false)
-
-    fun analytics() = preferenceStore.getBoolean("analytics", false)
-
     /**
      * For app lock. Will be set when there is a pending timed lock.
      * Otherwise this pref should be deleted.

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/SecurityPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/core/security/SecurityPreferences.kt
@@ -18,6 +18,10 @@ class SecurityPreferences(
 
     fun hideNotificationContent() = preferenceStore.getBoolean("hide_notification_content", false)
 
+    fun crashlytics() = preferenceStore.getBoolean("crashlytics", false)
+
+    fun analytics() = preferenceStore.getBoolean("analytics", false)
+
     /**
      * For app lock. Will be set when there is a pending timed lock.
      * Otherwise this pref should be deleted.

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -190,6 +190,10 @@
     <string name="onboarding_permission_notifications_description">Get notified for library updates and more.</string>
     <string name="onboarding_permission_ignore_battery_opts">Background battery usage</string>
     <string name="onboarding_permission_ignore_battery_opts_description">Avoid interruptions to long-running library updates, downloads, and backup restores.</string>
+    <string name="onboarding_permission_crashlytics">Send crash logs</string>
+    <string name="onboarding_permission_crashlytics_description">Send anonymised crash logs to the developers.</string>
+    <string name="onboarding_permission_analytics">Allow analytics</string>
+    <string name="onboarding_permission_analytics_description">Send anonymized usage data to improve app features.</string>
     <string name="onboarding_permission_action_grant">Grant</string>
     <string name="onboarding_guides_new_user">New to %s? We recommend checking out the getting started guide.</string>
     <string name="onboarding_guides_returning_user">Reinstalling %s?</string>
@@ -246,6 +250,8 @@
     <string name="lock_when_idle">Lock when idle</string>
     <string name="lock_always">Always</string>
     <string name="lock_never">Never</string>
+    <string name="share_crash_logs">Allow sharing crash logs with devs</string>
+    <string name="share_analytics">Allow sharing analytics data</string>
     <string name="hide_notification_content">Hide notification content</string>
     <string name="secure_screen">Secure screen</string>
     <string name="secure_screen_summary">Secure screen hides app contents when switching apps and block screenshots</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -250,8 +250,6 @@
     <string name="lock_when_idle">Lock when idle</string>
     <string name="lock_always">Always</string>
     <string name="lock_never">Never</string>
-    <string name="share_crash_logs">Allow sharing crash logs with devs</string>
-    <string name="share_analytics">Allow sharing analytics data</string>
     <string name="hide_notification_content">Hide notification content</string>
     <string name="secure_screen">Secure screen</string>
     <string name="secure_screen_summary">Secure screen hides app contents when switching apps and block screenshots</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -191,7 +191,7 @@
     <string name="onboarding_permission_ignore_battery_opts">Background battery usage</string>
     <string name="onboarding_permission_ignore_battery_opts_description">Avoid interruptions to long-running library updates, downloads, and backup restores.</string>
     <string name="onboarding_permission_crashlytics">Send crash logs</string>
-    <string name="onboarding_permission_crashlytics_description">Send anonymised crash logs to the developers.</string>
+    <string name="onboarding_permission_crashlytics_description">Send anonymized crash logs to the developers.</string>
     <string name="onboarding_permission_analytics">Allow analytics</string>
     <string name="onboarding_permission_analytics_description">Send anonymized usage data to improve app features.</string>
     <string name="onboarding_permission_action_grant">Grant</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -246,6 +246,9 @@
     <string name="pref_app_language">App language</string>
 
     <string name="pref_category_security">Security and privacy</string>
+    <string name="pref_security">Security</string>
+    <string name="pref_firebase">Analytics and Crash logs</string>
+
     <string name="lock_with_biometrics">Require unlock</string>
     <string name="lock_when_idle">Lock when idle</string>
     <string name="lock_always">Always</string>
@@ -253,6 +256,7 @@
     <string name="hide_notification_content">Hide notification content</string>
     <string name="secure_screen">Secure screen</string>
     <string name="secure_screen_summary">Secure screen hides app contents when switching apps and block screenshots</string>
+    <string name="firebase_summary">Sending crash logs and analytics will allow us to identify and fix issues, improve performance, and make future updates more relevant to your needs</string>
 
     <string name="pref_category_nsfw_content">NSFW (18+) sources</string>
     <string name="pref_show_nsfw_source">Show in sources and extensions lists</string>


### PR DESCRIPTION
Resolves #1187
Adds options to both Onboarding and the Security and Privacy Screen to toggle Analytics and Crashlytics

| Before | After | 
|---|---|
| ![image](https://github.com/user-attachments/assets/cbf6c952-7605-455d-bde8-938c827d8baa) | ![image](https://github.com/user-attachments/assets/b17c3a4e-20a1-41a6-80f1-26a8f9dff6a5) | 
| ![image](https://github.com/user-attachments/assets/e2ed5089-2b43-41de-bb59-67c56fdc8d5c) | ![image0](https://github.com/user-attachments/assets/66677a8b-1542-4fd6-91dc-e5b92b621973) | 
