### PR TITLE
Add weird Honor app to list of invalid browsers

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
@@ -64,6 +64,7 @@ object DeviceUtil {
 
     val invalidDefaultBrowsers = listOf(
         "android",
+        "com.hihonor.android.internal.app",
         "com.huawei.android.internal.app",
         "com.zui.resolver",
     )


### PR DESCRIPTION
Closes #1348.

Specifically adds com.hihonor.android.internal.app to the list of invalid browsers. It's very similar to the existing entry for Huawei, so it stands to reason it is the same/similar problem as with Huawei's internal app.