### PR TITLE
Fix Bangumi tracking losing track of login state

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiInterceptor.kt
@@ -21,12 +21,13 @@ class BangumiInterceptor(private val bangumi: Bangumi) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
-        val currAuth = oauth ?: throw Exception("Not authenticated with Bangumi")
+        var currAuth: BGMOAuth = oauth ?: throw Exception("Not authenticated with Bangumi")
 
         if (currAuth.isExpired()) {
             val response = chain.proceed(BangumiApi.refreshTokenRequest(currAuth.refreshToken!!))
             if (response.isSuccessful) {
-                newAuth(json.decodeFromString<BGMOAuth>(response.body.string()))
+                currAuth = json.decodeFromString<BGMOAuth>(response.body.string())
+                newAuth(currAuth)
             } else {
                 response.close()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMOAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMOAuth.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.track.bangumi.dto
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,6 +11,7 @@ data class BGMOAuth(
     @SerialName("token_type")
     val tokenType: String,
     @SerialName("created_at")
+    @EncodeDefault
     val createdAt: Long = System.currentTimeMillis() / 1000,
     @SerialName("expires_in")
     val expiresIn: Long,


### PR DESCRIPTION
kotlinx.serialization does NOT serialize default values (like createdAt in BGMOAuth.kt), so every time the Bangumi tracker deserialized the tracker OAuth, createdAt was set to the time of the read, not the time of issuance.

Separately, BangumiInterceptor did correctly fetch new OAuth credentials upon detected expiry of the stored credentials and saved them, but did not use them for the current request (the new credentials were used for all subsequent requests only). This led to 401 errors from Bangumi because the expired access_token was provided.
 A subsequent request using the newly acquired access_token would end
 up being successful.

Some version or another of this bug has been around since before #1103 so for once it's not me breaking things. 😅 