### PR TITLE
fix: app update error notification always disappeared

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -71,6 +71,7 @@ object Notifications {
     const val CHANNEL_APP_UPDATE = "app_apk_update_channel"
     const val ID_APP_UPDATER = 1
     const val ID_APP_UPDATE_PROMPT = 2
+    const val ID_APP_UPDATE_ERROR = 3
     const val CHANNEL_EXTENSIONS_UPDATE = "ext_apk_update_channel"
     const val ID_UPDATES_TO_EXTS = -401
     const val ID_EXTENSION_INSTALLER = -402

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
@@ -181,9 +181,9 @@ internal class AppUpdateNotifier(private val context: Context) {
             addAction(
                 R.drawable.ic_close_24dp,
                 context.stringResource(MR.strings.action_cancel),
-                NotificationReceiver.dismissNotificationPendingBroadcast(context, Notifications.ID_APP_UPDATER),
+                NotificationReceiver.dismissNotificationPendingBroadcast(context, Notifications.ID_APP_UPDATE_PROMPT),
             )
         }
-        notificationBuilder.show(Notifications.ID_APP_UPDATER)
+        notificationBuilder.show(Notifications.ID_APP_UPDATE_PROMPT)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
@@ -181,9 +181,9 @@ internal class AppUpdateNotifier(private val context: Context) {
             addAction(
                 R.drawable.ic_close_24dp,
                 context.stringResource(MR.strings.action_cancel),
-                NotificationReceiver.dismissNotificationPendingBroadcast(context, Notifications.ID_APP_UPDATE_PROMPT),
+                NotificationReceiver.dismissNotificationPendingBroadcast(context, Notifications.ID_APP_UPDATE_ERROR),
             )
         }
-        notificationBuilder.show(Notifications.ID_APP_UPDATE_PROMPT)
+        notificationBuilder.show(Notifications.ID_APP_UPDATE_ERROR)
     }
 }


### PR DESCRIPTION
#### How to reproduce the issue
1. Try downloading the app update on a slow network - Or purposely decrease `network.client.callTimeout` to just 1-3 seconds.
2. Wait for the timeout exception to occur (could be any other exception that could be manipulated to occur)

#### Expect
- The `Download Error` notification should be shown after the `Downloading` notification hides.

#### Actual
- The `Downloading` notification hides and there are no more notification.

#### Reason
- `AppUpdateDownloadJob` foreground is set tied to `Notifications.ID_APP_UPDATER`
- The `Download Error` notification also use `Notifications.ID_APP_UPDATER` - debug shows that it is actually called to show
- But when Job is done (i.e. download stoped for any reason), the whole `Notifications.ID_APP_UPDATER` is closed and hence clearing the `Download Error` notification.
