### PR TITLE
Add Infinix system app to list of invalid browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))
 - Fix Bangumi and MAL tracking 401 errors due to Mihon sending expired credentials ([@MajorTanya](https://github.com/MajorTanya)) ([#1681](https://github.com/mihonapp/mihon/pull/1681), [#1682](https://github.com/mihonapp/mihon/pull/1682))
+- Fix certain Infinix devices being unable to use any "Open link in browser" actions, including tracker setup ([@MajorTanya](https://github.com/MajorTanya)) ([#1684](https://github.com/mihonapp/mihon/pull/1684))
 
 ### Other
 - Add zoned "Current time" to debug info and include year & timezone in logcat output ([@MajorTanya](https://github.com/MajorTanya)) ([#1672](https://github.com/mihonapp/mihon/pull/1672))

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
@@ -62,11 +62,24 @@ object DeviceUtil {
         }
     }
 
+    /**
+     * A list of package names that may be incorrectly resolved as usable browsers by
+     * the system.
+     *
+     * If these are resolved for [android.content.Intent.ACTION_VIEW], it prevents the
+     * system from opening a proper browser or any usable app .
+     *
+     * Some of them may only be present on certain manufacturer's devices.
+     */
     val invalidDefaultBrowsers = listOf(
         "android",
+        // Honor
         "com.hihonor.android.internal.app",
+        // Huawei
         "com.huawei.android.internal.app",
+        // Lenovo
         "com.zui.resolver",
+        // Infinix
         "com.transsion.resolver",
     )
 

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/DeviceUtil.kt
@@ -67,6 +67,7 @@ object DeviceUtil {
         "com.hihonor.android.internal.app",
         "com.huawei.android.internal.app",
         "com.zui.resolver",
+        "com.transsion.resolver",
     )
 
     /**


### PR DESCRIPTION
`com.transsion.resolver` being picked by the system as a suitable browser caused a Mihon user with an Infinix device to be unable to open any links in browsers, including tracker login and opening a WebView page in a real browser.

Filtering this resolver via our list of invalid browsers enabled the system to suggest their Chrome browser instead, making the affected features work again as expected.