### PR TITLE
Error screen

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -37,6 +37,9 @@ import mihon.domain.upcoming.interactor.GetUpcomingManga
 import tachiyomi.data.category.CategoryRepositoryImpl
 import tachiyomi.data.chapter.ChapterRepositoryImpl
 import tachiyomi.data.history.HistoryRepositoryImpl
+import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorRepositoryImpl
+import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorWithRelationsRepositoryImpl
+import tachiyomi.data.libraryUpdateErrorMessage.LibraryUpdateErrorMessageRepositoryImpl
 import tachiyomi.data.manga.MangaRepositoryImpl
 import tachiyomi.data.release.ReleaseServiceImpl
 import tachiyomi.data.source.SourceRepositoryImpl
@@ -67,6 +70,16 @@ import tachiyomi.domain.history.interactor.GetTotalReadDuration
 import tachiyomi.domain.history.interactor.RemoveHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.repository.HistoryRepository
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorWithRelationsRepository
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.DeleteLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.InsertLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
 import tachiyomi.domain.manga.interactor.FetchInterval
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFavorites
@@ -191,5 +204,20 @@ class DomainModule : InjektModule {
         addFactory { DeleteExtensionRepo(get()) }
         addFactory { ReplaceExtensionRepo(get()) }
         addFactory { UpdateExtensionRepo(get(), get()) }
+
+        addSingletonFactory<LibraryUpdateErrorWithRelationsRepository> {
+            LibraryUpdateErrorWithRelationsRepositoryImpl(get())
+        }
+        addFactory { GetLibraryUpdateErrorWithRelations(get()) }
+
+        addSingletonFactory<LibraryUpdateErrorMessageRepository> { LibraryUpdateErrorMessageRepositoryImpl(get()) }
+        addFactory { GetLibraryUpdateErrorMessages(get()) }
+        addFactory { DeleteLibraryUpdateErrorMessages(get()) }
+        addFactory { InsertLibraryUpdateErrorMessages(get()) }
+
+        addSingletonFactory<LibraryUpdateErrorRepository> { LibraryUpdateErrorRepositoryImpl(get()) }
+        addFactory { GetLibraryUpdateErrors(get()) }
+        addFactory { DeleteLibraryUpdateErrors(get()) }
+        addFactory { InsertLibraryUpdateErrors(get()) }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -130,17 +130,18 @@ fun LibraryUpdateErrorScreen(
                 },
             )
         },
-    ) { paddingValues ->
+    ) { contentPadding ->
         when {
-            state.isLoading -> LoadingScreen(modifier = Modifier.padding(paddingValues))
+            state.isLoading -> LoadingScreen(modifier = Modifier.padding(contentPadding))
             state.items.isEmpty() -> EmptyScreen(
                 message = stringResource(MR.strings.info_empty_library_update_errors),
-                modifier = Modifier.padding(paddingValues),
+                modifier = Modifier.padding(contentPadding),
             )
 
             else -> {
                 FastScrollLazyColumn(
-                    contentPadding = paddingValues,
+                    // Using modifier instead of contentPadding so we can use stickyHeader
+                    modifier = Modifier.padding(contentPadding),
                     state = listState,
                 ) {
                     libraryUpdateErrorUiItems(

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -1,0 +1,240 @@
+package eu.kanade.presentation.libraryUpdateError
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FindReplace
+import androidx.compose.material.icons.outlined.FlipToBack
+import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.libraryUpdateError.components.libraryUpdateErrorUiItems
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreenState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.FastScrollLazyColumn
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+fun LibraryUpdateErrorScreen(
+    state: LibraryUpdateErrorScreenState,
+    modifier: Modifier = Modifier,
+    onClick: (LibraryUpdateErrorItem) -> Unit,
+    onClickCover: (LibraryUpdateErrorItem) -> Unit,
+    onMultiMigrateClicked: (() -> Unit),
+    onSelectAll: (Boolean) -> Unit,
+    onInvertSelection: () -> Unit,
+    onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
+    navigateUp: () -> Unit,
+) {
+    BackHandler(enabled = state.selectionMode, onBack = { onSelectAll(false) })
+
+    Scaffold(
+        topBar = { scrollBehavior ->
+            LibraryUpdateErrorsAppBar(
+                title = stringResource(
+                    MR.strings.label_library_update_errors,
+                    state.items.size,
+                ),
+                actionModeCounter = state.selected.size,
+                onSelectAll = { onSelectAll(true) },
+                onInvertSelection = onInvertSelection,
+                onCancelActionMode = { onSelectAll(false) },
+                scrollBehavior = scrollBehavior,
+                navigateUp = navigateUp,
+            )
+        },
+        bottomBar = {
+            AnimatedVisibility(
+                visible = state.selected.isNotEmpty(),
+                enter = expandVertically(expandFrom = Alignment.Bottom),
+                exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
+            ) {
+                val scope = rememberCoroutineScope()
+                Surface(
+                    modifier = modifier,
+                    shape = MaterialTheme.shapes.large.copy(
+                        bottomEnd = ZeroCornerSize,
+                        bottomStart = ZeroCornerSize,
+                    ),
+                    tonalElevation = 3.dp,
+                ) {
+                    val haptic = LocalHapticFeedback.current
+                    val confirm = remember { mutableStateListOf(false) }
+                    var resetJob: Job? = remember { null }
+                    val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        (0 until 1).forEach { i -> confirm[i] = i == toConfirmIndex }
+                        resetJob?.cancel()
+                        resetJob = scope.launch {
+                            delay(1.seconds)
+                            if (isActive) confirm[toConfirmIndex] = false
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .padding(
+                                WindowInsets.navigationBars
+                                    .only(WindowInsetsSides.Bottom)
+                                    .asPaddingValues(),
+                            )
+                            .padding(horizontal = 8.dp, vertical = 12.dp),
+                    ) {
+                        Button(
+                            title = stringResource(MR.strings.migrate),
+                            icon = Icons.Outlined.FindReplace,
+                            toConfirm = confirm[0],
+                            onLongClick = { onLongClickItem(0) },
+                            onClick = onMultiMigrateClicked,
+                        )
+                    }
+                }
+            }
+        },
+    ) { paddingValues ->
+        when {
+            state.isLoading -> LoadingScreen(modifier = Modifier.padding(paddingValues))
+            state.items.isEmpty() -> EmptyScreen(
+                message = stringResource(MR.strings.info_empty_library_update_errors),
+                modifier = Modifier.padding(paddingValues),
+            )
+
+            else -> {
+                FastScrollLazyColumn(
+                    contentPadding = paddingValues,
+                ) {
+                    libraryUpdateErrorUiItems(
+                        uiModels = state.getUiModel(),
+                        selectionMode = state.selectionMode,
+                        onErrorSelected = onErrorSelected,
+                        onClick = onClick,
+                        onClickCover = onClickCover,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.Button(
+    title: String,
+    icon: ImageVector,
+    toConfirm: Boolean,
+    onLongClick: () -> Unit,
+    onClick: (() -> Unit),
+    content: (@Composable () -> Unit)? = null,
+) {
+    val animatedWeight by animateFloatAsState(if (toConfirm) 2f else 1f)
+    Column(
+        modifier = Modifier
+            .size(48.dp)
+            .weight(animatedWeight)
+            .combinedClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(bounded = false),
+                onLongClick = onLongClick,
+                onClick = onClick,
+            ),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = title,
+        )
+        AnimatedVisibility(
+            visible = toConfirm,
+            enter = expandVertically(expandFrom = Alignment.Top) + fadeIn(),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut(),
+        ) {
+            Text(
+                text = title,
+                overflow = TextOverflow.Visible,
+                maxLines = 1,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        content?.invoke()
+    }
+}
+
+@Composable
+private fun LibraryUpdateErrorsAppBar(
+    modifier: Modifier = Modifier,
+    title: String,
+    actionModeCounter: Int,
+    onSelectAll: () -> Unit,
+    onInvertSelection: () -> Unit,
+    onCancelActionMode: () -> Unit,
+    scrollBehavior: TopAppBarScrollBehavior,
+    navigateUp: () -> Unit,
+) {
+    AppBar(
+        modifier = modifier,
+        title = title,
+        scrollBehavior = scrollBehavior,
+        actionModeCounter = actionModeCounter,
+        onCancelActionMode = onCancelActionMode,
+        actionModeActions = {
+            IconButton(onClick = onSelectAll) {
+                Icon(
+                    imageVector = Icons.Outlined.SelectAll,
+                    contentDescription = stringResource(MR.strings.action_select_all),
+                )
+            }
+            IconButton(onClick = onInvertSelection) {
+                Icon(
+                    imageVector = Icons.Outlined.FlipToBack,
+                    contentDescription = stringResource(MR.strings.action_select_inverse),
+                )
+            }
+        },
+        navigateUp = navigateUp,
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -2,6 +2,8 @@ package eu.kanade.presentation.libraryUpdateError
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -20,19 +22,27 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ripple
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -44,8 +54,9 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.libraryUpdateError.components.libraryUpdateErrorUiItems
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreenState
 import kotlinx.coroutines.Job
@@ -72,6 +83,21 @@ fun LibraryUpdateErrorScreen(
     onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    val enableScrollToTop by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex > 0
+        }
+    }
+
+    val enableScrollToBottom by remember {
+        derivedStateOf {
+            listState.canScrollForward
+        }
+    }
+
     BackHandler(enabled = state.selectionMode, onBack = { onSelectAll(false) })
 
     Scaffold(
@@ -82,59 +108,32 @@ fun LibraryUpdateErrorScreen(
                     state.items.size,
                 ),
                 actionModeCounter = state.selected.size,
-                onSelectAll = { onSelectAll(true) },
-                onInvertSelection = onInvertSelection,
-                onCancelActionMode = { onSelectAll(false) },
                 scrollBehavior = scrollBehavior,
-                navigateUp = navigateUp,
             )
         },
         bottomBar = {
-            AnimatedVisibility(
-                visible = state.selected.isNotEmpty(),
-                enter = expandVertically(expandFrom = Alignment.Bottom),
-                exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
-            ) {
-                val scope = rememberCoroutineScope()
-                Surface(
-                    modifier = modifier,
-                    shape = MaterialTheme.shapes.large.copy(
-                        bottomEnd = ZeroCornerSize,
-                        bottomStart = ZeroCornerSize,
-                    ),
-                    tonalElevation = 3.dp,
-                ) {
-                    val haptic = LocalHapticFeedback.current
-                    val confirm = remember { mutableStateListOf(false) }
-                    var resetJob: Job? = remember { null }
-                    val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        (0 until 1).forEach { i -> confirm[i] = i == toConfirmIndex }
-                        resetJob?.cancel()
-                        resetJob = scope.launch {
-                            delay(1.seconds)
-                            if (isActive) confirm[toConfirmIndex] = false
-                        }
+            LibraryUpdateErrorsBottomBar(
+                modifier = modifier,
+                selected = state.selected,
+                itemCount = state.items.size,
+                enableScrollToTop = enableScrollToTop,
+                enableScrollToBottom = enableScrollToBottom,
+                onMultiMigrateClicked = onMultiMigrateClicked,
+                onSelectAll = { onSelectAll(true) },
+                onInvertSelection = onInvertSelection,
+                onCancelActionMode = { onSelectAll(false) },
+                navigateUp = navigateUp,
+                scrollToTop = {
+                    scope.launch {
+                        listState.scrollToItem(0)
                     }
-                    Row(
-                        modifier = Modifier
-                            .padding(
-                                WindowInsets.navigationBars
-                                    .only(WindowInsetsSides.Bottom)
-                                    .asPaddingValues(),
-                            )
-                            .padding(horizontal = 8.dp, vertical = 12.dp),
-                    ) {
-                        Button(
-                            title = stringResource(MR.strings.migrate),
-                            icon = Icons.Outlined.FindReplace,
-                            toConfirm = confirm[0],
-                            onLongClick = { onLongClickItem(0) },
-                            onClick = onMultiMigrateClicked,
-                        )
+                },
+                scrollToBottom = {
+                    scope.launch {
+                        listState.scrollToItem(state.items.size - 1)
                     }
-                }
-            }
+                },
+            )
         },
     ) { paddingValues ->
         when {
@@ -147,6 +146,7 @@ fun LibraryUpdateErrorScreen(
             else -> {
                 FastScrollLazyColumn(
                     contentPadding = paddingValues,
+                    state = listState,
                 ) {
                     libraryUpdateErrorUiItems(
                         uiModels = state.getUiModel(),
@@ -162,15 +162,156 @@ fun LibraryUpdateErrorScreen(
 }
 
 @Composable
+private fun LibraryUpdateErrorsBottomBar(
+    modifier: Modifier = Modifier,
+    selected: List<LibraryUpdateErrorItem>,
+    itemCount: Int,
+    enableScrollToTop: Boolean,
+    enableScrollToBottom: Boolean,
+    onMultiMigrateClicked: (() -> Unit),
+    onSelectAll: () -> Unit,
+    onInvertSelection: () -> Unit,
+    onCancelActionMode: () -> Unit,
+    navigateUp: () -> Unit,
+    scrollToTop: () -> Unit,
+    scrollToBottom: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val animatedElevation by animateDpAsState(if (selected.isNotEmpty()) 3.dp else 0.dp)
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large.copy(
+            bottomEnd = ZeroCornerSize,
+            bottomStart = ZeroCornerSize,
+        ),
+        color = MaterialTheme.colorScheme.surfaceColorAtElevation(
+            elevation = animatedElevation,
+        ),
+    ) {
+        val haptic = LocalHapticFeedback.current
+        val confirm = remember { mutableStateListOf(false, false, false, false, false, false) }
+        var resetJob: Job? = remember { null }
+        val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            (0 until 6).forEach { i -> confirm[i] = i == toConfirmIndex }
+            resetJob?.cancel()
+            resetJob = scope.launch {
+                delay(1.seconds)
+                if (isActive) confirm[toConfirmIndex] = false
+            }
+        }
+        Row(
+            modifier = Modifier
+                .padding(
+                    WindowInsets.navigationBars
+                        .only(WindowInsetsSides.Bottom)
+                        .asPaddingValues(),
+                )
+                .padding(horizontal = 8.dp, vertical = 12.dp),
+        ) {
+            if (selected.isNotEmpty()) {
+                Button(
+                    title = stringResource(MR.strings.action_cancel),
+                    icon = Icons.Outlined.Close,
+                    toConfirm = confirm[0],
+                    onLongClick = { onLongClickItem(0) },
+                    onClick = onCancelActionMode,
+                    enabled = true,
+                )
+            } else {
+                Button(
+                    title = androidx.compose.ui.res.stringResource(R.string.abc_action_bar_up_description),
+                    icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                    toConfirm = confirm[0],
+                    onLongClick = { onLongClickItem(0) },
+                    onClick = navigateUp,
+                    enabled = true,
+                )
+            }
+            Button(
+                title = stringResource(MR.strings.action_select_all),
+                icon = Icons.Outlined.SelectAll,
+                toConfirm = confirm[1],
+                onLongClick = { onLongClickItem(1) },
+                onClick = if (selected.isEmpty() or (selected.size != itemCount)) {
+                    onSelectAll
+                } else {
+                    {}
+                },
+                enabled = selected.isEmpty() or (selected.size != itemCount),
+            )
+            Button(
+                title = stringResource(MR.strings.action_select_inverse),
+                icon = Icons.Outlined.FlipToBack,
+                toConfirm = confirm[2],
+                onLongClick = { onLongClickItem(2) },
+                onClick = if (selected.isNotEmpty()) {
+                    onInvertSelection
+                } else {
+                    {}
+                },
+                enabled = selected.isNotEmpty(),
+            )
+            Button(
+                title = stringResource(MR.strings.action_scroll_to_top),
+                icon = Icons.Outlined.ArrowUpward,
+                toConfirm = confirm[3],
+                onLongClick = { onLongClickItem(3) },
+                onClick = if (enableScrollToTop) {
+                    scrollToTop
+                } else {
+                    {}
+                },
+                enabled = enableScrollToTop,
+            )
+            Button(
+                title = stringResource(MR.strings.action_scroll_to_bottom),
+                icon = Icons.Outlined.ArrowDownward,
+                toConfirm = confirm[4],
+                onLongClick = { onLongClickItem(4) },
+                onClick = if (enableScrollToBottom) {
+                    scrollToBottom
+                } else {
+                    {}
+                },
+                enabled = enableScrollToBottom,
+            )
+            Button(
+                title = stringResource(MR.strings.migrate),
+                icon = Icons.Outlined.FindReplace,
+                toConfirm = confirm[5],
+                onLongClick = { onLongClickItem(5) },
+                onClick = if (selected.isNotEmpty()) {
+                    onMultiMigrateClicked
+                } else {
+                    {}
+                },
+                enabled = selected.isNotEmpty(),
+            )
+        }
+    }
+}
+
+@Composable
 private fun RowScope.Button(
     title: String,
     icon: ImageVector,
     toConfirm: Boolean,
+    enabled: Boolean,
     onLongClick: () -> Unit,
     onClick: (() -> Unit),
     content: (@Composable () -> Unit)? = null,
 ) {
     val animatedWeight by animateFloatAsState(if (toConfirm) 2f else 1f)
+    val animatedColor by animateColorAsState(
+        if (enabled) {
+            MaterialTheme.colorScheme.onSurface
+        } else {
+            MaterialTheme.colorScheme.onSurface.copy(
+                alpha = 0.38f,
+            )
+        },
+    )
     Column(
         modifier = Modifier
             .size(48.dp)
@@ -187,6 +328,7 @@ private fun RowScope.Button(
         Icon(
             imageVector = icon,
             contentDescription = title,
+            tint = animatedColor,
         )
         AnimatedVisibility(
             visible = toConfirm,
@@ -198,6 +340,7 @@ private fun RowScope.Button(
                 overflow = TextOverflow.Visible,
                 maxLines = 1,
                 style = MaterialTheme.typography.labelSmall,
+                color = animatedColor,
             )
         }
         content?.invoke()
@@ -209,32 +352,30 @@ private fun LibraryUpdateErrorsAppBar(
     modifier: Modifier = Modifier,
     title: String,
     actionModeCounter: Int,
-    onSelectAll: () -> Unit,
-    onInvertSelection: () -> Unit,
-    onCancelActionMode: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
-    navigateUp: () -> Unit,
 ) {
-    AppBar(
+    val isActionMode by remember(actionModeCounter) {
+        derivedStateOf { actionModeCounter > 0 }
+    }
+
+    Column(
         modifier = modifier,
-        title = title,
-        scrollBehavior = scrollBehavior,
-        actionModeCounter = actionModeCounter,
-        onCancelActionMode = onCancelActionMode,
-        actionModeActions = {
-            IconButton(onClick = onSelectAll) {
-                Icon(
-                    imageVector = Icons.Outlined.SelectAll,
-                    contentDescription = stringResource(MR.strings.action_select_all),
-                )
-            }
-            IconButton(onClick = onInvertSelection) {
-                Icon(
-                    imageVector = Icons.Outlined.FlipToBack,
-                    contentDescription = stringResource(MR.strings.action_select_inverse),
-                )
-            }
-        },
-        navigateUp = navigateUp,
-    )
+    ) {
+        TopAppBar(
+            title = {
+                if (isActionMode) {
+                    AppBarTitle("$actionModeCounter selected")
+                } else {
+                    AppBarTitle(title)
+                }
+            },
+            actions = {},
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
+                    elevation = if (isActionMode) 3.dp else 0.dp,
+                ),
+            ),
+            scrollBehavior = scrollBehavior,
+        )
+    }
 }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -11,8 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.manga.components.MangaCover
@@ -24,14 +22,11 @@ import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.Scroller.STICKY_HEADER_KEY_PREFIX
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.util.secondaryItemAlpha
-import tachiyomi.presentation.core.util.selectedBackground
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 internal fun LazyListScope.libraryUpdateErrorUiItems(
     uiModels: List<LibraryUpdateErrorUiModel>,
-    selectionMode: Boolean,
-    onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
     onClick: (LibraryUpdateErrorItem) -> Unit,
     onClickCover: (LibraryUpdateErrorItem) -> Unit,
 ) {
@@ -57,28 +52,10 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
                     LibraryUpdateErrorUiItem(
                         modifier = Modifier.animateItemFastScroll(),
                         error = libraryUpdateErrorItem.error,
-                        selected = libraryUpdateErrorItem.selected,
                         onClick = {
-                            when {
-                                selectionMode -> onErrorSelected(
-                                    libraryUpdateErrorItem,
-                                    !libraryUpdateErrorItem.selected,
-                                    true,
-                                    false,
-                                )
-
-                                else -> onClick(libraryUpdateErrorItem)
-                            }
+                            onClick(libraryUpdateErrorItem)
                         },
-                        onLongClick = {
-                            onErrorSelected(
-                                libraryUpdateErrorItem,
-                                !libraryUpdateErrorItem.selected,
-                                true,
-                                true,
-                            )
-                        },
-                        onClickCover = { onClickCover(libraryUpdateErrorItem) }.takeIf { !selectionMode },
+                        onClickCover = { onClickCover(libraryUpdateErrorItem) },
                     )
                 }
             }
@@ -90,22 +67,13 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
 private fun LibraryUpdateErrorUiItem(
     modifier: Modifier,
     error: LibraryUpdateErrorWithRelations,
-    selected: Boolean,
     onClick: () -> Unit,
-    onLongClick: () -> Unit,
     onClickCover: (() -> Unit)?,
 ) {
-    val haptic = LocalHapticFeedback.current
-
     Row(
         modifier = modifier
-            .selectedBackground(selected)
             .combinedClickable(
                 onClick = onClick,
-                onLongClick = {
-                    onLongClick()
-                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                },
             )
             .padding(horizontal = MaterialTheme.padding.medium),
         verticalAlignment = Alignment.Top,

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -1,0 +1,156 @@
+package eu.kanade.presentation.libraryUpdateError.components
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.presentation.core.components.ListGroupHeader
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.util.secondaryItemAlpha
+import tachiyomi.presentation.core.util.selectedBackground
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+internal fun LazyListScope.libraryUpdateErrorUiItems(
+    uiModels: List<LibraryUpdateErrorUiModel>,
+    selectionMode: Boolean,
+    onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
+    onClick: (LibraryUpdateErrorItem) -> Unit,
+    onClickCover: (LibraryUpdateErrorItem) -> Unit,
+) {
+    items(
+        items = uiModels,
+        contentType = {
+            when (it) {
+                is LibraryUpdateErrorUiModel.Header -> "header"
+                is LibraryUpdateErrorUiModel.Item -> "item"
+            }
+        },
+        key = {
+            when (it) {
+                is LibraryUpdateErrorUiModel.Header -> "sticky:errorHeader-${it.hashCode()}"
+                is LibraryUpdateErrorUiModel.Item -> "error-${it.item.error.errorId}-${it.item.error.mangaId}"
+            }
+        },
+    ) { item ->
+        when (item) {
+            is LibraryUpdateErrorUiModel.Header -> {
+                ListGroupHeader(
+                    modifier = Modifier.animateItemPlacement(),
+                    text = item.errorMessage,
+                )
+            }
+
+            is LibraryUpdateErrorUiModel.Item -> {
+                val libraryUpdateErrorItem = item.item
+                LibraryUpdateErrorUiItem(
+                    modifier = Modifier.animateItemPlacement(),
+                    error = libraryUpdateErrorItem.error,
+                    selected = libraryUpdateErrorItem.selected,
+                    onClick = {
+                        when {
+                            selectionMode -> onErrorSelected(
+                                libraryUpdateErrorItem,
+                                !libraryUpdateErrorItem.selected,
+                                true,
+                                false,
+                            )
+
+                            else -> onClick(libraryUpdateErrorItem)
+                        }
+                    },
+                    onLongClick = {
+                        onErrorSelected(
+                            libraryUpdateErrorItem,
+                            !libraryUpdateErrorItem.selected,
+                            true,
+                            true,
+                        )
+                    },
+                    onClickCover = { onClickCover(libraryUpdateErrorItem) }.takeIf { !selectionMode },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryUpdateErrorUiItem(
+    modifier: Modifier,
+    error: LibraryUpdateErrorWithRelations,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onClickCover: (() -> Unit)?,
+) {
+    val haptic = LocalHapticFeedback.current
+
+    Row(
+        modifier = modifier
+            .selectedBackground(selected)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = {
+                    onLongClick()
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                },
+            )
+            .padding(horizontal = MaterialTheme.padding.medium),
+        verticalAlignment = Alignment.Top,
+    ) {
+        MangaCover.Square(
+            modifier = Modifier
+                .padding(vertical = 6.dp)
+                .height(48.dp),
+            data = error.mangaCover,
+            onClick = onClickCover,
+        )
+
+        Column(
+            modifier = Modifier
+                .padding(horizontal = MaterialTheme.padding.medium, vertical = 5.dp)
+                .weight(1f),
+        ) {
+            Text(
+                text = error.mangaTitle,
+                style = MaterialTheme.typography.bodyMedium,
+                overflow = TextOverflow.Visible,
+            )
+
+            Row(modifier = Modifier.padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = Injekt.get<SourceManager>().getOrStub(error.mangaSource).name,
+                    style = MaterialTheme.typography.bodySmall,
+                    overflow = TextOverflow.Visible,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .secondaryItemAlpha()
+                        .weight(weight = 1f, fill = false),
+                )
+            }
+        }
+    }
+}
+
+sealed class LibraryUpdateErrorUiModel {
+
+    data class Header(val errorMessage: String) : LibraryUpdateErrorUiModel()
+
+    data class Item(val item: LibraryUpdateErrorItem) : LibraryUpdateErrorUiModel()
+}

--- a/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.GetApp
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material.icons.outlined.QueryStats
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storage
@@ -47,6 +48,7 @@ fun MoreScreen(
     onClickDataAndStorage: () -> Unit,
     onClickSettings: () -> Unit,
     onClickAbout: () -> Unit,
+    onClickLibraryUpdateErrors: () -> Unit,
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -131,6 +133,13 @@ fun MoreScreen(
                     title = stringResource(MR.strings.label_stats),
                     icon = Icons.Outlined.QueryStats,
                     onPreferenceClick = onClickStats,
+                )
+            }
+            item {
+                TextPreferenceWidget(
+                    title = stringResource(MR.strings.option_label_library_update_errors),
+                    icon = Icons.Outlined.NewReleases,
+                    onPreferenceClick = onClickLibraryUpdateErrors,
                 )
             }
             item {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -55,6 +55,12 @@ import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_HAS_U
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_COMPLETED
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_READ
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_OUTSIDE_RELEASE_PERIOD
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.DeleteLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.InsertLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
 import tachiyomi.domain.manga.interactor.FetchInterval
 import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
@@ -85,6 +91,11 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
     private val fetchInterval: FetchInterval = Injekt.get()
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get()
+
+    private val deleteLibraryUpdateErrorMessages: DeleteLibraryUpdateErrorMessages = Injekt.get()
+    private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get()
+    private val insertLibraryUpdateErrors: InsertLibraryUpdateErrors = Injekt.get()
+    private val insertLibraryUpdateErrorMessages: InsertLibraryUpdateErrorMessages = Injekt.get()
 
     private val notifier = LibraryUpdateNotifier(context)
 
@@ -310,6 +321,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
 
         if (failedUpdates.isNotEmpty()) {
+            writeErrorsToDB(failedUpdates)
             val errorFile = writeErrorFile(failedUpdates)
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
@@ -404,6 +416,24 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             }
         } catch (_: Exception) {}
         return File("")
+    }
+
+    private suspend fun writeErrorsToDB(errors: List<Pair<Manga, String?>>) {
+        deleteLibraryUpdateErrorMessages.await()
+        deleteLibraryUpdateErrors.await()
+        val libraryErrors = errors.groupBy({ it.second }, { it.first })
+        val errorMessages = insertLibraryUpdateErrorMessages.insertAll(
+            libraryUpdateErrorMessages = libraryErrors.keys.map { errorMessage ->
+                LibraryUpdateErrorMessage(-1L, errorMessage.orEmpty())
+            },
+        )
+        val errorList = mutableListOf<LibraryUpdateError>()
+        errorMessages.forEach {
+            libraryErrors[it.second]?.forEach { manga ->
+                errorList.add(LibraryUpdateError(id = -1L, mangaId = manga.id, messageId = it.first))
+            }
+        }
+        insertLibraryUpdateErrors.insertAll(errorList)
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -110,6 +110,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             }
         }
 
+        deleteLibraryUpdateErrors.cleanUnrelevantMangaErrors()
+
         setForegroundSafely()
 
         libraryPreferences.lastUpdatedTimestamp().set(Instant.now().toEpochMilli())

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -24,7 +24,6 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
-import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import eu.kanade.tachiyomi.util.system.isRunning
@@ -322,10 +321,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
         if (failedUpdates.isNotEmpty()) {
             writeErrorsToDB(failedUpdates)
-            val errorFile = writeErrorFile(failedUpdates)
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
-                errorFile.getUriCompat(context),
             )
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import coil3.asDrawable
@@ -142,9 +141,8 @@ class LibraryUpdateNotifier(
      * Shows notification containing update entries that failed with action to open full log.
      *
      * @param failed Number of entries that failed to update.
-     * @param uri Uri for error log file containing all titles that failed.
      */
-    fun showUpdateErrorNotification(failed: Int, uri: Uri) {
+    fun showUpdateErrorNotification(failed: Int) {
         if (failed == 0) {
             return
         }
@@ -157,7 +155,7 @@ class LibraryUpdateNotifier(
             setContentText(context.stringResource(MR.strings.action_show_errors))
             setSmallIcon(R.drawable.ic_mihon)
 
-            setContentIntent(NotificationReceiver.openErrorLogPendingActivity(context, uri))
+            setContentIntent(NotificationReceiver.openErrorLogPendingActivity(context))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -619,6 +619,20 @@ class NotificationReceiver : BroadcastReceiver() {
         }
 
         /**
+         * Returns [PendingIntent] that opens the error log file in an external viewer
+         *
+         * @param context context of application
+         * @return [PendingIntent]
+         */
+        internal fun openErrorLogPendingActivity(context: Context): PendingIntent {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                action = Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
+        /**
          * Returns [PendingIntent] that cancels a backup restore job.
          *
          * @param context context of application

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -629,7 +629,12 @@ class NotificationReceiver : BroadcastReceiver() {
                 action = Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
-            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
         }
 
         /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -41,6 +41,7 @@ import eu.kanade.tachiyomi.ui.browse.BrowseTab
 import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
 import eu.kanade.tachiyomi.ui.history.HistoryTab
 import eu.kanade.tachiyomi.ui.library.LibraryTab
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.more.MoreTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
@@ -166,8 +167,12 @@ object HomeScreen : Screen() {
                         if (it is Tab.Library && it.mangaIdToOpen != null) {
                             navigator.push(MangaScreen(it.mangaIdToOpen))
                         }
-                        if (it is Tab.More && it.toDownloads) {
-                            navigator.push(DownloadQueueScreen)
+                        if (it is Tab.More) {
+                            if (it.toDownloads) {
+                                navigator.push(DownloadQueueScreen)
+                            } else if (it.toLibraryUpdateErrors) {
+                                navigator.push(LibraryUpdateErrorScreen())
+                            }
                         }
                     }
                 }
@@ -307,6 +312,9 @@ object HomeScreen : Screen() {
         data object Updates : Tab
         data object History : Tab
         data class Browse(val toExtensions: Boolean = false) : Tab
-        data class More(val toDownloads: Boolean) : Tab
+        data class More(
+            val toDownloads: Boolean,
+            val toLibraryUpdateErrors: Boolean = false,
+        ) : Tab
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -1,0 +1,48 @@
+package eu.kanade.tachiyomi.ui.libraryUpdateError
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.libraryUpdateError.LibraryUpdateErrorScreen
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.ui.browse.migration.advanced.design.PreMigrationScreen
+import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import tachiyomi.domain.UnsortedPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LibraryUpdateErrorScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val screenModel = rememberScreenModel { LibraryUpdateErrorScreenModel() }
+        val state by screenModel.state.collectAsState()
+
+        LibraryUpdateErrorScreen(
+            state = state,
+            onClick = { item ->
+                PreMigrationScreen.navigateToMigration(
+                    Injekt.get<UnsortedPreferences>().skipPreMigration().get(),
+                    navigator,
+                    listOf(item.error.mangaId),
+                )
+            },
+            onClickCover = { item -> navigator.push(MangaScreen(item.error.mangaId)) },
+            onMultiMigrateClicked = {
+                PreMigrationScreen.navigateToMigration(
+                    Injekt.get<UnsortedPreferences>().skipPreMigration().get(),
+                    navigator,
+                    state.selected.map { it.error.mangaId },
+                )
+            },
+            onSelectAll = screenModel::toggleAllSelection,
+            onInvertSelection = screenModel::invertSelection,
+            onErrorSelected = screenModel::toggleSelection,
+            navigateUp = navigator::pop,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -8,11 +8,8 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.libraryUpdateError.LibraryUpdateErrorScreen
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.design.PreMigrationScreen
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import tachiyomi.domain.UnsortedPreferences
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class LibraryUpdateErrorScreen : Screen() {
 
@@ -25,23 +22,9 @@ class LibraryUpdateErrorScreen : Screen() {
         LibraryUpdateErrorScreen(
             state = state,
             onClick = { item ->
-                PreMigrationScreen.navigateToMigration(
-                    Injekt.get<UnsortedPreferences>().skipPreMigration().get(),
-                    navigator,
-                    listOf(item.error.mangaId),
-                )
+                navigator.push(MigrateSearchScreen(item.error.mangaId))
             },
             onClickCover = { item -> navigator.push(MangaScreen(item.error.mangaId)) },
-            onMultiMigrateClicked = {
-                PreMigrationScreen.navigateToMigration(
-                    Injekt.get<UnsortedPreferences>().skipPreMigration().get(),
-                    navigator,
-                    state.selected.map { it.error.mangaId },
-                )
-            },
-            onSelectAll = screenModel::toggleAllSelection,
-            onInvertSelection = screenModel::invertSelection,
-            onErrorSelected = screenModel::toggleSelection,
             navigateUp = navigator::pop,
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -159,6 +159,11 @@ data class LibraryUpdateErrorScreenState(
         }
         return uiModels
     }
+
+    fun getHeaderIndexes(): List<Int> = getUiModel()
+        .withIndex()
+        .filter { it.value is LibraryUpdateErrorUiModel.Header }
+        .map { it.index }
 }
 
 @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -1,0 +1,168 @@
+package eu.kanade.tachiyomi.ui.libraryUpdateError
+
+import androidx.compose.runtime.Immutable
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.core.util.addOrRemove
+import eu.kanade.presentation.libraryUpdateError.components.LibraryUpdateErrorUiModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LibraryUpdateErrorScreenModel(
+    private val getLibraryUpdateErrorWithRelations: GetLibraryUpdateErrorWithRelations = Injekt.get(),
+    private val getLibraryUpdateErrorMessages: GetLibraryUpdateErrorMessages = Injekt.get(),
+) : StateScreenModel<LibraryUpdateErrorScreenState>(LibraryUpdateErrorScreenState()) {
+
+    // First and last selected index in list
+    private val selectedPositions: Array<Int> = arrayOf(-1, -1)
+    private val selectedErrorIds: HashSet<Long> = HashSet()
+
+    init {
+        screenModelScope.launchIO {
+            getLibraryUpdateErrorWithRelations.subscribeAll()
+                .collectLatest { errors ->
+                    val errorMessages = getLibraryUpdateErrorMessages.await()
+                    mutableState.update {
+                        it.copy(
+                            isLoading = false,
+                            items = toLibraryUpdateErrorItems(errors),
+                            messages = errorMessages,
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun toLibraryUpdateErrorItems(errors: List<LibraryUpdateErrorWithRelations>): List<LibraryUpdateErrorItem> {
+        return errors.map { error ->
+            LibraryUpdateErrorItem(
+                error = error,
+                selected = error.errorId in selectedErrorIds,
+            )
+        }
+    }
+
+    fun toggleSelection(
+        item: LibraryUpdateErrorItem,
+        selected: Boolean,
+        userSelected: Boolean = false,
+        fromLongPress: Boolean = false,
+    ) {
+        mutableState.update { state ->
+            val newItems = state.items.toMutableList().apply {
+                val selectedIndex = indexOfFirst { it.error.errorId == item.error.errorId }
+                if (selectedIndex < 0) return@apply
+
+                val selectedItem = get(selectedIndex)
+                if (selectedItem.selected == selected) return@apply
+
+                val firstSelection = none { it.selected }
+                set(selectedIndex, selectedItem.copy(selected = selected))
+                selectedErrorIds.addOrRemove(item.error.errorId, selected)
+
+                if (selected && userSelected && fromLongPress) {
+                    if (firstSelection) {
+                        selectedPositions[0] = selectedIndex
+                        selectedPositions[1] = selectedIndex
+                    } else {
+                        // Try to select the items in-between when possible
+                        val range: IntRange
+                        if (selectedIndex < selectedPositions[0]) {
+                            range = selectedIndex + 1 until selectedPositions[0]
+                            selectedPositions[0] = selectedIndex
+                        } else if (selectedIndex > selectedPositions[1]) {
+                            range = (selectedPositions[1] + 1) until selectedIndex
+                            selectedPositions[1] = selectedIndex
+                        } else {
+                            // Just select itself
+                            range = IntRange.EMPTY
+                        }
+
+                        range.forEach {
+                            val inbetweenItem = get(it)
+                            if (!inbetweenItem.selected) {
+                                selectedErrorIds.add(inbetweenItem.error.errorId)
+                                set(it, inbetweenItem.copy(selected = true))
+                            }
+                        }
+                    }
+                } else if (userSelected && !fromLongPress) {
+                    if (!selected) {
+                        if (selectedIndex == selectedPositions[0]) {
+                            selectedPositions[0] = indexOfFirst { it.selected }
+                        } else if (selectedIndex == selectedPositions[1]) {
+                            selectedPositions[1] = indexOfLast { it.selected }
+                        }
+                    } else {
+                        if (selectedIndex < selectedPositions[0]) {
+                            selectedPositions[0] = selectedIndex
+                        } else if (selectedIndex > selectedPositions[1]) {
+                            selectedPositions[1] = selectedIndex
+                        }
+                    }
+                }
+            }
+            state.copy(items = newItems)
+        }
+    }
+
+    fun toggleAllSelection(selected: Boolean) {
+        mutableState.update { state ->
+            val newItems = state.items.map {
+                selectedErrorIds.addOrRemove(it.error.errorId, selected)
+                it.copy(selected = selected)
+            }
+            state.copy(items = newItems)
+        }
+
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+    }
+
+    fun invertSelection() {
+        mutableState.update { state ->
+            val newItems = state.items.map {
+                selectedErrorIds.addOrRemove(it.error.errorId, !it.selected)
+                it.copy(selected = !it.selected)
+            }
+            state.copy(items = newItems)
+        }
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+    }
+}
+
+@Immutable
+data class LibraryUpdateErrorScreenState(
+    val isLoading: Boolean = true,
+    val items: List<LibraryUpdateErrorItem> = emptyList(),
+    val messages: List<LibraryUpdateErrorMessage> = emptyList(),
+) {
+
+    val selected = items.filter { it.selected }
+    val selectionMode = selected.isNotEmpty()
+
+    fun getUiModel(): List<LibraryUpdateErrorUiModel> {
+        val uiModels = mutableListOf<LibraryUpdateErrorUiModel>()
+        val errorMap = items.groupBy { it.error.messageId }
+        errorMap.forEach { (messageId, errors) ->
+            val message = messages.find { it.id == messageId }
+            uiModels.add(LibraryUpdateErrorUiModel.Header(message!!.message))
+            uiModels.addAll(errors.map { LibraryUpdateErrorUiModel.Item(it) })
+        }
+        return uiModels
+    }
+}
+
+@Immutable
+data class LibraryUpdateErrorItem(
+    val error: LibraryUpdateErrorWithRelations,
+    val selected: Boolean,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.libraryUpdateError
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
-import eu.kanade.core.util.addOrRemove
 import eu.kanade.presentation.libraryUpdateError.components.LibraryUpdateErrorUiModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
@@ -19,10 +18,6 @@ class LibraryUpdateErrorScreenModel(
     private val getLibraryUpdateErrorWithRelations: GetLibraryUpdateErrorWithRelations = Injekt.get(),
     private val getLibraryUpdateErrorMessages: GetLibraryUpdateErrorMessages = Injekt.get(),
 ) : StateScreenModel<LibraryUpdateErrorScreenState>(LibraryUpdateErrorScreenState()) {
-
-    // First and last selected index in list
-    private val selectedPositions: Array<Int> = arrayOf(-1, -1)
-    private val selectedErrorIds: HashSet<Long> = HashSet()
 
     init {
         screenModelScope.launchIO {
@@ -44,98 +39,8 @@ class LibraryUpdateErrorScreenModel(
         return errors.map { error ->
             LibraryUpdateErrorItem(
                 error = error,
-                selected = error.errorId in selectedErrorIds,
             )
         }
-    }
-
-    fun toggleSelection(
-        item: LibraryUpdateErrorItem,
-        selected: Boolean,
-        userSelected: Boolean = false,
-        fromLongPress: Boolean = false,
-    ) {
-        mutableState.update { state ->
-            val newItems = state.items.toMutableList().apply {
-                val selectedIndex = indexOfFirst { it.error.errorId == item.error.errorId }
-                if (selectedIndex < 0) return@apply
-
-                val selectedItem = get(selectedIndex)
-                if (selectedItem.selected == selected) return@apply
-
-                val firstSelection = none { it.selected }
-                set(selectedIndex, selectedItem.copy(selected = selected))
-                selectedErrorIds.addOrRemove(item.error.errorId, selected)
-
-                if (selected && userSelected && fromLongPress) {
-                    if (firstSelection) {
-                        selectedPositions[0] = selectedIndex
-                        selectedPositions[1] = selectedIndex
-                    } else {
-                        // Try to select the items in-between when possible
-                        val range: IntRange
-                        if (selectedIndex < selectedPositions[0]) {
-                            range = selectedIndex + 1 until selectedPositions[0]
-                            selectedPositions[0] = selectedIndex
-                        } else if (selectedIndex > selectedPositions[1]) {
-                            range = (selectedPositions[1] + 1) until selectedIndex
-                            selectedPositions[1] = selectedIndex
-                        } else {
-                            // Just select itself
-                            range = IntRange.EMPTY
-                        }
-
-                        range.forEach {
-                            val inbetweenItem = get(it)
-                            if (!inbetweenItem.selected) {
-                                selectedErrorIds.add(inbetweenItem.error.errorId)
-                                set(it, inbetweenItem.copy(selected = true))
-                            }
-                        }
-                    }
-                } else if (userSelected && !fromLongPress) {
-                    if (!selected) {
-                        if (selectedIndex == selectedPositions[0]) {
-                            selectedPositions[0] = indexOfFirst { it.selected }
-                        } else if (selectedIndex == selectedPositions[1]) {
-                            selectedPositions[1] = indexOfLast { it.selected }
-                        }
-                    } else {
-                        if (selectedIndex < selectedPositions[0]) {
-                            selectedPositions[0] = selectedIndex
-                        } else if (selectedIndex > selectedPositions[1]) {
-                            selectedPositions[1] = selectedIndex
-                        }
-                    }
-                }
-            }
-            state.copy(items = newItems)
-        }
-    }
-
-    fun toggleAllSelection(selected: Boolean) {
-        mutableState.update { state ->
-            val newItems = state.items.map {
-                selectedErrorIds.addOrRemove(it.error.errorId, selected)
-                it.copy(selected = selected)
-            }
-            state.copy(items = newItems)
-        }
-
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
-    }
-
-    fun invertSelection() {
-        mutableState.update { state ->
-            val newItems = state.items.map {
-                selectedErrorIds.addOrRemove(it.error.errorId, !it.selected)
-                it.copy(selected = !it.selected)
-            }
-            state.copy(items = newItems)
-        }
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 }
 
@@ -145,9 +50,6 @@ data class LibraryUpdateErrorScreenState(
     val items: List<LibraryUpdateErrorItem> = emptyList(),
     val messages: List<LibraryUpdateErrorMessage> = emptyList(),
 ) {
-
-    val selected = items.filter { it.selected }
-    val selectionMode = selected.isNotEmpty()
 
     fun getUiModel(): List<LibraryUpdateErrorUiModel> {
         val uiModels = mutableListOf<LibraryUpdateErrorUiModel>()
@@ -169,5 +71,4 @@ data class LibraryUpdateErrorScreenState(
 @Immutable
 data class LibraryUpdateErrorItem(
     val error: LibraryUpdateErrorWithRelations,
-    val selected: Boolean,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -403,6 +403,10 @@ class MainActivity : BaseActivity() {
                 navigator.popUntilRoot()
                 HomeScreen.Tab.More(toDownloads = true)
             }
+            Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS -> {
+                navigator.popUntilRoot()
+                HomeScreen.Tab.More(toDownloads = false, toLibraryUpdateErrors = true)
+            }
             Intent.ACTION_SEARCH, Intent.ACTION_SEND, "com.google.android.gms.actions.SEARCH_ACTION" -> {
                 // If the intent match the "standard" Android search intent
                 // or the Google-specific search intent (triggered by saying or typing "search *query* on *Tachiyomi*" in Google Search/Google Assistant)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreen
 import eu.kanade.tachiyomi.ui.setting.SettingsScreen
 import eu.kanade.tachiyomi.ui.stats.StatsScreen
 import eu.kanade.tachiyomi.util.system.isInstalledFromFDroid
@@ -75,6 +76,7 @@ object MoreTab : Tab {
             onClickDataAndStorage = { navigator.push(SettingsScreen(SettingsScreen.Destination.DataAndStorage)) },
             onClickSettings = { navigator.push(SettingsScreen()) },
             onClickAbout = { navigator.push(SettingsScreen(SettingsScreen.Destination.About)) },
+            onClickLibraryUpdateErrors = { navigator.push(LibraryUpdateErrorScreen()) },
         )
     }
 }

--- a/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
@@ -16,4 +16,6 @@ object Constants {
     const val SHORTCUT_SOURCES = "eu.kanade.tachiyomi.SHOW_CATALOGUES"
     const val SHORTCUT_EXTENSIONS = "eu.kanade.tachiyomi.EXTENSIONS"
     const val SHORTCUT_DOWNLOADS = "eu.kanade.tachiyomi.SHOW_DOWNLOADS"
+
+    const val SHORTCUT_LIBRARY_UPDATE_ERRORS = "eu.kanade.tachiyomi.SHOW_LIBRARY_UPDATE_ERRORS"
 }

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorMapper.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorMapper.kt
@@ -1,0 +1,11 @@
+package tachiyomi.data.libraryUpdateError
+
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+
+val libraryUpdateErrorMapper: (Long, Long, Long) -> LibraryUpdateError = { id, mangaId, messageId ->
+    LibraryUpdateError(
+        id = id,
+        mangaId = mangaId,
+        messageId = messageId,
+    )
+}

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package tachiyomi.data.libraryUpdateError
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+
+class LibraryUpdateErrorRepositoryImpl(
+    private val handler: DatabaseHandler,
+) : LibraryUpdateErrorRepository {
+
+    override suspend fun getAll(): List<LibraryUpdateError> {
+        return handler.awaitList {
+            libraryUpdateErrorQueries.getAllErrors(
+                libraryUpdateErrorMapper,
+            )
+        }
+    }
+
+    override fun getAllAsFlow(): Flow<List<LibraryUpdateError>> {
+        return handler.subscribeToList {
+            libraryUpdateErrorQueries.getAllErrors(
+                libraryUpdateErrorMapper,
+            )
+        }
+    }
+
+    override suspend fun deleteAll() {
+        return handler.await { libraryUpdateErrorQueries.deleteAllErrors() }
+    }
+
+    override suspend fun delete(errorId: Long) {
+        return handler.await {
+            libraryUpdateErrorQueries.deleteError(
+                _id = errorId,
+            )
+        }
+    }
+
+    override suspend fun insert(libraryUpdateError: LibraryUpdateError) {
+        return handler.await(inTransaction = true) {
+            libraryUpdateErrorQueries.insert(
+                mangaId = libraryUpdateError.mangaId,
+                messageId = libraryUpdateError.messageId,
+            )
+        }
+    }
+
+    override suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) {
+        return handler.await(inTransaction = true) {
+            libraryUpdateErrors.forEach {
+                libraryUpdateErrorQueries.insert(
+                    mangaId = it.mangaId,
+                    messageId = it.messageId,
+                )
+            }
+        }
+    }
+}

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -45,6 +45,12 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun cleanUnrelevantMangaErrors() {
+        return handler.await {
+            libraryUpdateErrorQueries.cleanUnrelevantMangaErrors()
+        }
+    }
+
     override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.upsert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -37,6 +37,14 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun deleteMangaError(mangaId: Long) {
+        return handler.await {
+            libraryUpdateErrorQueries.deleteMangaError(
+                mangaId = mangaId,
+            )
+        }
+    }
+
     override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.upsert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -37,6 +37,15 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
+        return handler.await(inTransaction = true) {
+            libraryUpdateErrorQueries.upsert(
+                mangaId = libraryUpdateError.mangaId,
+                messageId = libraryUpdateError.messageId,
+            )
+        }
+    }
+
     override suspend fun insert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.insert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsMapper.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsMapper.kt
@@ -1,0 +1,23 @@
+package tachiyomi.data.libraryUpdateError
+
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.domain.manga.model.MangaCover
+
+val libraryUpdateErrorWithRelationsMapper:
+    (Long, String, Long, Boolean, String?, Long, Long, Long) -> LibraryUpdateErrorWithRelations =
+    { mangaId, mangaTitle, mangaSource, favorite, mangaThumbnail, coverLastModified, errorId, messageId ->
+        LibraryUpdateErrorWithRelations(
+            mangaId = mangaId,
+            mangaTitle = mangaTitle,
+            mangaSource = mangaSource,
+            mangaCover = MangaCover(
+                mangaId = mangaId,
+                sourceId = mangaSource,
+                isMangaFavorite = favorite,
+                url = mangaThumbnail,
+                lastModified = coverLastModified,
+            ),
+            errorId = errorId,
+            messageId = messageId,
+        )
+    }

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package tachiyomi.data.libraryUpdateError
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorWithRelationsRepository
+
+class LibraryUpdateErrorWithRelationsRepositoryImpl(
+    private val handler: DatabaseHandler,
+) : LibraryUpdateErrorWithRelationsRepository {
+
+    override fun subscribeAll(): Flow<List<LibraryUpdateErrorWithRelations>> {
+        return handler.subscribeToList {
+            libraryUpdateErrorViewQueries.errors(
+                libraryUpdateErrorWithRelationsMapper,
+            )
+        }
+    }
+}

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageMapper.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageMapper.kt
@@ -1,0 +1,10 @@
+package tachiyomi.data.libraryUpdateErrorMessage
+
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+
+val LibraryUpdateErrorMessageMapper: (Long, String) -> LibraryUpdateErrorMessage = { id, message ->
+    LibraryUpdateErrorMessage(
+        id = id,
+        message = message,
+    )
+}

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -29,8 +29,14 @@ class LibraryUpdateErrorMessageRepositoryImpl(
         return handler.await { libraryUpdateErrorMessageQueries.deleteAllErrorMessages() }
     }
 
-    override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
-        return handler.awaitOneOrNullExecutable(inTransaction = true) {
+    override suspend fun get(message: String): Long? {
+        return handler.awaitOneOrNullExecutable {
+            libraryUpdateErrorMessageQueries.getErrorMessages(message) { id, _ -> id }
+        }
+    }
+
+    override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long {
+        return handler.awaitOneExecutable(inTransaction = true) {
             libraryUpdateErrorMessageQueries.insert(libraryUpdateErrorMessage.message)
             libraryUpdateErrorMessageQueries.selectLastInsertedRowId()
         }

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package tachiyomi.data.libraryUpdateErrorMessage
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
+
+class LibraryUpdateErrorMessageRepositoryImpl(
+    private val handler: DatabaseHandler,
+) : LibraryUpdateErrorMessageRepository {
+
+    override suspend fun getAll(): List<LibraryUpdateErrorMessage> {
+        return handler.awaitList {
+            libraryUpdateErrorMessageQueries.getAllErrorMessages(
+                LibraryUpdateErrorMessageMapper,
+            )
+        }
+    }
+
+    override fun getAllAsFlow(): Flow<List<LibraryUpdateErrorMessage>> {
+        return handler.subscribeToList {
+            libraryUpdateErrorMessageQueries.getAllErrorMessages(
+                LibraryUpdateErrorMessageMapper,
+            )
+        }
+    }
+
+    override suspend fun deleteAll() {
+        return handler.await { libraryUpdateErrorMessageQueries.deleteAllErrorMessages() }
+    }
+
+    override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
+        return handler.awaitOneOrNullExecutable(inTransaction = true) {
+            libraryUpdateErrorMessageQueries.insert(libraryUpdateErrorMessage.message)
+            libraryUpdateErrorMessageQueries.selectLastInsertedRowId()
+        }
+    }
+
+    override suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>> {
+        return handler.await(inTransaction = true) {
+            libraryUpdateErrorMessages.map {
+                libraryUpdateErrorMessageQueries.insert(it.message)
+                libraryUpdateErrorMessageQueries.selectLastInsertedRowId().executeAsOne() to it.message
+            }
+        }
+    }
+}

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -36,7 +36,9 @@ class LibraryUpdateErrorMessageRepositoryImpl(
         }
     }
 
-    override suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>> {
+    override suspend fun insertAll(
+        libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>,
+    ): List<Pair<Long, String>> {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorMessages.map {
                 libraryUpdateErrorMessageQueries.insert(it.message)

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -1,0 +1,19 @@
+CREATE TABLE libraryUpdateError (
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    message_id INTEGER NOT NULL
+);
+
+getAllErrors:
+SELECT *
+FROM libraryUpdateError;
+
+insert:
+INSERT INTO libraryUpdateError(manga_id, message_id) VALUES (:mangaId, :messageId);
+
+deleteAllErrors:
+DELETE FROM libraryUpdateError;
+
+deleteError:
+DELETE FROM libraryUpdateError
+WHERE _id = :_id;

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -1,6 +1,6 @@
 CREATE TABLE libraryUpdateError (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    manga_id INTEGER NOT NULL,
+    manga_id INTEGER NOT NULL UNIQUE,
     message_id INTEGER NOT NULL
 );
 
@@ -10,6 +10,15 @@ FROM libraryUpdateError;
 
 insert:
 INSERT INTO libraryUpdateError(manga_id, message_id) VALUES (:mangaId, :messageId);
+
+upsert:
+INSERT INTO libraryUpdateError(manga_id, message_id)
+VALUES (:mangaId, :messageId)
+ON CONFLICT(manga_id)
+DO UPDATE
+SET
+    message_id = :messageId
+WHERE manga_id = :mangaId;
 
 deleteAllErrors:
 DELETE FROM libraryUpdateError;

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -30,3 +30,12 @@ WHERE _id = :_id;
 deleteMangaError:
 DELETE FROM libraryUpdateError
 WHERE manga_id = :mangaId;
+
+cleanUnrelevantMangaErrors:
+DELETE FROM libraryUpdateError
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM mangas
+    WHERE libraryUpdateError.manga_id = mangas._id
+    AND mangas.favorite == 1
+);

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -26,3 +26,7 @@ DELETE FROM libraryUpdateError;
 deleteError:
 DELETE FROM libraryUpdateError
 WHERE _id = :_id;
+
+deleteMangaError:
+DELETE FROM libraryUpdateError
+WHERE manga_id = :mangaId;

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
@@ -1,0 +1,17 @@
+CREATE TABLE libraryUpdateErrorMessage (
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    message TEXT NOT NULL UNIQUE
+);
+
+getAllErrorMessages:
+SELECT *
+FROM libraryUpdateErrorMessage;
+
+insert:
+INSERT INTO libraryUpdateErrorMessage(message) VALUES (:message);
+
+deleteAllErrorMessages:
+DELETE FROM libraryUpdateErrorMessage;
+
+selectLastInsertedRowId:
+SELECT last_insert_rowid();

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
@@ -7,6 +7,10 @@ getAllErrorMessages:
 SELECT *
 FROM libraryUpdateErrorMessage;
 
+getErrorMessages:
+SELECT *
+FROM libraryUpdateErrorMessage WHERE message == :message;
+
 insert:
 INSERT INTO libraryUpdateErrorMessage(message) VALUES (:message);
 

--- a/data/src/main/sqldelight/tachiyomi/migrations/4.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/4.sqm
@@ -2,7 +2,7 @@ DROP VIEW IF EXISTS libraryUpdateErrorView;
 
 CREATE TABLE IF NOT EXISTS libraryUpdateError (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    manga_id INTEGER NOT NULL,
+    manga_id INTEGER NOT NULL UNIQUE,
     message_id INTEGER NOT NULL
 );
 

--- a/data/src/main/sqldelight/tachiyomi/migrations/4.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/4.sqm
@@ -1,0 +1,26 @@
+DROP VIEW IF EXISTS libraryUpdateErrorView;
+
+CREATE TABLE IF NOT EXISTS libraryUpdateError (
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    message_id INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS libraryUpdateErrorMessage (
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    message TEXT NOT NULL UNIQUE
+);
+
+CREATE VIEW libraryUpdateErrorView AS
+SELECT
+    mangas._id AS mangaId,
+    mangas.title AS mangaTitle,
+    mangas.source,
+    mangas.favorite,
+    mangas.thumbnail_url AS thumbnailUrl,
+    mangas.cover_last_modified AS coverLastModified,
+    libraryUpdateError._id AS errorId,
+    libraryUpdateError.message_id AS messageId
+FROM mangas JOIN libraryUpdateError
+ON mangas._id = libraryUpdateError.manga_id
+WHERE favorite = 1;

--- a/data/src/main/sqldelight/tachiyomi/view/libraryUpdateErrorView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryUpdateErrorView.sq
@@ -1,0 +1,17 @@
+CREATE VIEW libraryUpdateErrorView AS
+SELECT
+    mangas._id AS mangaId,
+    mangas.title AS mangaTitle,
+    mangas.source,
+    mangas.favorite,
+    mangas.thumbnail_url AS thumbnailUrl,
+    mangas.cover_last_modified AS coverLastModified,
+    libraryUpdateError._id AS errorId,
+    libraryUpdateError.message_id AS messageId
+FROM mangas JOIN libraryUpdateError
+ON mangas._id = libraryUpdateError.manga_id
+WHERE favorite = 1;
+
+errors:
+SELECT *
+FROM libraryUpdateErrorView;

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -29,6 +29,16 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
+    suspend fun deleteMangaError(mangaId: Long) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.deleteMangaError(mangaId)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
     sealed class Result {
         object Success : Result()
         data class InternalError(val error: Throwable) : Result()

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -1,0 +1,36 @@
+package tachiyomi.domain.libraryUpdateError.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+
+class DeleteLibraryUpdateErrors(
+    private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
+) {
+
+    suspend fun await() = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.deleteAll()
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
+    suspend fun await(errorId: Long) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.delete(errorId)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
+    sealed class Result {
+        object Success : Result()
+        data class InternalError(val error: Throwable) : Result()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -39,8 +39,18 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
+    suspend fun cleanUnrelevantMangaErrors() = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.cleanUnrelevantMangaErrors()
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
     sealed class Result {
-        object Success : Result()
+        data object Success : Result()
         data class InternalError(val error: Throwable) : Result()
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/GetLibraryUpdateErrorWithRelations.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/GetLibraryUpdateErrorWithRelations.kt
@@ -1,0 +1,14 @@
+package tachiyomi.domain.libraryUpdateError.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorWithRelationsRepository
+
+class GetLibraryUpdateErrorWithRelations(
+    private val libraryUpdateErrorWithRelationsRepository: LibraryUpdateErrorWithRelationsRepository,
+) {
+
+    fun subscribeAll(): Flow<List<LibraryUpdateErrorWithRelations>> {
+        return libraryUpdateErrorWithRelationsRepository.subscribeAll()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/GetLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/GetLibraryUpdateErrors.kt
@@ -1,0 +1,18 @@
+package tachiyomi.domain.libraryUpdateError.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+
+class GetLibraryUpdateErrors(
+    private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
+) {
+
+    fun subscribe(): Flow<List<LibraryUpdateError>> {
+        return libraryUpdateErrorRepository.getAllAsFlow()
+    }
+
+    suspend fun await(): List<LibraryUpdateError> {
+        return libraryUpdateErrorRepository.getAll()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
@@ -1,0 +1,16 @@
+package tachiyomi.domain.libraryUpdateError.interactor
+
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+
+class InsertLibraryUpdateErrors(
+    private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
+) {
+    suspend fun insert(libraryUpdateError: LibraryUpdateError) {
+        return libraryUpdateErrorRepository.insert(libraryUpdateError)
+    }
+
+    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) {
+        return libraryUpdateErrorRepository.insertAll(libraryUpdateErrors)
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
@@ -6,6 +6,10 @@ import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorReposito
 class InsertLibraryUpdateErrors(
     private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
 ) {
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
+        return libraryUpdateErrorRepository.upsert(libraryUpdateError)
+    }
+
     suspend fun insert(libraryUpdateError: LibraryUpdateError) {
         return libraryUpdateErrorRepository.insert(libraryUpdateError)
     }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
@@ -1,20 +1,42 @@
 package tachiyomi.domain.libraryUpdateError.interactor
 
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors.Result
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
 import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
 
 class InsertLibraryUpdateErrors(
     private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
 ) {
-    suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
-        return libraryUpdateErrorRepository.upsert(libraryUpdateError)
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.upsert(libraryUpdateError)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 
-    suspend fun insert(libraryUpdateError: LibraryUpdateError) {
-        return libraryUpdateErrorRepository.insert(libraryUpdateError)
+    suspend fun insert(libraryUpdateError: LibraryUpdateError) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.insert(libraryUpdateError)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 
-    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) {
-        return libraryUpdateErrorRepository.insertAll(libraryUpdateErrors)
+    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.insertAll(libraryUpdateErrors)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateError.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateError.kt
@@ -1,0 +1,9 @@
+package tachiyomi.domain.libraryUpdateError.model
+
+import java.io.Serializable
+
+data class LibraryUpdateError(
+    val id: Long,
+    val mangaId: Long,
+    val messageId: Long,
+) : Serializable

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateErrorWithRelations.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateErrorWithRelations.kt
@@ -1,0 +1,12 @@
+package tachiyomi.domain.libraryUpdateError.model
+
+import tachiyomi.domain.manga.model.MangaCover
+
+data class LibraryUpdateErrorWithRelations(
+    val mangaId: Long,
+    val mangaTitle: String,
+    val mangaSource: Long,
+    val mangaCover: MangaCover,
+    val errorId: Long,
+    val messageId: Long,
+)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -15,6 +15,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun deleteMangaError(mangaId: Long)
 
+    suspend fun cleanUnrelevantMangaErrors()
+
     suspend fun upsert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insert(libraryUpdateError: LibraryUpdateError)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -1,0 +1,19 @@
+package tachiyomi.domain.libraryUpdateError.repository
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
+
+interface LibraryUpdateErrorRepository {
+
+    suspend fun getAll(): List<LibraryUpdateError>
+
+    fun getAllAsFlow(): Flow<List<LibraryUpdateError>>
+
+    suspend fun deleteAll()
+
+    suspend fun delete(errorId: Long)
+
+    suspend fun insert(libraryUpdateError: LibraryUpdateError)
+
+    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>)
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -13,6 +13,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun delete(errorId: Long)
 
+    suspend fun deleteMangaError(mangaId: Long)
+
     suspend fun upsert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insert(libraryUpdateError: LibraryUpdateError)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -13,6 +13,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun delete(errorId: Long)
 
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError)
+
     suspend fun insert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorWithRelationsRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorWithRelationsRepository.kt
@@ -1,0 +1,9 @@
+package tachiyomi.domain.libraryUpdateError.repository
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+
+interface LibraryUpdateErrorWithRelationsRepository {
+
+    fun subscribeAll(): Flow<List<LibraryUpdateErrorWithRelations>>
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
@@ -1,0 +1,27 @@
+package tachiyomi.domain.libraryUpdateErrorMessage.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
+import kotlin.Exception
+
+class DeleteLibraryUpdateErrorMessages(
+    private val libraryUpdateErrorMessageRepository: LibraryUpdateErrorMessageRepository,
+) {
+
+    suspend fun await() = withNonCancellableContext {
+        try {
+            libraryUpdateErrorMessageRepository.deleteAll()
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
+    sealed class Result {
+        object Success : Result()
+        data class InternalError(val error: Throwable) : Result()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
@@ -21,7 +21,7 @@ class DeleteLibraryUpdateErrorMessages(
     }
 
     sealed class Result {
-        object Success : Result()
+        data object Success : Result()
         data class InternalError(val error: Throwable) : Result()
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/GetLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/GetLibraryUpdateErrorMessages.kt
@@ -1,0 +1,18 @@
+package tachiyomi.domain.libraryUpdateErrorMessage.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
+
+class GetLibraryUpdateErrorMessages(
+    private val libraryUpdateErrorMessageRepository: LibraryUpdateErrorMessageRepository,
+) {
+
+    fun subscribe(): Flow<List<LibraryUpdateErrorMessage>> {
+        return libraryUpdateErrorMessageRepository.getAllAsFlow()
+    }
+
+    suspend fun await(): List<LibraryUpdateErrorMessage> {
+        return libraryUpdateErrorMessageRepository.getAll()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
@@ -6,8 +6,11 @@ import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorM
 class InsertLibraryUpdateErrorMessages(
     private val libraryUpdateErrorMessageRepository: LibraryUpdateErrorMessageRepository,
 ) {
+    suspend fun get(message: String): Long? {
+        return libraryUpdateErrorMessageRepository.get(message)
+    }
 
-    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long {
         return libraryUpdateErrorMessageRepository.insert(libraryUpdateErrorMessage)
     }
 

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
@@ -1,0 +1,17 @@
+package tachiyomi.domain.libraryUpdateErrorMessage.interactor
+
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
+
+class InsertLibraryUpdateErrorMessages(
+    private val libraryUpdateErrorMessageRepository: LibraryUpdateErrorMessageRepository,
+) {
+
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
+        return libraryUpdateErrorMessageRepository.insert(libraryUpdateErrorMessage)
+    }
+
+    suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>> {
+        return libraryUpdateErrorMessageRepository.insertAll(libraryUpdateErrorMessages)
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/model/LibraryUpdateErrorMessage.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/model/LibraryUpdateErrorMessage.kt
@@ -1,0 +1,8 @@
+package tachiyomi.domain.libraryUpdateErrorMessage.model
+
+import java.io.Serializable
+
+data class LibraryUpdateErrorMessage(
+    val id: Long,
+    val message: String,
+) : Serializable

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
@@ -11,7 +11,9 @@ interface LibraryUpdateErrorMessageRepository {
 
     suspend fun deleteAll()
 
-    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long?
+    suspend fun get(message: String): Long?
+
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long
 
     suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>>
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
@@ -1,0 +1,17 @@
+package tachiyomi.domain.libraryUpdateErrorMessage.repository
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+
+interface LibraryUpdateErrorMessageRepository {
+
+    suspend fun getAll(): List<LibraryUpdateErrorMessage>
+
+    fun getAllAsFlow(): Flow<List<LibraryUpdateErrorMessage>>
+
+    suspend fun deleteAll()
+
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long?
+
+    suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>>
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -573,6 +573,11 @@
     <string name="syncing_library">Syncing library</string>
     <string name="library_sync_complete">Library sync complete</string>
 
+    <!-- Error section -->
+    <string name="option_label_library_update_errors">Library update errors</string>
+    <string name="label_library_update_errors">Library update errors (%d)</string>
+    <string name="info_empty_library_update_errors">You have no library update errors.</string>
+
       <!-- Advanced section -->
     <string name="label_network">Networking</string>
     <string name="pref_clear_cookies">Clear cookies</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -579,6 +579,8 @@
     <string name="info_empty_library_update_errors">You have no library update errors.</string>
     <string name="action_scroll_to_top">Scroll to top</string>
     <string name="action_scroll_to_bottom">Scroll to bottom</string>
+    <string name="action_scroll_to_previous">Scroll to previous</string>
+    <string name="action_scroll_to_next">Scroll to next</string>
 
       <!-- Advanced section -->
     <string name="label_network">Networking</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -577,6 +577,8 @@
     <string name="option_label_library_update_errors">Library update errors</string>
     <string name="label_library_update_errors">Library update errors (%d)</string>
     <string name="info_empty_library_update_errors">You have no library update errors.</string>
+    <string name="action_scroll_to_top">Scroll to top</string>
+    <string name="action_scroll_to_bottom">Scroll to bottom</string>
 
       <!-- Advanced section -->
     <string name="label_network">Networking</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
@@ -1,7 +1,9 @@
 package tachiyomi.presentation.core.components
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,15 +15,21 @@ fun ListGroupHeader(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = text,
+    Surface(
         modifier = modifier
-            .padding(
-                horizontal = MaterialTheme.padding.medium,
-                vertical = MaterialTheme.padding.small,
-            ),
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontWeight = FontWeight.SemiBold,
-        style = MaterialTheme.typography.bodyMedium,
-    )
+            .fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(
+                    horizontal = MaterialTheme.padding.medium,
+                    vertical = MaterialTheme.padding.small,
+                ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
 }


### PR DESCRIPTION
* A dedicated screen in Settings for error list when updating library
* Allow to jump to Error screen if click on notification
* Allow to migrate error entry
* Create error on each entry updated instead of waiting for the whole updating list to finished
* Overwrite entry's error if new error happens after updating
* Clear entry's error if it successfully updated
* Clear un-relevant errors (entry which was removed from Library) on next update
* List of errors can jump to top/bottom or next/previous errors group
* Won't create error file anymore

Close #132

![image](https://github.com/user-attachments/assets/21ed675e-0e75-4fe5-8483-12f6b00369dd)
![image](https://github.com/user-attachments/assets/6385eac6-67d8-44c1-b2db-34c8c4be8688)
