### PR TITLE
Revert "Update subsampling-scale-image-view (#687)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ coil-gif = { module = "io.coil-kt.coil3:coil-gif" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp" }
 
-subsamplingscaleimageview = "com.github.tachiyomiorg:subsampling-scale-image-view:b8e1b0ed2b"
+subsamplingscaleimageview = "com.github.tachiyomiorg:subsampling-scale-image-view:aeaa170036"
 image-decoder = "com.github.tachiyomiorg:image-decoder:41c059e540"
 
 natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"


### PR DESCRIPTION
This reverts commit 80461d88 in order to fix commit bb4d9fc8 not working as intended.

Latest preview fails to display long vertical strips affected by the blanks issue even if the setting is enabled
https://github.com/user-attachments/assets/00b248b2-14bf-475e-899d-bb245cf2b1c4

A build made after reverting this commit allows SSIV to work in these cases
https://github.com/user-attachments/assets/0c2d8d9b-a0fa-4df9-b7b8-d87ccb35f495

Note that this does not solve the original issue of Coil failing to handle these taller than expected images, hardware bitmaps still result in black screens if the SSIV in preview or the setting in the PR #1440 are off

