### PR TITLE
Confirmation dialog when removing privately installed extensions

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.browse
 
-import android.content.Context
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -56,7 +55,6 @@ import eu.kanade.tachiyomi.extension.model.InstallStep
 import eu.kanade.tachiyomi.ui.browse.extension.ExtensionUiModel
 import eu.kanade.tachiyomi.ui.browse.extension.ExtensionsScreenModel
 import eu.kanade.tachiyomi.util.system.LocaleHelper
-import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import eu.kanade.tachiyomi.util.system.launchRequestPackageInstallsPermission
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
@@ -250,7 +248,6 @@ private fun ExtensionContent(
                             }
                         }
                     },
-                    context = context,
                 )
             }
         }
@@ -281,43 +278,16 @@ private fun ExtensionItem(
     onClickItemAction: (Extension) -> Unit,
     onClickItemSecondaryAction: (Extension) -> Unit,
     modifier: Modifier = Modifier,
-    context: Context,
 ) {
     val (extension, installStep) = item
-    var showUninstallConfirmation by remember { mutableStateOf(false) }
-
-    val internalOnLongClickItem: () -> Unit = {
-        if (context.isPackageInstalled(extension.pkgName)) {
-            onLongClickItem(extension)
-        } else {
-            showUninstallConfirmation = true
-        }
-    }
-
-    if (showUninstallConfirmation) {
-        ExtensionUninstallConfirmation(
-            extensionName = extension.name,
-            onClickConfirm = {
-                onLongClickItem(extension)
-                showUninstallConfirmation = false
-            },
-            onClickDismiss = {
-                showUninstallConfirmation = false
-            },
-            onDismissRequest = {
-                showUninstallConfirmation = false
-            },
-        )
-    }
-
     BaseBrowseItem(
         modifier = modifier
             .combinedClickable(
                 onClick = { onClickItem(extension) },
-                onLongClick = internalOnLongClickItem,
+                onLongClick = { onLongClickItem(extension) },
             ),
         onClickItem = { onClickItem(extension) },
-        onLongClickItem = internalOnLongClickItem,
+        onLongClickItem = { onLongClickItem(extension) },
         icon = {
             Box(
                 modifier = Modifier
@@ -565,34 +535,6 @@ private fun ExtensionTrustDialog(
         dismissButton = {
             TextButton(onClick = onClickDismiss) {
                 Text(text = stringResource(MR.strings.ext_uninstall))
-            }
-        },
-        onDismissRequest = onDismissRequest,
-    )
-}
-
-@Composable
-private fun ExtensionUninstallConfirmation(
-    extensionName: String,
-    onClickConfirm: () -> Unit,
-    onClickDismiss: () -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    AlertDialog(
-        title = {
-            Text(text = stringResource(MR.strings.ext_confirm_remove))
-        },
-        text = {
-            Text(text = stringResource(MR.strings.remove_private_extension_message, extensionName))
-        },
-        confirmButton = {
-            TextButton(onClick = onClickConfirm) {
-                Text(text = stringResource(MR.strings.ext_remove))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onClickDismiss) {
-                Text(text = stringResource(MR.strings.action_cancel))
             }
         },
         onDismissRequest = onDismissRequest,

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
@@ -286,6 +286,14 @@ private fun ExtensionItem(
     val (extension, installStep) = item
     var showUninstallConfirmation by remember { mutableStateOf(false) }
 
+    val internalOnLongClickItem: () -> Unit = {
+        if (context.isPackageInstalled(extension.pkgName)) {
+            onLongClickItem(extension)
+        } else {
+            showUninstallConfirmation = true
+        }
+    }
+
     if (showUninstallConfirmation) {
         ExtensionUninstallConfirmation(
             extensionName = extension.name,
@@ -306,22 +314,10 @@ private fun ExtensionItem(
         modifier = modifier
             .combinedClickable(
                 onClick = { onClickItem(extension) },
-                onLongClick = {
-                    if (context.isPackageInstalled(extension.pkgName)) {
-                        onLongClickItem(extension)
-                    } else {
-                        showUninstallConfirmation = true
-                    }
-                },
+                onLongClick = internalOnLongClickItem,
             ),
         onClickItem = { onClickItem(extension) },
-        onLongClickItem = {
-            if (context.isPackageInstalled(extension.pkgName)) {
-                onLongClickItem(extension)
-            } else {
-                showUninstallConfirmation = true
-            }
-        },
+        onLongClickItem = internalOnLongClickItem,
         icon = {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
@@ -88,9 +88,9 @@ fun extensionsTab(
 
             privateExtensionToUninstall?.let { extension ->
                 ExtensionUninstallConfirmation(
-                    extensionName = privateExtensionToUninstall!!.name,
+                    extensionName = extension.name,
                     onClickConfirm = {
-                        extensionsScreenModel.uninstallExtension(privateExtensionToUninstall!!)
+                        extensionsScreenModel.uninstallExtension(extension)
                     },
                     onDismissRequest = {
                         privateExtensionToUninstall = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -31,7 +32,7 @@ fun extensionsTab(
     val context = LocalContext.current
 
     val state by extensionsScreenModel.state.collectAsState()
-    val privateExtensionToUninstall = remember { mutableStateOf<Extension?>(null) }
+    var privateExtensionToUninstall by remember { mutableStateOf<Extension?>(null) }
 
     return TabContent(
         titleRes = MR.strings.label_extensions,
@@ -59,7 +60,7 @@ fun extensionsTab(
                             if (context.isPackageInstalled(extension.pkgName)) {
                                 extensionsScreenModel.uninstallExtension(extension)
                             } else {
-                                privateExtensionToUninstall.value = extension
+                                privateExtensionToUninstall = extension
                             }
                         }
                     }
@@ -85,14 +86,14 @@ fun extensionsTab(
                 onRefresh = extensionsScreenModel::findAvailableExtensions,
             )
 
-            privateExtensionToUninstall.value?.let { extension ->
+            privateExtensionToUninstall?.let { extension ->
                 ExtensionUninstallConfirmation(
-                    extensionName = privateExtensionToUninstall.value!!.name,
+                    extensionName = privateExtensionToUninstall!!.name,
                     onClickConfirm = {
-                        extensionsScreenModel.uninstallExtension(privateExtensionToUninstall.value!!)
+                        extensionsScreenModel.uninstallExtension(privateExtensionToUninstall!!)
                     },
                     onDismissRequest = {
-                        privateExtensionToUninstall.value = null
+                        privateExtensionToUninstall = null
                     },
                 )
             }
@@ -118,7 +119,7 @@ private fun ExtensionUninstallConfirmation(
                 onClick = {
                     onClickConfirm()
                     onDismissRequest()
-                }
+                },
             ) {
                 Text(text = stringResource(MR.strings.ext_remove))
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
@@ -1,8 +1,14 @@
 package eu.kanade.tachiyomi.ui.browse.extension
 
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.ExtensionScreen
@@ -12,6 +18,7 @@ import eu.kanade.presentation.more.settings.screen.browse.ExtensionReposScreen
 import eu.kanade.tachiyomi.extension.model.Extension
 import eu.kanade.tachiyomi.ui.browse.extension.details.ExtensionDetailsScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
+import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -22,6 +29,8 @@ fun extensionsTab(
 ): TabContent {
     val navigator = LocalNavigator.currentOrThrow
     val state by extensionsScreenModel.state.collectAsState()
+    val context = LocalContext.current
+    val showUninstallConfirmation = remember { mutableStateOf<Extension?>(null) }
 
     return TabContent(
         titleRes = MR.strings.label_extensions,
@@ -45,7 +54,13 @@ fun extensionsTab(
                 onLongClickItem = { extension ->
                     when (extension) {
                         is Extension.Available -> extensionsScreenModel.installExtension(extension)
-                        else -> extensionsScreenModel.uninstallExtension(extension)
+                        else -> {
+                            if (context.isPackageInstalled(extension.pkgName)) {
+                                extensionsScreenModel.uninstallExtension(extension)
+                            } else {
+                                showUninstallConfirmation.value = extension
+                            }
+                        }
                     }
                 },
                 onClickItemCancel = extensionsScreenModel::cancelInstallUpdateExtension,
@@ -68,6 +83,50 @@ fun extensionsTab(
                 onUpdateExtension = extensionsScreenModel::updateExtension,
                 onRefresh = extensionsScreenModel::findAvailableExtensions,
             )
+
+            if (showUninstallConfirmation.value != null) {
+                ExtensionUninstallConfirmation(
+                    extensionName = showUninstallConfirmation.value!!.name,
+                    onClickConfirm = {
+                        extensionsScreenModel.uninstallExtension(showUninstallConfirmation.value!!)
+                        showUninstallConfirmation.value = null
+                    },
+                    onClickDismiss = {
+                        showUninstallConfirmation.value = null
+                    },
+                    onDismissRequest = {
+                        showUninstallConfirmation.value = null
+                    },
+                )
+            }
         },
+    )
+}
+
+@Composable
+private fun ExtensionUninstallConfirmation(
+    extensionName: String,
+    onClickConfirm: () -> Unit,
+    onClickDismiss: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        title = {
+            Text(text = stringResource(MR.strings.ext_confirm_remove))
+        },
+        text = {
+            Text(text = stringResource(MR.strings.remove_private_extension_message, extensionName))
+        },
+        confirmButton = {
+            TextButton(onClick = onClickConfirm) {
+                Text(text = stringResource(MR.strings.ext_remove))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onClickDismiss) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        onDismissRequest = onDismissRequest,
     )
 }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -331,7 +331,7 @@
     <string name="untrusted_extension">Untrusted extension</string>
     <string name="untrusted_extension_message">Malicious extensions can read any stored login credentials or execute arbitrary code.\n\nBy trusting this extension, you accept these risks.</string>
     <string name="obsolete_extension_message">This extension is no longer available. It may not function properly and can cause issues with the app. Uninstalling it is recommended.</string>
-    <string name="remove_private_extension_message">Do you really want to remove the \"%s\" extension?</string>
+    <string name="remove_private_extension_message">Do you really want to remove \"%s\" extension?</string>
     <string name="extension_api_error">Failed to fetch available extensions</string>
     <string name="ext_info_version">Version</string>
     <string name="ext_info_language">Language</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -325,10 +325,13 @@
     <string name="ext_trust">Trust</string>
     <string name="ext_untrusted">Untrusted</string>
     <string name="ext_uninstall">Uninstall</string>
+    <string name="ext_remove">Remove</string>
+    <string name="ext_confirm_remove">Remove Extension?</string>
     <string name="ext_app_info">App info</string>
     <string name="untrusted_extension">Untrusted extension</string>
     <string name="untrusted_extension_message">Malicious extensions can read any stored login credentials or execute arbitrary code.\n\nBy trusting this extension, you accept these risks.</string>
     <string name="obsolete_extension_message">This extension is no longer available. It may not function properly and can cause issues with the app. Uninstalling it is recommended.</string>
+    <string name="remove_private_extension_message">Do you really want to remove the \"%s\" extension?</string>
     <string name="extension_api_error">Failed to fetch available extensions</string>
     <string name="ext_info_version">Version</string>
     <string name="ext_info_language">Language</string>


### PR DESCRIPTION
Adds a confirmation dialog on long tap of an extension installed with the Private Installer as it lacks a system confirmation.

https://git.mihon.tech/tachiyomi/tachiyomi/issues/9864

![image](https://github.com/user-attachments/assets/751a7ef5-e4d3-40c2-9f44-99ecb785bdc9)
