### PR TITLE
Fix off by one error in SliderItem

### DIFF
--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -202,7 +202,7 @@ fun SliderItem(
             },
             modifier = Modifier.weight(1.5f),
             valueRange = min.toFloat()..max.toFloat(),
-            steps = max - min,
+            steps = max - min-1,
         )
     }
 }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -202,7 +202,7 @@ fun SliderItem(
             },
             modifier = Modifier.weight(1.5f),
             valueRange = min.toFloat()..max.toFloat(),
-            steps = max - min-1,
+            steps = max - min - 1,
         )
     }
 }


### PR DESCRIPTION
Small error with how sliders are implemented that i noticed when trying to implement other changes. steps should be 1 less than the amount of steps you want if you are defining min and max, because steps takes in the amount of inner steps excluding the lowest and highest. as it is now if the slider passes the middle step, its starts skipping by 2 whenever decrementing.


(added a dummy slider so its easier to see, not in the code pushed)
example of slider now
https://github.com/user-attachments/assets/8d4231c0-411b-427f-a134-7a24278c1d8a


example of slider fixed

(https://github.com/user-attachments/assets/6e1a5ca8-c063-4c3e-b187-0f9972c77bb9)
