### PR TITLE
fix: app crashes when delete a track if the entry is already removed …

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
@@ -824,7 +824,11 @@ private data class TrackerRemoveScreen(
 
         fun deleteMangaFromService() {
             screenModelScope.launchNonCancellable {
-                (tracker as DeletableTracker).delete(track)
+                try {
+                    (tracker as DeletableTracker).delete(track)
+                } catch (e: Exception) {
+                    logcat(LogPriority.ERROR, e) { "Failed to delete entry from service" }
+                }
             }
         }
 


### PR DESCRIPTION
…from tracker's service

with option to "Also remove from \<Tracker\>"

close #1023