### PR TITLE
Various improvements to Bangumi search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Fixed "currentTab was used multiple times"
 
+### Improved
+- Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
+
 ## [v0.17.0] - 2024-10-26
 ### Added
 - Option to disable reader zoom out ([@Splintorien](https://github.com/Splintorien)) ([#302](https://github.com/mihonapp/mihon/pull/302))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -71,6 +71,8 @@ class BangumiApi(
             val url = "$API_URL/search/subject/${URLEncoder.encode(search, StandardCharsets.UTF_8.name())}"
                 .toUri()
                 .buildUpon()
+                .appendQueryParameter("type", "1")
+                .appendQueryParameter("responseGroup", "large")
                 .appendQueryParameter("max_results", "20")
                 .build()
             with(json) {
@@ -81,7 +83,6 @@ class BangumiApi(
                         if (result.code == 404) emptyList<TrackSearch>()
 
                         result.list
-                            ?.filter { it.type == 1 }
                             ?.map { it.toTrackSearch(trackId) }
                             .orEmpty()
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
@@ -28,7 +28,11 @@ data class BGMSearchItem(
         remote_id = this@BGMSearchItem.id
         title = nameCn.ifEmpty { name }
         cover_url = images?.common ?: ""
-        summary = name + this@BGMSearchItem.summary?.let { "\n$it" }.orEmpty()
+        summary = if (nameCn.isNotEmpty()) {
+            "作品原名：$name" + this@BGMSearchItem.summary?.let { "\n$it" }.orEmpty()
+        } else {
+            this@BGMSearchItem.summary.orEmpty()
+        }
         score = rating?.score ?: -1.0
         tracking_url = url
         total_chapters = epsCount ?: 0

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
@@ -26,9 +26,9 @@ data class BGMSearchItem(
 ) {
     fun toTrackSearch(trackId: Long): TrackSearch = TrackSearch.create(trackId).apply {
         remote_id = this@BGMSearchItem.id
-        title = nameCn.ifEmpty { name }
+        title = nameCn.ifBlank { name }
         cover_url = images?.common.orEmpty()
-        summary = if (nameCn.isNotEmpty()) {
+        summary = if (nameCn.isNotBlank()) {
             "作品原名：$name" + this@BGMSearchItem.summary?.let { "\n$it" }.orEmpty()
         } else {
             this@BGMSearchItem.summary.orEmpty()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
@@ -27,7 +27,7 @@ data class BGMSearchItem(
     fun toTrackSearch(trackId: Long): TrackSearch = TrackSearch.create(trackId).apply {
         remote_id = this@BGMSearchItem.id
         title = nameCn.ifEmpty { name }
-        cover_url = images?.common ?: ""
+        cover_url = images?.common.orEmpty()
         summary = if (nameCn.isNotEmpty()) {
             "作品原名：$name" + this@BGMSearchItem.summary?.let { "\n$it" }.orEmpty()
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
@@ -17,6 +17,7 @@ data class BGMSearchItem(
     val nameCn: String,
     val name: String,
     val type: Int,
+    val summary: String?,
     val images: BGMSearchItemCovers?,
     @SerialName("eps_count")
     val epsCount: Long?,
@@ -25,9 +26,9 @@ data class BGMSearchItem(
 ) {
     fun toTrackSearch(trackId: Long): TrackSearch = TrackSearch.create(trackId).apply {
         remote_id = this@BGMSearchItem.id
-        title = nameCn
+        title = nameCn.ifEmpty { name }
         cover_url = images?.common ?: ""
-        summary = this@BGMSearchItem.name
+        summary = name + this@BGMSearchItem.summary?.let { "\n$it" }.orEmpty()
         score = rating?.score ?: -1.0
         tracking_url = url
         total_chapters = epsCount ?: 0


### PR DESCRIPTION
In short:
- fetch & show actual summary
- fallback to "name" if "name_cn" is empty
- request larger responseGroup to get & display the summary & rating
- add type filter query param to make Bangumi filter, not us

Previously, we only displayed the "name" in the summary area and used "name_cn" as the entry name. However, "name_cn" (Chinese name) can be an empty string at times, resulting in an awkward looking search result list where some, many, or even all the results have no title displayed and only show the "name" (Japanese name) in the summary area. This has been solved by using "name" as a fallback value should "name_cn" be empty.

By using the "responseGroup=large" query parameter, we can request the required data we need to display the actual summary for an entry and the entry's average rating.
The "name" is prepended to the summary contents, if any exist, so it is still accessible for series identification if a "name_cn" exists too and was used for the result title.

Adding the "type=1" filter query parameter means Bangumi will only return entries of type 1 ("book") instead of all types and Mihon needing to filter, resulting in potentially missed entry matches.

Sadly, Bangumi does not return any data on start or end dates in the search, no matter what responseGroup is used. Their data on this is sometimes contradictory at best anyway and often mixes Japanese and Chinese release dates.

| Old | New |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/35a0bf18-60fa-48fc-b581-95cde8558abc) | ![image](https://github.com/user-attachments/assets/bef989ae-b5cf-462c-8498-42fb02ca90d9) |
