### PR TITLE
Add a setting for users to lower the threshold for HW bitmaps

### DIFF
--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -32,4 +32,6 @@ class BasePreferences(
     fun displayProfile() = preferenceStore.getString("pref_display_profile_key", "")
 
     fun alwaysUseSSIVToDecode() = preferenceStore.getBoolean("pref_always_use_ssiv_to_decode", false)
+
+    fun fallbackForLongStrips() = preferenceStore.getBoolean("pref_fallback_for_long_strips", false)
 }

--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -2,6 +2,7 @@ package eu.kanade.domain.base
 
 import android.content.Context
 import dev.icerock.moko.resources.StringResource
+import eu.kanade.tachiyomi.util.system.GLUtil
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.i18n.MR
@@ -33,5 +34,5 @@ class BasePreferences(
 
     fun alwaysUseSSIVToDecode() = preferenceStore.getBoolean("pref_always_use_ssiv_to_decode", false)
 
-    fun fallbackForLongStrips() = preferenceStore.getBoolean("pref_fallback_for_long_strips", false)
+    fun maxBitmapSize() = preferenceStore.getString("pref_max_bitmap_size", GLUtil.maxTextureSize.toString())
 }

--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -34,5 +34,5 @@ class BasePreferences(
 
     fun alwaysUseSSIVToDecode() = preferenceStore.getBoolean("pref_always_use_ssiv_to_decode", false)
 
-    fun maxBitmapSize() = preferenceStore.getString("pref_max_bitmap_size", GLUtil.maxTextureSize.toString())
+    fun maxBitmapSize() = preferenceStore.getInt("pref_max_bitmap_size", GLUtil.maxTextureSize)
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -51,6 +51,7 @@ sealed class Preference {
             val value: Int,
             val min: Int = 0,
             val max: Int,
+            val steps: Int = 0,
             override val title: String = "",
             override val subtitle: String? = null,
             override val icon: ImageVector? = null,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -83,6 +83,7 @@ internal fun PreferenceItem(
                     max = item.max,
                     value = item.value,
                     valueText = item.subtitle.takeUnless { it.isNullOrEmpty() } ?: item.value.toString(),
+                    steps = item.steps,
                     onChange = {
                         scope.launch {
                             item.onValueChanged(it)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.core.net.toUri
-import androidx.core.text.isDigitsOnly
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.base.BasePreferences
@@ -48,6 +47,7 @@ import eu.kanade.tachiyomi.network.PREF_DOH_QUAD9
 import eu.kanade.tachiyomi.network.PREF_DOH_SHECAN
 import eu.kanade.tachiyomi.ui.more.OnboardingScreen
 import eu.kanade.tachiyomi.util.CrashLogUtil
+import eu.kanade.tachiyomi.util.system.GLUtil
 import eu.kanade.tachiyomi.util.system.isDevFlavor
 import eu.kanade.tachiyomi.util.system.isPreviewBuildType
 import eu.kanade.tachiyomi.util.system.isShizukuInstalled
@@ -350,26 +350,15 @@ object SettingsAdvancedScreen : SearchableSettings {
                     pref = basePreferences.alwaysUseSSIVToDecode(),
                     title = stringResource(MR.strings.pref_always_use_ssiv_to_decode),
                 ),
-                Preference.PreferenceItem.EditTextPreference(
-                    pref = maxBitmapSize,
+                Preference.PreferenceItem.SliderPreference(
+                    value = maxBitmap,
+                    min = (GLUtil.maxTextureSize / 2),
+                    max = GLUtil.maxTextureSize,
                     title = stringResource(MR.strings.pref_max_bitmap_size),
-                    subtitle = stringResource(MR.strings.pref_max_bitmap_size_summary),
+                    steps = 5,
                     onValueChanged = {
-                        if (it.isDigitsOnly() && it <= maxBitmapSize.defaultValue()) {
-                            context.toast(MR.strings.pref_max_bitmap_size_success)
-                        } else {
-                            context.toast(MR.strings.pref_max_bitmap_size_error)
-                            return@EditTextPreference false
-                        }
+                        maxBitmapSize.set(it)
                         true
-                    },
-                ),
-                Preference.PreferenceItem.TextPreference(
-                    title = stringResource(MR.strings.pref_max_bitmap_size_reset),
-                    enabled = remember(maxBitmap) { maxBitmap != maxBitmapSize.defaultValue() },
-                    onClick = {
-                        maxBitmapSize.delete()
-                        context.toast(MR.strings.pref_max_bitmap_size_success)
                     },
                 ),
             ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.core.net.toUri
+import androidx.core.text.isDigitsOnly
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.base.BasePreferences
@@ -331,6 +332,10 @@ object SettingsAdvancedScreen : SearchableSettings {
                 basePreferences.displayProfile().set(uri.toString())
             }
         }
+
+        val maxBitmapSize = basePreferences.maxBitmapSize()
+        val maxBitmap by maxBitmapSize.collectAsState()
+
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_reader),
             preferenceItems = persistentListOf(
@@ -345,9 +350,27 @@ object SettingsAdvancedScreen : SearchableSettings {
                     pref = basePreferences.alwaysUseSSIVToDecode(),
                     title = stringResource(MR.strings.pref_always_use_ssiv_to_decode),
                 ),
-                Preference.PreferenceItem.SwitchPreference(
-                    pref = basePreferences.fallbackForLongStrips(),
-                    title = stringResource(MR.strings.pref_fallback_for_long_strips),
+                Preference.PreferenceItem.EditTextPreference(
+                    pref = maxBitmapSize,
+                    title = stringResource(MR.strings.pref_max_bitmap_size),
+                    subtitle = stringResource(MR.strings.pref_max_bitmap_size_summary),
+                    onValueChanged = {
+                        if (it.isDigitsOnly() && it <= maxBitmapSize.defaultValue()) {
+                            context.toast(MR.strings.pref_max_bitmap_size_success)
+                        } else {
+                            context.toast(MR.strings.pref_max_bitmap_size_error)
+                            return@EditTextPreference false
+                        }
+                        true
+                    },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_max_bitmap_size_reset),
+                    enabled = remember(maxBitmap) { maxBitmap != maxBitmapSize.defaultValue() },
+                    onClick = {
+                        maxBitmapSize.delete()
+                        context.toast(MR.strings.pref_max_bitmap_size_success)
+                    },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -345,6 +345,10 @@ object SettingsAdvancedScreen : SearchableSettings {
                     pref = basePreferences.alwaysUseSSIVToDecode(),
                     title = stringResource(MR.strings.pref_always_use_ssiv_to_decode),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = basePreferences.fallbackForLongStrips(),
+                    title = stringResource(MR.strings.pref_fallback_for_long_strips),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -30,7 +30,7 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
 
         check(decoder != null && decoder.width > 0 && decoder.height > 0) { "Failed to initialize decoder" }
 
-        val maxBitmapSize by lazy { Injekt.get<BasePreferences>().maxBitmapSize().get().toInt() }
+        val maxBitmapSize by lazy { Injekt.get<BasePreferences>().maxBitmapSize().get() }
 
         val srcWidth = decoder.width
         val srcHeight = decoder.height

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/TachiyomiImageDecoder.kt
@@ -50,14 +50,13 @@ class TachiyomiImageDecoder(private val resources: ImageSource, private val opti
         decoder.recycle()
 
         check(bitmap != null) { "Failed to decode image" }
-
+     
         if (
             options.bitmapConfig == Bitmap.Config.HARDWARE &&
             maxOf(bitmap.width, bitmap.height) <= GLUtil.maxTextureSize
         ) {
             if (
-                bitmap.height*1.1 <= GLUtil.maxTextureSize &&
-                bitmap.width < 1100 || !fallbackForLongStrips
+                !fallbackForLongStrips || bitmap.width < dstWidth && bitmap.height*1.1 <= GLUtil.maxTextureSize
             ) {
                 val hwBitmap = bitmap.copy(Bitmap.Config.HARDWARE, false)
                 if (hwBitmap != null) {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -393,11 +393,7 @@
     <string name="pref_show_reading_mode_summary">Briefly show current mode when reader is opened</string>
     <string name="pref_display_profile">Custom display profile</string>
     <string name="pref_always_use_ssiv_to_decode">Always use SSIV to decode long strip images</string>
-    <string name="pref_max_bitmap_size">Set maximum height for HW bitmaps</string>
-    <string name="pref_max_bitmap_size_summary">Software bitmaps are used for big images</string>
-    <string name="pref_max_bitmap_size_success">Changed the maximum height for bitmaps</string>
-    <string name="pref_max_bitmap_size_error">Input a number equal or lower than default</string>
-    <string name="pref_max_bitmap_size_reset">Restore the maximum height for bitmaps</string>
+    <string name="pref_max_bitmap_size">Bitmap height</string>
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Custom brightness</string>
     <string name="pref_grayscale">Grayscale</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -393,6 +393,7 @@
     <string name="pref_show_reading_mode_summary">Briefly show current mode when reader is opened</string>
     <string name="pref_display_profile">Custom display profile</string>
     <string name="pref_always_use_ssiv_to_decode">Always use SSIV to decode long strip images</string>
+    <string name="pref_fallback_for_long_strips">Fallback to software when loading long vertical strips</string>
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Custom brightness</string>
     <string name="pref_grayscale">Grayscale</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -393,7 +393,11 @@
     <string name="pref_show_reading_mode_summary">Briefly show current mode when reader is opened</string>
     <string name="pref_display_profile">Custom display profile</string>
     <string name="pref_always_use_ssiv_to_decode">Always use SSIV to decode long strip images</string>
-    <string name="pref_fallback_for_long_strips">Fallback to software when loading long vertical strips</string>
+    <string name="pref_max_bitmap_size">Set maximum height for HW bitmaps</string>
+    <string name="pref_max_bitmap_size_summary">Software bitmaps are used for big images</string>
+    <string name="pref_max_bitmap_size_success">Changed the maximum height for bitmaps</string>
+    <string name="pref_max_bitmap_size_error">Input a number equal or lower than default</string>
+    <string name="pref_max_bitmap_size_reset">Restore the maximum height for bitmaps</string>
     <string name="pref_crop_borders">Crop borders</string>
     <string name="pref_custom_brightness">Custom brightness</string>
     <string name="pref_grayscale">Grayscale</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -171,6 +171,7 @@ fun SliderItem(
     onChange: (Int) -> Unit,
     max: Int,
     min: Int = 0,
+    steps: Int = 0,
 ) {
     val haptic = LocalHapticFeedback.current
 
@@ -195,6 +196,7 @@ fun SliderItem(
         Slider(
             modifier = Modifier.weight(1.5f),
             value = value,
+            steps = steps,
             onValueChange = f@{
                 if (it == value) return@f
                 onChange(it)


### PR DESCRIPTION
Allow users to configure a new value that will override maxTextureSize when deciding if a software bitmap should be replaced by a hardware one after being decoded, to prevent textures from failing on older devices. Default is maxTextureSize since that works for most people.

Fix #1436 with a better approach than #1440 since it's all up to the user. It references the way the user-agent setting is set, so if there's anything that should be changed or streamlined in the code I'm all ears.

The issue of blanks and flickering:

https://github.com/user-attachments/assets/a7286d96-2c6b-4281-8a79-56d15e950a22

What the setting looks like and how it works:

https://github.com/user-attachments/assets/70cc1832-54e3-4833-8b21-7fb6124dc77e