### PR TITLE
update all trackers progress when new tracker is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
 - Extension repo URLs are now auto-formatted ([@AntsyLich](https://github.com/AntsyLich), [@MajorTanya](https://github.com/MajorTanya))
-- Update all trackers' progress when adding a new tracker ([@cuong-tran](https://github.com/cuong-tran))
+- Update all trackers' progress when adding a new tracker ([@cuong-tran](https://github.com/cuong-tran)) ([#1372](https://github.com/mihonapp/mihon/pull/1372))
 
 ## [v0.17.0] - 2024-10-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
 - Extension repo URLs are now auto-formatted ([@AntsyLich](https://github.com/AntsyLich), [@MajorTanya](https://github.com/MajorTanya))
-- Update all trackers' progress when adding a new tracker ([@cuong-tran](https://github.com/cuong-tran)) ([#1372](https://github.com/mihonapp/mihon/pull/1372))
 
 ## [v0.17.0] - 2024-10-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
 - Extension repo URLs are now auto-formatted ([@AntsyLich](https://github.com/AntsyLich), [@MajorTanya](https://github.com/MajorTanya))
+- Update all trackers' progress when adding a new tracker ([@cuong-tran](https://github.com/cuong-tran))
 
 ## [v0.17.0] - 2024-10-26
 ### Added

--- a/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
@@ -27,6 +27,7 @@ import java.time.ZoneOffset
 
 class AddTracks(
     private val insertTrack: InsertTrack,
+    private val refreshTracks: RefreshTracks,
     private val getChaptersByMangaId: GetChaptersByMangaId,
     private val trackerManager: TrackerManager,
 ) {
@@ -76,9 +77,7 @@ class AddTracks(
                 }
             }
 
-            val refreshTracks = Injekt.get<RefreshTracks>()
             val context = Injekt.get<Application>()
-
             refreshTracks.await(mangaId)
                 .filter { it.first != null }
                 .forEach { (track, e) ->
@@ -118,9 +117,7 @@ class AddTracks(
                     }
                 }
 
-            val refreshTracks = Injekt.get<RefreshTracks>()
             val context = Injekt.get<Application>()
-
             refreshTracks.await(manga.id)
                 .filter { it.first != null }
                 .forEach { (track, e) ->


### PR DESCRIPTION
Whenever a new tracker is add, it will try to sync all trackers together with local reading progress