### PR TITLE
add missing material lib to presentation-widget

### DIFF
--- a/presentation-widget/build.gradle.kts
+++ b/presentation-widget/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
     implementation(libs.coil.core)
 
     api(libs.injekt)
+    implementation(libs.material)
 }

--- a/presentation-widget/build.gradle.kts
+++ b/presentation-widget/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(projects.i18n)
 
     implementation(compose.glance)
+    implementation(libs.material)
 
     implementation(kotlinx.immutables)
 
@@ -27,5 +28,4 @@ dependencies {
     implementation(libs.coil.core)
 
     api(libs.injekt)
-    implementation(libs.material)
 }


### PR DESCRIPTION
Not sure which changes caused this but recently my Android Studio always got this error:
`ERROR: AAPT: tachiyomi.presentation.widget.test.presentation-widget-mergeDebugAndroidTestResources-70:/values-v31/values-v31.xml:3: error: resource color/m3_sys_color_dynamic_light_surface (aka tachiyomi.presentation.widget.test:color/m3_sys_color_dynamic_light_surface) not found.`

Although CI build still works fine on Github Action.