### PR TITLE
Trim whitespace from Repo URL and lowercase it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
+- Extension repo URLs are now auto-formatted ([@MajorTanya](https://github.com/MajorTanya)) ([#1393](https://github.com/mihonapp/mihon/pull/1393))
 
 ## [v0.17.0] - 2024-10-26
 ### Added

--- a/domain/src/main/java/mihon/domain/extensionrepo/interactor/CreateExtensionRepo.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/interactor/CreateExtensionRepo.kt
@@ -14,11 +14,12 @@ class CreateExtensionRepo(
     private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
 
     suspend fun await(repoUrl: String): Result {
-        if (!repoUrl.matches(repoRegex)) {
+        val cleanedRepoUrl = repoUrl.trim().lowercase()
+        if (!cleanedRepoUrl.matches(repoRegex)) {
             return Result.InvalidUrl
         }
 
-        val baseUrl = repoUrl.removeSuffix("/index.min.json")
+        val baseUrl = cleanedRepoUrl.removeSuffix("/index.min.json")
         return service.fetchRepoDetails(baseUrl)?.let { insert(it) } ?: Result.InvalidUrl
     }
 

--- a/domain/src/main/java/mihon/domain/extensionrepo/interactor/CreateExtensionRepo.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/interactor/CreateExtensionRepo.kt
@@ -11,10 +11,11 @@ class CreateExtensionRepo(
     private val repository: ExtensionRepoRepository,
     private val service: ExtensionRepoService,
 ) {
+    private val httpsRegex = "^https".toRegex(RegexOption.IGNORE_CASE)
     private val repoRegex = """^https://.*/index\.min\.json$""".toRegex()
 
     suspend fun await(repoUrl: String): Result {
-        val cleanedRepoUrl = repoUrl.trim().lowercase()
+        val cleanedRepoUrl = repoUrl.trim().replaceFirst(httpsRegex, "https")
         if (!cleanedRepoUrl.matches(repoRegex)) {
             return Result.InvalidUrl
         }


### PR DESCRIPTION
This should close #1392.

Trimming whitespace and lowercasing the URL isn't an invasive procedure on the URL itself, and helps users who may have accidentally copied a space, or somehow capitalised or uppercased the URL because of an overzealous autocorrect, etc.