### PR TITLE
Fix MAL manga cover nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 - Add option to always decode long strip images with SSIV
 
+### Fixed
+- Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))
+
 ## [v0.17.1] - 2024-12-06
 ### Changed
 - Bump default user agent ([@AntsyLich](https://github.com/AntsyLich)) ([`76dcf90`](https://github.com/mihonapp/mihon/commit/76dcf903403d565056f44c66d965c1ea8affffc3))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -111,7 +111,7 @@ class MyAnimeListApi(
                             summary = it.synopsis
                             total_chapters = it.numChapters
                             score = it.mean
-                            cover_url = it.covers.large
+                            cover_url = it.covers?.large.orEmpty()
                             tracking_url = "https://myanimelist.net/manga/$remote_id"
                             publishing_status = it.status.replace("_", " ")
                             publishing_type = it.mediaType.replace("_", " ")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
@@ -12,7 +12,7 @@ data class MALManga(
     val numChapters: Long,
     val mean: Double = -1.0,
     @SerialName("main_picture")
-    val covers: MALMangaCovers,
+    val covers: MALMangaCovers?,
     val status: String,
     @SerialName("media_type")
     val mediaType: String,


### PR DESCRIPTION
If a manga doesn't have a cover, MAL doesn't provide the `main_picture` element in the API response at all.

The long-unwanted sequel to the DTO migration fuckup saga. Please let this be the last one.