### PR TITLE
Added random library sort

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +31,7 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.HeadingItem
+import tachiyomi.presentation.core.components.NondirectionalSortItem
 import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.components.SortItem
@@ -178,27 +181,42 @@ private fun ColumnScope.SortPage(
         MR.strings.action_sort_latest_chapter to LibrarySort.Type.LatestChapter,
         MR.strings.action_sort_chapter_fetch_date to LibrarySort.Type.ChapterFetchDate,
         MR.strings.action_sort_date_added to LibrarySort.Type.DateAdded,
+        MR.strings.action_sort_random to LibrarySort.Type.Random,
     ).plus(trackerSortOption).map { (titleRes, mode) ->
-        SortItem(
-            label = stringResource(titleRes),
-            sortDescending = sortDescending.takeIf { sortingMode == mode },
-            onClick = {
-                val isTogglingDirection = sortingMode == mode
-                val direction = when {
-                    isTogglingDirection -> if (sortDescending) {
-                        LibrarySort.Direction.Ascending
-                    } else {
-                        LibrarySort.Direction.Descending
-                    }
-                    else -> if (sortDescending) {
-                        LibrarySort.Direction.Descending
-                    } else {
-                        LibrarySort.Direction.Ascending
-                    }
-                }
-                screenModel.setSort(category, mode, direction)
-            },
-        )
+        when(mode) {
+            LibrarySort.Type.Random -> {
+                NondirectionalSortItem(
+                    label = stringResource(titleRes),
+                    enabled = sortingMode == LibrarySort.Type.Random,
+                    enabledIcon = Icons.Default.Refresh,
+                    onClick = {
+                        screenModel.setSort(category, mode, LibrarySort.Direction.Ascending)
+                    },
+                )
+            }
+            else -> {
+                SortItem(
+                    label = stringResource(titleRes),
+                    sortDescending = sortDescending.takeIf { sortingMode == mode },
+                    onClick = {
+                        val isTogglingDirection = sortingMode == mode
+                        val direction = when {
+                            isTogglingDirection -> if (sortDescending) {
+                                LibrarySort.Direction.Ascending
+                            } else {
+                                LibrarySort.Direction.Descending
+                            }
+                            else -> if (sortDescending) {
+                                LibrarySort.Direction.Descending
+                            } else {
+                                LibrarySort.Direction.Ascending
+                            }
+                        }
+                        screenModel.setSort(category, mode, direction)
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -29,9 +29,9 @@ import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.sort
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.BaseSortItem
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.HeadingItem
-import tachiyomi.presentation.core.components.NondirectionalSortItem
 import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.components.SortItem
@@ -184,10 +184,14 @@ private fun ColumnScope.SortPage(
         MR.strings.action_sort_random to LibrarySort.Type.Random,
     ).plus(trackerSortOption).map { (titleRes, mode) ->
         if (mode == LibrarySort.Type.Random) {
-            NondirectionalSortItem(
+            val enabledIcon = if (sortingMode == LibrarySort.Type.Random) {
+                Icons.Default.Refresh
+            } else {
+                null
+            }
+            BaseSortItem(
                 label = stringResource(titleRes),
-                enabled = sortingMode == LibrarySort.Type.Random,
-                enabledIcon = Icons.Default.Refresh,
+                icon = enabledIcon,
                 onClick = {
                     screenModel.setSort(category, mode, LibrarySort.Direction.Ascending)
                 },

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -184,14 +184,10 @@ private fun ColumnScope.SortPage(
         MR.strings.action_sort_random to LibrarySort.Type.Random,
     ).plus(trackerSortOption).map { (titleRes, mode) ->
         if (mode == LibrarySort.Type.Random) {
-            val enabledIcon = if (sortingMode == LibrarySort.Type.Random) {
-                Icons.Default.Refresh
-            } else {
-                null
-            }
             BaseSortItem(
                 label = stringResource(titleRes),
-                icon = enabledIcon,
+                icon = Icons.Default.Refresh
+                    .takeIf { sortingMode == LibrarySort.Type.Random },
                 onClick = {
                     screenModel.setSort(category, mode, LibrarySort.Direction.Ascending)
                 },

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -183,40 +183,37 @@ private fun ColumnScope.SortPage(
         MR.strings.action_sort_date_added to LibrarySort.Type.DateAdded,
         MR.strings.action_sort_random to LibrarySort.Type.Random,
     ).plus(trackerSortOption).map { (titleRes, mode) ->
-        when(mode) {
-            LibrarySort.Type.Random -> {
-                NondirectionalSortItem(
-                    label = stringResource(titleRes),
-                    enabled = sortingMode == LibrarySort.Type.Random,
-                    enabledIcon = Icons.Default.Refresh,
-                    onClick = {
-                        screenModel.setSort(category, mode, LibrarySort.Direction.Ascending)
-                    },
-                )
-            }
-            else -> {
-                SortItem(
-                    label = stringResource(titleRes),
-                    sortDescending = sortDescending.takeIf { sortingMode == mode },
-                    onClick = {
-                        val isTogglingDirection = sortingMode == mode
-                        val direction = when {
-                            isTogglingDirection -> if (sortDescending) {
-                                LibrarySort.Direction.Ascending
-                            } else {
-                                LibrarySort.Direction.Descending
-                            }
-                            else -> if (sortDescending) {
-                                LibrarySort.Direction.Descending
-                            } else {
-                                LibrarySort.Direction.Ascending
-                            }
-                        }
-                        screenModel.setSort(category, mode, direction)
-                    },
-                )
-            }
+        if (mode == LibrarySort.Type.Random) {
+            NondirectionalSortItem(
+                label = stringResource(titleRes),
+                enabled = sortingMode == LibrarySort.Type.Random,
+                enabledIcon = Icons.Default.Refresh,
+                onClick = {
+                    screenModel.setSort(category, mode, LibrarySort.Direction.Ascending)
+                },
+            )
+            return@map
         }
+        SortItem(
+            label = stringResource(titleRes),
+            sortDescending = sortDescending.takeIf { sortingMode == mode },
+            onClick = {
+                val isTogglingDirection = sortingMode == mode
+                val direction = when {
+                    isTogglingDirection -> if (sortDescending) {
+                        LibrarySort.Direction.Ascending
+                    } else {
+                        LibrarySort.Direction.Descending
+                    }
+                    else -> if (sortDescending) {
+                        LibrarySort.Direction.Descending
+                    } else {
+                        LibrarySort.Direction.Ascending
+                    }
+                }
+                screenModel.setSort(category, mode, direction)
+            },
+        )
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -302,8 +302,7 @@ class LibraryScreenModel(
                     item1Score.compareTo(item2Score)
                 }
                 LibrarySort.Type.Random -> {
-                    error("A comparator should not be requested for the random sort style. Instead, intercept this " +
-                        "case and call .shuffle()")
+                    error("Why Are We Still Here? Just To Suffer?")
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -267,7 +267,7 @@ class LibraryScreenModel(
 
         fun LibrarySort.comparator(): Comparator<LibraryItem> = Comparator { i1, i2 ->
             when (this.type) {
-                LibrarySort.Type.Alphabetical -> {
+                LibrarySort.Type.Alphabetical, LibrarySort.Type.Random -> {
                     sortAlphabetically(i1, i2)
                 }
                 LibrarySort.Type.LastRead -> {
@@ -304,11 +304,16 @@ class LibraryScreenModel(
         }
 
         return mapValues { (key, value) ->
-            val comparator = key.sort.comparator()
-                .let { if (key.sort.isAscending) it else it.reversed() }
-                .thenComparator(sortAlphabetically)
+            when (key.sort.type) {
+                LibrarySort.Type.Random -> value.shuffled()
+                else -> {
+                    val comparator = key.sort.comparator()
+                        .let { if (key.sort.isAscending) it else it.reversed() }
+                        .thenComparator(sortAlphabetically)
 
-            value.sortedWith(comparator)
+                    value.sortedWith(comparator)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -309,7 +309,7 @@ class LibraryScreenModel(
 
         return mapValues { (key, value) ->
            if (key.sort.type == LibrarySort.Type.Random) {
-               return@mapValues value.shuffled(Random(libraryPreferences.currentRandomSortSeed().get()))
+               return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed().get()))
            }
 
             val comparator = key.sort.comparator()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -72,6 +72,8 @@ import tachiyomi.domain.track.model.Track
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.Collections
+import kotlin.random.Random
 
 /**
  * Typealias for the library manga, using the category as keys, and list of manga as values.
@@ -305,7 +307,7 @@ class LibraryScreenModel(
 
         return mapValues { (key, value) ->
             when (key.sort.type) {
-                LibrarySort.Type.Random -> value.shuffled()
+                LibrarySort.Type.Random -> value.shuffled(Random(libraryPreferences.currentRandomSortSeed().get()))
                 else -> {
                     val comparator = key.sort.comparator()
                         .let { if (key.sort.isAscending) it else it.reversed() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -268,7 +268,7 @@ class LibraryScreenModel(
 
         fun LibrarySort.comparator(): Comparator<LibraryItem> = Comparator { i1, i2 ->
             when (this.type) {
-                LibrarySort.Type.Alphabetical, LibrarySort.Type.Random -> {
+                LibrarySort.Type.Alphabetical -> {
                     sortAlphabetically(i1, i2)
                 }
                 LibrarySort.Type.LastRead -> {
@@ -300,6 +300,10 @@ class LibraryScreenModel(
                     val item1Score = trackerScores[i1.libraryManga.id] ?: defaultTrackerScoreSortValue
                     val item2Score = trackerScores[i2.libraryManga.id] ?: defaultTrackerScoreSortValue
                     item1Score.compareTo(item2Score)
+                }
+                LibrarySort.Type.Random -> {
+                    error("A comparator should not be requested for the random sort style. Instead, intercept this " +
+                        "case and call .shuffle()")
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -305,16 +305,15 @@ class LibraryScreenModel(
         }
 
         return mapValues { (key, value) ->
-            when (key.sort.type) {
-                LibrarySort.Type.Random -> value.shuffled(Random(libraryPreferences.currentRandomSortSeed().get()))
-                else -> {
-                    val comparator = key.sort.comparator()
-                        .let { if (key.sort.isAscending) it else it.reversed() }
-                        .thenComparator(sortAlphabetically)
+           if (key.sort.type == LibrarySort.Type.Random) {
+               return@mapValues value.shuffled(Random(libraryPreferences.currentRandomSortSeed().get()))
+           }
 
-                    value.sortedWith(comparator)
-                }
-            }
+            val comparator = key.sort.comparator()
+                .let { if (key.sort.isAscending) it else it.reversed() }
+                .thenComparator(sortAlphabetically)
+
+            value.sortedWith(comparator)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -308,9 +308,9 @@ class LibraryScreenModel(
         }
 
         return mapValues { (key, value) ->
-           if (key.sort.type == LibrarySort.Type.Random) {
-               return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed().get()))
-           }
+            if (key.sort.type == LibrarySort.Type.Random) {
+                return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed().get()))
+            }
 
             val comparator = key.sort.comparator()
                 .let { if (key.sort.isAscending) it else it.reversed() }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -72,7 +72,6 @@ import tachiyomi.domain.track.model.Track
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.util.Collections
 import kotlin.random.Random
 
 /**

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/SetSortModeForCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/SetSortModeForCategory.kt
@@ -17,7 +17,7 @@ class SetSortModeForCategory(
         val category = categoryId?.let { categoryRepository.get(it) }
         val flags = (category?.flags ?: 0) + type + direction
         if (type == LibrarySort.Type.Random) {
-            preferences.currentRandomSortSeed().set(Random.nextInt())
+            preferences.randomSortSeed().set(Random.nextInt())
         }
         if (category != null && preferences.categorizedDisplaySettings().get()) {
             categoryRepository.updatePartial(

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/SetSortModeForCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/SetSortModeForCategory.kt
@@ -6,6 +6,7 @@ import tachiyomi.domain.category.repository.CategoryRepository
 import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.model.plus
 import tachiyomi.domain.library.service.LibraryPreferences
+import kotlin.random.Random
 
 class SetSortModeForCategory(
     private val preferences: LibraryPreferences,
@@ -15,6 +16,9 @@ class SetSortModeForCategory(
     suspend fun await(categoryId: Long?, type: LibrarySort.Type, direction: LibrarySort.Direction) {
         val category = categoryId?.let { categoryRepository.get(it) }
         val flags = (category?.flags ?: 0) + type + direction
+        if (type == LibrarySort.Type.Random) {
+            preferences.currentRandomSortSeed().set(Random.nextInt())
+        }
         if (category != null && preferences.categorizedDisplaySettings().get()) {
             categoryRepository.updatePartial(
                 CategoryUpdate(

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
@@ -31,6 +31,7 @@ data class LibrarySort(
         data object ChapterFetchDate : Type(0b00011000)
         data object DateAdded : Type(0b00011100)
         data object TrackerMean : Type(0b000100000)
+        data object Random : Type(0b000100100)
 
         companion object {
             fun valueOf(flag: Long): Type {
@@ -77,6 +78,7 @@ data class LibrarySort(
                 Type.ChapterFetchDate,
                 Type.DateAdded,
                 Type.TrackerMean,
+                Type.Random
             )
         }
         val directions by lazy { setOf(Direction.Ascending, Direction.Descending) }
@@ -104,6 +106,7 @@ data class LibrarySort(
                     "CHAPTER_FETCH_DATE" -> Type.ChapterFetchDate
                     "DATE_ADDED" -> Type.DateAdded
                     "TRACKER_MEAN" -> Type.TrackerMean
+                    "RANDOM" -> Type.Random
                     else -> Type.Alphabetical
                 }
                 val ascending = if (values[1] == "ASCENDING") Direction.Ascending else Direction.Descending
@@ -125,6 +128,7 @@ data class LibrarySort(
             Type.ChapterFetchDate -> "CHAPTER_FETCH_DATE"
             Type.DateAdded -> "DATE_ADDED"
             Type.TrackerMean -> "TRACKER_MEAN"
+            Type.Random -> "RANDOM"
         }
         val direction = if (direction == Direction.Ascending) "ASCENDING" else "DESCENDING"
         return "$type,$direction"

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
@@ -31,7 +31,7 @@ data class LibrarySort(
         data object ChapterFetchDate : Type(0b00011000)
         data object DateAdded : Type(0b00011100)
         data object TrackerMean : Type(0b00100000)
-        data object Random : Type(0b00100100)
+        data object Random : Type(0b00111100)
 
         companion object {
             fun valueOf(flag: Long): Type {

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
@@ -78,7 +78,7 @@ data class LibrarySort(
                 Type.ChapterFetchDate,
                 Type.DateAdded,
                 Type.TrackerMean,
-                Type.Random
+                Type.Random,
             )
         }
         val directions by lazy { setOf(Direction.Ascending, Direction.Descending) }

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibrarySortMode.kt
@@ -30,8 +30,8 @@ data class LibrarySort(
         data object LatestChapter : Type(0b00010100)
         data object ChapterFetchDate : Type(0b00011000)
         data object DateAdded : Type(0b00011100)
-        data object TrackerMean : Type(0b000100000)
-        data object Random : Type(0b000100100)
+        data object TrackerMean : Type(0b00100000)
+        data object Random : Type(0b00100100)
 
         companion object {
             fun valueOf(flag: Long): Type {

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -26,7 +26,7 @@ class LibraryPreferences(
         LibrarySort.Serializer::deserialize,
     )
 
-    fun currentRandomSortSeed() = preferenceStore.getInt("library_random_sort_seed", 0)
+    fun randomSortSeed() = preferenceStore.getInt("library_random_sort_seed", 0)
 
     fun portraitColumns() = preferenceStore.getInt("pref_library_columns_portrait_key", 0)
 

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -26,6 +26,8 @@ class LibraryPreferences(
         LibrarySort.Serializer::deserialize,
     )
 
+    fun currentRandomSortSeed() = preferenceStore.getInt("library_random_sort_seed", 0)
+
     fun portraitColumns() = preferenceStore.getInt("pref_library_columns_portrait_key", 0)
 
     fun landscapeColumns() = preferenceStore.getInt("pref_library_columns_landscape_key", 0)

--- a/domain/src/test/java/tachiyomi/domain/library/model/LibraryFlagsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/library/model/LibraryFlagsTest.kt
@@ -12,7 +12,7 @@ class LibraryFlagsTest {
     @Test
     fun `Check the amount of flags`() {
         LibraryDisplayMode.values.size shouldBe 4
-        LibrarySort.types.size shouldBe 9
+        LibrarySort.types.size shouldBe 10
         LibrarySort.directions.size shouldBe 2
     }
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -69,6 +69,7 @@
     <string name="action_sort_chapter_fetch_date">Chapter fetch date</string>
     <string name="action_sort_date_added">Date added</string>
     <string name="action_sort_tracker_score">Tracker score</string>
+    <string name="action_sort_random">Random</string>
     <string name="action_search">Search</string>
     <string name="action_search_hint">Search…</string>
     <string name="action_search_settings">Search settings</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -99,30 +99,15 @@ fun SortItem(label: String, sortDescending: Boolean?, onClick: () -> Unit) {
         null -> null
     }
 
-    BaseSettingsItem(
+    BaseSortItem(
         label = label,
-        widget = {
-            if (arrowIcon != null) {
-                Icon(
-                    imageVector = arrowIcon,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-            } else {
-                Spacer(modifier = Modifier.size(24.dp))
-            }
-        },
+        icon = arrowIcon,
         onClick = onClick,
     )
 }
 
 @Composable
-fun NondirectionalSortItem(label: String, enabled: Boolean, enabledIcon: ImageVector, onClick: () -> Unit) {
-    val icon = when(enabled) {
-        true -> enabledIcon
-        false -> null
-    }
-
+fun BaseSortItem(label: String, icon: ImageVector?, onClick: () -> Unit) {
     BaseSettingsItem(
         label = label,
         widget = {

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.rounded.CheckBox
 import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
 import androidx.compose.material.icons.rounded.DisabledByDefault

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.rounded.CheckBox
 import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
 import androidx.compose.material.icons.rounded.DisabledByDefault
@@ -104,6 +105,30 @@ fun SortItem(label: String, sortDescending: Boolean?, onClick: () -> Unit) {
             if (arrowIcon != null) {
                 Icon(
                     imageVector = arrowIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            } else {
+                Spacer(modifier = Modifier.size(24.dp))
+            }
+        },
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun NondirectionalSortItem(label: String, enabled: Boolean, enabledIcon: ImageVector, onClick: () -> Unit) {
+    val icon = when(enabled) {
+        true -> enabledIcon
+        false -> null
+    }
+
+    BaseSettingsItem(
+        label = label,
+        widget = {
+            if (icon != null) {
+                Icon(
+                    imageVector = icon,
                     contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
                 )


### PR DESCRIPTION
Replacing https://github.com/mihonapp/mihon/pull/1315 because I was using my main branch like a goon

Problem:
If you have a large bulk from a source that uses something that interferes with alphabetical tagging - e.g. a comic source that leads its releases with the year ([2019], ex), the sort options will group every title like that together when, personally, I've found I sometimes want to view my library in a way that scatters them more evenly. Sometimes I don't want to view my stuff chronologically.
Also I just like random sort.

Behavior:
Using a single random seed for all categories. The seed for all categories using random sort will change any time a section switches to random or taps on the randomization again. I believe this should line up with expected behavior and that users don't expect a distinctly saved random ordering for each tab, but I'm open to discussion there.

### Images
| Selected | Unselected |
| ------- | ------- |
| ![](https://github.com/user-attachments/assets/d91a25e4-6e9e-437d-ba08-b2f2cfd5c838) | ![](https://github.com/user-attachments/assets/88b3e436-0810-4b97-a0b6-0fab9f2025f5) |