### PR TITLE
Support case sensitive CBZ files

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -351,7 +351,7 @@ class DownloadCache(
                                             // Folder of images
                                             it.isDirectory -> it.name
                                             // CBZ files
-                                            it.isFile && it.extension == "cbz" -> it.nameWithoutExtension
+                                            it.isFile && it.extension.lowercase() == "cbz" -> it.nameWithoutExtension
                                             // Anything else is irrelevant
                                             else -> null
                                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -345,7 +345,7 @@ class DownloadManager(
             .firstOrNull() ?: return
 
         var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator)
-        if (oldDownload.isFile && oldDownload.extension == "cbz") {
+        if (oldDownload.isFile && oldDownload.extension.lowercase() == "cbz") {
             newName += ".cbz"
         }
 


### PR DESCRIPTION
Code has NOT been tested.

Adapted from `return file.extension?.lowercase() in SUPPORTED_ARCHIVE_TYPES` unsure if it needs the null `?` operator thing or not.

Hopefully fixes this:

```
cupid:/sdcard/Tachiyomi/local $ ls -lah cbz cbzlower/                                                                                                                                                                                                                                       
cbz:
total 959K
-rw-rw---- 1 u0_a171 media_rw    0 2024-09-25 22:20 .noxml
-rw-rw---- 1 u0_a171 media_rw 958M 2024-09-25 21:46 Kill\ Six\ Billion\ Demons.CBZ

cbzlower:
total 959K
-rw-rw---- 1 u0_a171 media_rw 958M 2024-09-25 21:46 Kill\ Six\ Billion\ Demons.cbz
```


![image](https://github.com/user-attachments/assets/0566801f-c153-467b-a597-0612be111a7e)

![image](https://github.com/user-attachments/assets/fad51484-08b0-4e4d-a2ed-737603ae6673)

```xml
<?xml version='1.0' encoding='UTF-8' ?>
<ComicInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <Title>Kill Six Billion Demons</Title>
  <Series>Book One</Series>
  <Number>1</Number>
  <Volume>1</Volume>
  <AlternateSeries />
  <AlternateNumber />
  <StoryArc />
  <SeriesGroup />
  <Summary>In this collection of the first story arc of the popular webcomic Kill Six Billion Demons, sorority sister Allison Ruth must travel to Throne, the ancient city at the center of the multiverse, in an epic bid to save her boyfriend from the clutches of the seven evil kings that rule creation. Includes excerpts from in-universe religious texts, stories, and more.</Summary>
  <Notes />
  <Writer>Tom Parkinson-Morgan (Abbadon)</Writer>
  <Publisher />
  <Imprint />
  <Genre>Comics & Graphic Novels, Horror</Genre>
  <Web />
  <PageCount>999</PageCount>
  <LanguageISO>en</LanguageISO>
  <Format />
  <AgeRating />
  <Manga>No</Manga>
  <Characters />
  <Teams />
  <Locations />
  <ScanInformation />
  <Pages>
    <Page Image="1" Type="FrontCover" />
  </Pages>
</ComicInfo>
```

I don't get why .noxml is there, probably because it does not find the file.

For some reason, even the lower case cbz does not parse any of the XML.

![image](https://github.com/user-attachments/assets/f4f854d8-b8f5-4a73-8ce7-9a66ce402b8d)

But I suppose that's for another issue, or is a PEBKAC on my part since finding documentation for CBZ stuff seems to be a nightmare.