### PR TITLE
Include Coil's broken hardware bitmap device list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
   - Switch to hardware bitmap in reader only if device can handle it ([@AntsyLich](https://github.com/AntsyLich)) ([`e6d96bd`](https://github.com/mihonapp/mihon/commit/e6d96bd348ea5d18a005d6465222ad5f5123103e))
   - Add option to lower the threshold for hardware bitmaps ([@AntsyLich](https://github.com/AntsyLich)) ([`dcddac5`](https://github.com/mihonapp/mihon/commit/dcddac5daaff3ec89c8507c35dc13d345ffdb6d7))
     - Improve hardware bitmap threshold option ([@AntsyLich](https://github.com/AntsyLich)) ([`d6dfd24`](https://github.com/mihonapp/mihon/commit/d6dfd24548eaa05a8c3e478068fe2e08f2ee4473))
-  - Always use software birmap in number of devices ([@MajorTanya](https://github.com/MajorTanya)) ([#1543](https://github.com/mihonapp/mihon/pull/1543))
+  - Always use software bitmap on certain devices ([@MajorTanya](https://github.com/MajorTanya)) ([#1543](https://github.com/mihonapp/mihon/pull/1543))
 - Fix crash after removing last category while it's active in library ([@cuong-tran](https://github.com/cuong-tran)) ([#1450](https://github.com/mihonapp/mihon/pull/1450))
 - Fix reader transition color scheme in auto background mode ([@cuong-tran](https://github.com/cuong-tran)) ([#1487](https://github.com/mihonapp/mihon/pull/1487))
 - Fix app update error notification disappearing ([@cuong-tran](https://github.com/cuong-tran)) ([#1476](https://github.com/mihonapp/mihon/pull/1476))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Changed
 - Bump default user agent ([@AntsyLich](https://github.com/AntsyLich)) ([`76dcf90`](https://github.com/mihonapp/mihon/commit/76dcf903403d565056f44c66d965c1ea8affffc3))
-- Hide Hardware Bitmap Threshold setting on devices with broken hardware bitmap implementations ([@MajorTanya](https://github.com/MajorTanya)) ([#1543](https://github.com/mihonapp/mihon/pull/1543))
 
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))
@@ -26,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
   - Switch to hardware bitmap in reader only if device can handle it ([@AntsyLich](https://github.com/AntsyLich)) ([`e6d96bd`](https://github.com/mihonapp/mihon/commit/e6d96bd348ea5d18a005d6465222ad5f5123103e))
   - Add option to lower the threshold for hardware bitmaps ([@AntsyLich](https://github.com/AntsyLich)) ([`dcddac5`](https://github.com/mihonapp/mihon/commit/dcddac5daaff3ec89c8507c35dc13d345ffdb6d7))
     - Improve hardware bitmap threshold option ([@AntsyLich](https://github.com/AntsyLich)) ([`d6dfd24`](https://github.com/mihonapp/mihon/commit/d6dfd24548eaa05a8c3e478068fe2e08f2ee4473))
+  - Always use software birmap in number of devices ([@MajorTanya](https://github.com/MajorTanya)) ([#1543](https://github.com/mihonapp/mihon/pull/1543))
 - Fix crash after removing last category while it's active in library ([@cuong-tran](https://github.com/cuong-tran)) ([#1450](https://github.com/mihonapp/mihon/pull/1450))
 - Fix reader transition color scheme in auto background mode ([@cuong-tran](https://github.com/cuong-tran)) ([#1487](https://github.com/mihonapp/mihon/pull/1487))
 - Fix app update error notification disappearing ([@cuong-tran](https://github.com/cuong-tran)) ([#1476](https://github.com/mihonapp/mihon/pull/1476))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Changed
 - Bump default user agent ([@AntsyLich](https://github.com/AntsyLich)) ([`76dcf90`](https://github.com/mihonapp/mihon/commit/76dcf903403d565056f44c66d965c1ea8affffc3))
+- Hide Hardware Bitmap Threshold setting on devices with broken hardware bitmap implementations ([@MajorTanya](https://github.com/MajorTanya)) ([#1543](https://github.com/mihonapp/mihon/pull/1543))
 
 ### Improved
 - Bangumi search now shows the score and summary of a search result ([@MajorTanya](https://github.com/MajorTanya)) ([#1396](https://github.com/mihonapp/mihon/pull/1396))

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -62,6 +62,7 @@ import logcat.LogPriority
 import okhttp3.Headers
 import tachiyomi.core.common.util.lang.launchNonCancellable
 import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
 import tachiyomi.i18n.MR
@@ -341,7 +342,8 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitleProvider = { value, options ->
                         stringResource(MR.strings.pref_hardware_bitmap_threshold_summary, options[value].orEmpty())
                     },
-                    enabled = GLUtil.DEVICE_TEXTURE_LIMIT > GLUtil.SAFE_TEXTURE_LIMIT,
+                    enabled = ImageUtil.HARDWARE_BITMAP_UNSUPPORTED ||
+                        GLUtil.DEVICE_TEXTURE_LIMIT > GLUtil.SAFE_TEXTURE_LIMIT,
                     entries = GLUtil.CUSTOM_TEXTURE_LIMIT_OPTIONS
                         .mapIndexed { index, option ->
                             val display = if (index == 0) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -342,7 +342,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitleProvider = { value, options ->
                         stringResource(MR.strings.pref_hardware_bitmap_threshold_summary, options[value].orEmpty())
                     },
-                    enabled = !ImageUtil.HARDWARE_BITMAP_UNSUPPORTED ||
+                    enabled = !ImageUtil.HARDWARE_BITMAP_UNSUPPORTED &&
                         GLUtil.DEVICE_TEXTURE_LIMIT > GLUtil.SAFE_TEXTURE_LIMIT,
                     entries = GLUtil.CUSTOM_TEXTURE_LIMIT_OPTIONS
                         .mapIndexed { index, option ->

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -342,7 +342,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitleProvider = { value, options ->
                         stringResource(MR.strings.pref_hardware_bitmap_threshold_summary, options[value].orEmpty())
                     },
-                    enabled = ImageUtil.HARDWARE_BITMAP_UNSUPPORTED ||
+                    enabled = !ImageUtil.HARDWARE_BITMAP_UNSUPPORTED ||
                         GLUtil.DEVICE_TEXTURE_LIMIT > GLUtil.SAFE_TEXTURE_LIMIT,
                     entries = GLUtil.CUSTOM_TEXTURE_LIMIT_OPTIONS
                         .mapIndexed { index, option ->

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -573,122 +573,122 @@ object ImageUtil {
     }
 
     private val optimalImageHeight = getDisplayMaxHeightInPx * 2
+
+    /**
+     * Taken from Coil
+     * (https://github.com/coil-kt/coil/blob/1674d3516f061aeacbe749a435b1924f9648fd41/coil-core/src/androidMain/kotlin/coil3/util/hardwareBitmaps.kt)
+     * ---
+     * Maintains a list of devices with broken/incomplete/unstable hardware bitmap implementations.
+     *
+     * Model names are retrieved from
+     * [Google's official device list](https://support.google.com/googleplay/answer/1727131?hl=en).
+     *
+     */
+    val HARDWARE_BITMAP_UNSUPPORTED = when (Build.VERSION.SDK_INT) {
+        26 -> run {
+            val model = Build.MODEL ?: return@run false
+
+            // Samsung Galaxy (ALL)
+            if (model.removePrefix("SAMSUNG-").startsWith("SM-")) return@run true
+
+            val device = Build.DEVICE ?: return@run false
+
+            return@run device in arrayOf(
+                "nora", "nora_8917", "nora_8917_n", // Moto E5
+                "james", "rjames_f", "rjames_go", "pettyl", // Moto E5 Play
+                "hannah", "ahannah", "rhannah", // Moto E5 Plus
+
+                "ali", "ali_n", // Moto G6
+                "aljeter", "aljeter_n", "jeter", // Moto G6 Play
+                "evert", "evert_n", "evert_nt", // Moto G6 Plus
+
+                "G3112", "G3116", "G3121", "G3123", "G3125", // Xperia XA1
+                "G3412", "G3416", "G3421", "G3423", "G3426", // Xperia XA1 Plus
+                "G3212", "G3221", "G3223", "G3226", // Xperia XA1 Ultra
+
+                "BV6800Pro", // BlackView BV6800Pro
+                "CatS41", // Cat S41
+                "Hi9Pro", // CHUWI Hi9 Pro
+                "manning", // Lenovo K8 Note
+                "N5702L", // NUU Mobile G3
+            )
+        }
+
+        27 -> run {
+            val device = Build.DEVICE ?: return@run false
+
+            return@run device in arrayOf(
+                "mcv1s", // LG Tribute Empire
+                "mcv3", // LG K11
+                "mcv5a", // LG Q7
+                "mcv7a", // LG Stylo 4
+
+                "A30ATMO", // T-Mobile REVVL 2
+                "A70AXLTMO", // T-Mobile REVVL 2 PLUS
+
+                "A3A_8_4G_TMO", // Alcatel 9027W
+                "Edison_CKT", // Alcatel ONYX
+                "EDISON_TF", // Alcatel TCL XL2
+                "FERMI_TF", // Alcatel A501DL
+                "U50A_ATT", // Alcatel TETRA
+                "U50A_PLUS_ATT", // Alcatel 5059R
+                "U50A_PLUS_TF", // Alcatel TCL LX
+                "U50APLUSTMO", // Alcatel 5059Z
+                "U5A_PLUS_4G", // Alcatel 1X
+
+                "RCT6513W87DK5e", // RCA Galileo Pro
+                "RCT6873W42BMF9A", // RCA Voyager
+                "RCT6A03W13", // RCA 10 Viking
+                "RCT6B03W12", // RCA Atlas 10 Pro
+                "RCT6B03W13", // RCA Atlas 10 Pro+
+                "RCT6T06E13", // RCA Artemis 10
+
+                "A3_Pro", // Umidigi A3 Pro
+                "One", // Umidigi One
+                "One_Max", // Umidigi One Max
+                "One_Pro", // Umidigi One Pro
+                "Z2", // Umidigi Z2
+                "Z2_PRO", // Umidigi Z2 Pro
+
+                "Armor_3", // Ulefone Armor 3
+                "Armor_6", // Ulefone Armor 6
+
+                "Blackview", // Blackview BV6000
+                "BV9500", // Blackview BV9500
+                "BV9500Pro", // Blackview BV9500Pro
+
+                "A6L-C", // Nuu A6L-C
+                "N5002LA", // Nuu A7L
+                "N5501LA", // Nuu A5L
+
+                "Power_2_Pro", // Leagoo Power 2 Pro
+                "Power_5", // Leagoo Power 5
+                "Z9", // Leagoo Z9
+
+                "V0310WW", // Blu VIVO VI+
+                "V0330WW", // Blu VIVO XI
+
+                "A3", // BenQ A3
+                "ASUS_X018_4", // Asus ZenFone Max Plus M1 (ZB570TL)
+                "C210AE", // Wiko Life
+                "fireball", // DROID Incredible 4G LTE
+                "ILA_X1", // iLA X1
+                "Infinix-X605_sprout", // Infinix NOTE 5 Stylus
+                "j7maxlte", // Samsung Galaxy J7 Max
+                "KING_KONG_3", // Cubot King Kong 3
+                "M10500", // Packard Bell M10500
+                "S70", // Altice ALTICE S70
+                "S80Lite", // Doogee S80Lite
+                "SGINO6", // SGiNO 6
+                "st18c10bnn", // Barnes and Noble BNTV650
+                "TECNO-CA8", // Tecno CAMON X Pro,
+                "SHIFT6m", // SHIFT 6m
+            )
+        }
+
+        else -> false
+    }
 }
 
 val getDisplayMaxHeightInPx: Int
     get() = Resources.getSystem().displayMetrics.let { max(it.heightPixels, it.widthPixels) }
-
-/**
- * Taken from Coil
- * (https://github.com/coil-kt/coil/blob/1674d3516f061aeacbe749a435b1924f9648fd41/coil-core/src/androidMain/kotlin/coil3/util/hardwareBitmaps.kt)
- * ---
- * Maintains a list of devices with broken/incomplete/unstable hardware bitmap implementations.
- *
- * Model names are retrieved from
- * [Google's official device list](https://support.google.com/googleplay/answer/1727131?hl=en).
- *
- */
-private val HARDWARE_BITMAP_UNSUPPORTED = when (Build.VERSION.SDK_INT) {
-    26 -> run {
-        val model = Build.MODEL ?: return@run false
-
-        // Samsung Galaxy (ALL)
-        if (model.removePrefix("SAMSUNG-").startsWith("SM-")) return@run true
-
-        val device = Build.DEVICE ?: return@run false
-
-        return@run device in arrayOf(
-            "nora", "nora_8917", "nora_8917_n", // Moto E5
-            "james", "rjames_f", "rjames_go", "pettyl", // Moto E5 Play
-            "hannah", "ahannah", "rhannah", // Moto E5 Plus
-
-            "ali", "ali_n", // Moto G6
-            "aljeter", "aljeter_n", "jeter", // Moto G6 Play
-            "evert", "evert_n", "evert_nt", // Moto G6 Plus
-
-            "G3112", "G3116", "G3121", "G3123", "G3125", // Xperia XA1
-            "G3412", "G3416", "G3421", "G3423", "G3426", // Xperia XA1 Plus
-            "G3212", "G3221", "G3223", "G3226", // Xperia XA1 Ultra
-
-            "BV6800Pro", // BlackView BV6800Pro
-            "CatS41", // Cat S41
-            "Hi9Pro", // CHUWI Hi9 Pro
-            "manning", // Lenovo K8 Note
-            "N5702L", // NUU Mobile G3
-        )
-    }
-
-    27 -> run {
-        val device = Build.DEVICE ?: return@run false
-
-        return@run device in arrayOf(
-            "mcv1s", // LG Tribute Empire
-            "mcv3", // LG K11
-            "mcv5a", // LG Q7
-            "mcv7a", // LG Stylo 4
-
-            "A30ATMO", // T-Mobile REVVL 2
-            "A70AXLTMO", // T-Mobile REVVL 2 PLUS
-
-            "A3A_8_4G_TMO", // Alcatel 9027W
-            "Edison_CKT", // Alcatel ONYX
-            "EDISON_TF", // Alcatel TCL XL2
-            "FERMI_TF", // Alcatel A501DL
-            "U50A_ATT", // Alcatel TETRA
-            "U50A_PLUS_ATT", // Alcatel 5059R
-            "U50A_PLUS_TF", // Alcatel TCL LX
-            "U50APLUSTMO", // Alcatel 5059Z
-            "U5A_PLUS_4G", // Alcatel 1X
-
-            "RCT6513W87DK5e", // RCA Galileo Pro
-            "RCT6873W42BMF9A", // RCA Voyager
-            "RCT6A03W13", // RCA 10 Viking
-            "RCT6B03W12", // RCA Atlas 10 Pro
-            "RCT6B03W13", // RCA Atlas 10 Pro+
-            "RCT6T06E13", // RCA Artemis 10
-
-            "A3_Pro", // Umidigi A3 Pro
-            "One", // Umidigi One
-            "One_Max", // Umidigi One Max
-            "One_Pro", // Umidigi One Pro
-            "Z2", // Umidigi Z2
-            "Z2_PRO", // Umidigi Z2 Pro
-
-            "Armor_3", // Ulefone Armor 3
-            "Armor_6", // Ulefone Armor 6
-
-            "Blackview", // Blackview BV6000
-            "BV9500", // Blackview BV9500
-            "BV9500Pro", // Blackview BV9500Pro
-
-            "A6L-C", // Nuu A6L-C
-            "N5002LA", // Nuu A7L
-            "N5501LA", // Nuu A5L
-
-            "Power_2_Pro", // Leagoo Power 2 Pro
-            "Power_5", // Leagoo Power 5
-            "Z9", // Leagoo Z9
-
-            "V0310WW", // Blu VIVO VI+
-            "V0330WW", // Blu VIVO XI
-
-            "A3", // BenQ A3
-            "ASUS_X018_4", // Asus ZenFone Max Plus M1 (ZB570TL)
-            "C210AE", // Wiko Life
-            "fireball", // DROID Incredible 4G LTE
-            "ILA_X1", // iLA X1
-            "Infinix-X605_sprout", // Infinix NOTE 5 Stylus
-            "j7maxlte", // Samsung Galaxy J7 Max
-            "KING_KONG_3", // Cubot King Kong 3
-            "M10500", // Packard Bell M10500
-            "S70", // Altice ALTICE S70
-            "S80Lite", // Doogee S80Lite
-            "SGINO6", // SGiNO 6
-            "st18c10bnn", // Barnes and Noble BNTV650
-            "TECNO-CA8", // Tecno CAMON X Pro,
-            "SHIFT6m", // SHIFT 6m
-        )
-    }
-
-    else -> false
-}

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -323,6 +323,7 @@ object ImageUtil {
     var hardwareBitmapThreshold: Int = GLUtil.SAFE_TEXTURE_LIMIT
 
     private fun canUseHardwareBitmap(width: Int, height: Int): Boolean {
+        if (HARDWARE_BITMAP_UNSUPPORTED) return false
         return maxOf(width, height) <= hardwareBitmapThreshold
     }
 
@@ -576,3 +577,118 @@ object ImageUtil {
 
 val getDisplayMaxHeightInPx: Int
     get() = Resources.getSystem().displayMetrics.let { max(it.heightPixels, it.widthPixels) }
+
+/**
+ * Taken from Coil
+ * (https://github.com/coil-kt/coil/blob/1674d3516f061aeacbe749a435b1924f9648fd41/coil-core/src/androidMain/kotlin/coil3/util/hardwareBitmaps.kt)
+ * ---
+ * Maintains a list of devices with broken/incomplete/unstable hardware bitmap implementations.
+ *
+ * Model names are retrieved from
+ * [Google's official device list](https://support.google.com/googleplay/answer/1727131?hl=en).
+ *
+ */
+private val HARDWARE_BITMAP_UNSUPPORTED = when (Build.VERSION.SDK_INT) {
+    26 -> run {
+        val model = Build.MODEL ?: return@run false
+
+        // Samsung Galaxy (ALL)
+        if (model.removePrefix("SAMSUNG-").startsWith("SM-")) return@run true
+
+        val device = Build.DEVICE ?: return@run false
+
+        return@run device in arrayOf(
+            "nora", "nora_8917", "nora_8917_n", // Moto E5
+            "james", "rjames_f", "rjames_go", "pettyl", // Moto E5 Play
+            "hannah", "ahannah", "rhannah", // Moto E5 Plus
+
+            "ali", "ali_n", // Moto G6
+            "aljeter", "aljeter_n", "jeter", // Moto G6 Play
+            "evert", "evert_n", "evert_nt", // Moto G6 Plus
+
+            "G3112", "G3116", "G3121", "G3123", "G3125", // Xperia XA1
+            "G3412", "G3416", "G3421", "G3423", "G3426", // Xperia XA1 Plus
+            "G3212", "G3221", "G3223", "G3226", // Xperia XA1 Ultra
+
+            "BV6800Pro", // BlackView BV6800Pro
+            "CatS41", // Cat S41
+            "Hi9Pro", // CHUWI Hi9 Pro
+            "manning", // Lenovo K8 Note
+            "N5702L", // NUU Mobile G3
+        )
+    }
+
+    27 -> run {
+        val device = Build.DEVICE ?: return@run false
+
+        return@run device in arrayOf(
+            "mcv1s", // LG Tribute Empire
+            "mcv3", // LG K11
+            "mcv5a", // LG Q7
+            "mcv7a", // LG Stylo 4
+
+            "A30ATMO", // T-Mobile REVVL 2
+            "A70AXLTMO", // T-Mobile REVVL 2 PLUS
+
+            "A3A_8_4G_TMO", // Alcatel 9027W
+            "Edison_CKT", // Alcatel ONYX
+            "EDISON_TF", // Alcatel TCL XL2
+            "FERMI_TF", // Alcatel A501DL
+            "U50A_ATT", // Alcatel TETRA
+            "U50A_PLUS_ATT", // Alcatel 5059R
+            "U50A_PLUS_TF", // Alcatel TCL LX
+            "U50APLUSTMO", // Alcatel 5059Z
+            "U5A_PLUS_4G", // Alcatel 1X
+
+            "RCT6513W87DK5e", // RCA Galileo Pro
+            "RCT6873W42BMF9A", // RCA Voyager
+            "RCT6A03W13", // RCA 10 Viking
+            "RCT6B03W12", // RCA Atlas 10 Pro
+            "RCT6B03W13", // RCA Atlas 10 Pro+
+            "RCT6T06E13", // RCA Artemis 10
+
+            "A3_Pro", // Umidigi A3 Pro
+            "One", // Umidigi One
+            "One_Max", // Umidigi One Max
+            "One_Pro", // Umidigi One Pro
+            "Z2", // Umidigi Z2
+            "Z2_PRO", // Umidigi Z2 Pro
+
+            "Armor_3", // Ulefone Armor 3
+            "Armor_6", // Ulefone Armor 6
+
+            "Blackview", // Blackview BV6000
+            "BV9500", // Blackview BV9500
+            "BV9500Pro", // Blackview BV9500Pro
+
+            "A6L-C", // Nuu A6L-C
+            "N5002LA", // Nuu A7L
+            "N5501LA", // Nuu A5L
+
+            "Power_2_Pro", // Leagoo Power 2 Pro
+            "Power_5", // Leagoo Power 5
+            "Z9", // Leagoo Z9
+
+            "V0310WW", // Blu VIVO VI+
+            "V0330WW", // Blu VIVO XI
+
+            "A3", // BenQ A3
+            "ASUS_X018_4", // Asus ZenFone Max Plus M1 (ZB570TL)
+            "C210AE", // Wiko Life
+            "fireball", // DROID Incredible 4G LTE
+            "ILA_X1", // iLA X1
+            "Infinix-X605_sprout", // Infinix NOTE 5 Stylus
+            "j7maxlte", // Samsung Galaxy J7 Max
+            "KING_KONG_3", // Cubot King Kong 3
+            "M10500", // Packard Bell M10500
+            "S70", // Altice ALTICE S70
+            "S80Lite", // Doogee S80Lite
+            "SGINO6", // SGiNO 6
+            "st18c10bnn", // Barnes and Noble BNTV650
+            "TECNO-CA8", // Tecno CAMON X Pro,
+            "SHIFT6m", // SHIFT 6m
+        )
+    }
+
+    else -> false
+}


### PR DESCRIPTION
Declares all listed devices as unable to use hardware bitmaps and hides the Hardware Bitmap Threshold setting on all such devices.

Might fix #1541.