### PR TITLE
Fix sporadically recurring spotless CI failure

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -738,7 +738,8 @@ class MangaScreenModel(
 
             if (
                 successState?.hasLoggedInTrackers == false ||
-                !read || autoTrackState == AutoTrackState.NEVER
+                !read ||
+                autoTrackState == AutoTrackState.NEVER
             ) {
                 return@launchIO
             }


### PR DESCRIPTION
Somehow this specific issue keeps getting flagged by unrelated PRs' CI runs (but only sometimes? Somehow? Other times the CI run would succeed with no spotless issues.)

If this doesn't fix it, I declare spotless to be cursed (please don't change the linter again).