### PR TITLE
Add missing @EncodeDefault annotation to MALOAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))
-- Fix Bangumi tracking 401 errors due to Mihon sending expired credentials ([@MajorTanya](https://github.com/MajorTanya)) ([#1681](https://github.com/mihonapp/mihon/pull/1681))
+- Fix Bangumi and MAL tracking 401 errors due to Mihon sending expired credentials ([@MajorTanya](https://github.com/MajorTanya)) ([#1681](https://github.com/mihonapp/mihon/pull/1681), [#1682](https://github.com/mihonapp/mihon/pull/1682))
 
 ### Other
 - Add zoned "Current time" to debug info and include year & timezone in logcat output ([@MajorTanya](https://github.com/MajorTanya)) ([#1672](https://github.com/mihonapp/mihon/pull/1672))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.data.track.myanimelist.dto
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,10 +15,11 @@ data class MALOAuth(
     @SerialName("expires_in")
     val expiresIn: Long,
     @SerialName("created_at")
-    val createdAt: Long = System.currentTimeMillis(),
+    @EncodeDefault
+    val createdAt: Long = System.currentTimeMillis() / 1000,
 ) {
     // Assumes expired a minute earlier
-    private val adjustedExpiresIn: Long = (expiresIn - 60) * 1000
+    private val adjustedExpiresIn: Long = (expiresIn - 60)
 
-    fun isExpired() = createdAt + adjustedExpiresIn < System.currentTimeMillis()
+    fun isExpired() = createdAt + adjustedExpiresIn < System.currentTimeMillis() / 1000
 }


### PR DESCRIPTION
Similar to the situation with Bangumi, the missing annotation means [kotlinx.serialization would _provide_ the default value upon instantiation but not serialise it to disk](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/basic-serialization.md#defaults-are-not-encoded-by-default). This means the isExpired() calculation would effectively rarely/never do its job correctly, leading to Mihon sending expired tokens to MAL and causing problems for everyone involved.

Overall, this change _could_ (should) lead to a drastic reduction in MAL requests failing, leading to users having to relink their MAL accounts.

Also switched createdAt to be in seconds instead of milliseconds as all other trackers use seconds for timestamps (except for AniList, which uses milliseconds but doesn't use a createdAt timestamp anyway).

MIGHT solve the underlying issues of #724, #1065, and probably others I can't find right now.