### PR TITLE
Retain remote last chapter read if it's higher than the local one for EnhancedTracker

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/SyncChapterProgressWithTrack.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/SyncChapterProgressWithTrack.kt
@@ -10,6 +10,7 @@ import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.toChapterUpdate
 import tachiyomi.domain.track.interactor.InsertTrack
 import tachiyomi.domain.track.model.Track
+import kotlin.math.max
 
 class SyncChapterProgressWithTrack(
     private val updateChapter: UpdateChapter,
@@ -36,7 +37,8 @@ class SyncChapterProgressWithTrack(
 
         // only take into account continuous reading
         val localLastRead = sortedChapters.takeWhile { it.read }.lastOrNull()?.chapterNumber ?: 0F
-        val updatedTrack = remoteTrack.copy(lastChapterRead = localLastRead.toDouble())
+        val lastRead = max(remoteTrack.lastChapterRead, localLastRead.toDouble())
+        val updatedTrack = remoteTrack.copy(lastChapterRead = lastRead)
 
         try {
             tracker.update(updatedTrack.toDbTrack())


### PR DESCRIPTION
This PR is related to #1298.

When adding an item to the library, with the #1298 fix, the track's last_read_chapter value set by `SyncChapterProgressWithTrack` is always set to the local last read chapter.
This fix uses the max between the local and remote last read chapter to set its new value.