### PR TITLE
fix: reader's transition dark/light theme was wrong in auto mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -15,6 +15,7 @@ import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import com.hippo.unifile.UniFile
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.base.delegate.ThemingDelegate
@@ -107,9 +108,13 @@ fun Context.createFileInCacheDir(name: String): File {
 fun Context.createReaderThemeContext(): Context {
     val preferences = Injekt.get<UiPreferences>()
     val readerPreferences = Injekt.get<ReaderPreferences>()
+    val themeMode = preferences.themeMode().get()
     val isDarkBackground = when (readerPreferences.readerTheme().get()) {
         1, 2 -> true // Black, Gray
-        3 -> applicationContext.isNightMode() // Automatic bg uses activity background by default
+        3 -> when (themeMode) { // Automatic bg uses activity background by default
+            ThemeMode.SYSTEM -> applicationContext.isNightMode()
+            else -> themeMode == ThemeMode.DARK
+        }
         else -> false // White
     }
     val expected = if (isDarkBackground) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO


### PR DESCRIPTION
#### Reproduce:
1. Set Reader's background color mode to *Auto*
2. System is in Light mode, App theme is in Dark mode; OR System is in Light mode, App theme is in Dark mode

#### This happens
![image](https://github.com/user-attachments/assets/1ef14e2d-af9b-40e0-9ffc-5cf5efcfade5)
![image](https://github.com/user-attachments/assets/4ae2f49a-135d-4799-8261-54f67c17c32f)
