### PR TITLE
feat(ui): added a size slider for list display mode

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
@@ -41,6 +41,8 @@ fun BrowseSourceContent(
     source: Source?,
     mangaList: LazyPagingItems<StateFlow<Manga>>,
     columns: GridCells,
+    entries: Int = 0,
+    topBarHeight: Int = 0,
     displayMode: LibraryDisplayMode,
     snackbarHostState: SnackbarHostState,
     contentPadding: PaddingValues,
@@ -129,6 +131,8 @@ fun BrowseSourceContent(
         LibraryDisplayMode.List -> {
             BrowseSourceList(
                 mangaList = mangaList,
+                entries = entries,
+                topBarHeight = topBarHeight,
                 contentPadding = contentPadding,
                 onMangaClick = onMangaClick,
                 onMangaLongClick = onMangaLongClick,

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceList.kt
@@ -5,6 +5,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -18,12 +23,19 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 fun BrowseSourceList(
     mangaList: LazyPagingItems<StateFlow<Manga>>,
+    entries: Int,
+    topBarHeight: Int,
     contentPadding: PaddingValues,
     onMangaClick: (Manga) -> Unit,
     onMangaLongClick: (Manga) -> Unit,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0) }
     LazyColumn(
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
+        modifier = Modifier
+            .onGloballyPositioned { layoutCoordinates ->
+                containerHeight = layoutCoordinates.size.height - topBarHeight
+            },
     ) {
         item {
             if (mangaList.loadState.prepend is LoadState.Loading) {
@@ -37,6 +49,8 @@ fun BrowseSourceList(
                 manga = manga,
                 onClick = { onMangaClick(manga) },
                 onLongClick = { onMangaLongClick(manga) },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
 
@@ -53,6 +67,8 @@ private fun BrowseSourceListItem(
     manga: Manga,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = onClick,
+    entries: Int,
+    containerHeight: Int,
 ) {
     MangaListItem(
         title = manga.title,
@@ -69,5 +85,7 @@ private fun BrowseSourceListItem(
         },
         onLongClick = onLongClick,
         onClick = onClick,
+        entries = entries,
+        containerHeight = containerHeight,
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -36,6 +36,7 @@ import tachiyomi.presentation.core.components.SettingsChipRow
 import tachiyomi.presentation.core.components.SliderItem
 import tachiyomi.presentation.core.components.SortItem
 import tachiyomi.presentation.core.components.TriStateItem
+import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 
@@ -243,17 +244,29 @@ private fun ColumnScope.DisplayPage(
         }
     }
 
-    if (displayMode != LibraryDisplayMode.List) {
-        val configuration = LocalConfiguration.current
-        val columnPreference = remember {
-            if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                screenModel.libraryPreferences.landscapeColumns()
-            } else {
-                screenModel.libraryPreferences.portraitColumns()
-            }
+    val configuration = LocalConfiguration.current
+    val columnPreference = remember {
+        if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            screenModel.libraryPreferences.landscapeColumns()
+        } else {
+            screenModel.libraryPreferences.portraitColumns()
         }
+    }
 
-        val columns by columnPreference.collectAsState()
+    val columns by columnPreference.collectAsState()
+    if (displayMode == LibraryDisplayMode.List) {
+        SliderItem(
+            label = stringResource(MR.strings.pref_library_rows),
+            max = 10,
+            value = columns,
+            valueText = if (columns > 0) {
+                pluralStringResource(MR.plurals.pref_library_entries_in_column, columns, columns)
+            } else {
+                stringResource(MR.strings.label_default)
+            },
+            onChange = columnPreference::set,
+        )
+    } else {
         SliderItem(
             label = stringResource(MR.strings.pref_library_columns),
             max = 10,

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -346,14 +346,13 @@ fun MangaListItem(
         modifier = Modifier
             .selectedBackground(isSelected)
             .height(
-                when (entries)
-                {
+                when (entries) {
                     0 -> 76.dp
                     else -> {
                         val density = LocalDensity.current
                         with(density) { (containerHeight / entries).toDp() } - (3 / entries).dp
                     }
-                }
+                },
             )
             .combinedClickable(
                 onClick = onClick,

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -338,19 +339,30 @@ fun MangaListItem(
     isSelected: Boolean = false,
     coverAlpha: Float = 1f,
     onClickContinueReading: (() -> Unit)? = null,
+    entries: Int = 0,
+    containerHeight: Int = 0,
 ) {
     Row(
         modifier = Modifier
             .selectedBackground(isSelected)
-            .height(56.dp)
+            .height(
+                when (entries)
+                {
+                    0 -> 76.dp
+                    else -> {
+                        val density = LocalDensity.current
+                        with(density) { (containerHeight / entries).toDp() } - (3 / entries).dp
+                    }
+                }
+            )
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick,
             )
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        MangaCover.Square(
+        MangaCover.Book(
             modifier = Modifier
                 .fillMaxHeight()
                 .alpha(coverAlpha),
@@ -361,7 +373,6 @@ fun MangaListItem(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .weight(1f),
-            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             style = MaterialTheme.typography.bodyMedium,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
@@ -17,6 +17,8 @@ import tachiyomi.presentation.core.util.plus
 @Composable
 internal fun LibraryList(
     items: List<LibraryItem>,
+    entries: Int,
+    containerHeight: Int,
     contentPadding: PaddingValues,
     selection: List<LibraryManga>,
     onClick: (LibraryManga) -> Unit,
@@ -69,6 +71,8 @@ internal fun LibraryList(
                 } else {
                     null
                 },
+                entries = entries,
+                containerHeight = containerHeight,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
@@ -43,12 +43,12 @@ fun LibraryPager(
     onLongClickManga: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
 ) {
-    var containerHeight by remember { mutableIntStateOf(0)}
+    var containerHeight by remember { mutableIntStateOf(0) }
     HorizontalPager(
         modifier = Modifier
             .fillMaxSize()
-            .onGloballyPositioned {
-                    layoutCoordinates -> containerHeight = layoutCoordinates.size.height
+            .onGloballyPositioned { layoutCoordinates ->
+                containerHeight = layoutCoordinates.size.height
             },
         state = state,
         verticalAlignment = Alignment.Top,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
@@ -14,8 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import eu.kanade.core.preference.PreferenceMutableState
@@ -41,8 +43,13 @@ fun LibraryPager(
     onLongClickManga: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
 ) {
+    var containerHeight by remember { mutableIntStateOf(0)}
     HorizontalPager(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .onGloballyPositioned {
+                    layoutCoordinates -> containerHeight = layoutCoordinates.size.height
+            },
         state = state,
         verticalAlignment = Alignment.Top,
     ) { page ->
@@ -63,19 +70,16 @@ fun LibraryPager(
         }
 
         val displayMode by getDisplayMode(page)
-        val columns by if (displayMode != LibraryDisplayMode.List) {
-            val configuration = LocalConfiguration.current
-            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-
-            remember(isLandscape) { getColumnsForOrientation(isLandscape) }
-        } else {
-            remember { mutableIntStateOf(0) }
-        }
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        val columns by remember(isLandscape) { getColumnsForOrientation(isLandscape) }
 
         when (displayMode) {
             LibraryDisplayMode.List -> {
                 LibraryList(
                     items = library,
+                    entries = columns,
+                    containerHeight = containerHeight,
                     contentPadding = contentPadding,
                     selection = selectedManga,
                     onClick = onClickManga,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/BaseMangaListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/BaseMangaListItem.kt
@@ -30,8 +30,8 @@ fun BaseMangaListItem(
     Row(
         modifier = modifier
             .clickable(onClick = onClickItem)
-            .height(56.dp)
-            .padding(horizontal = MaterialTheme.padding.medium),
+            .height(76.dp)
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         cover()
@@ -41,9 +41,8 @@ fun BaseMangaListItem(
 }
 
 private val defaultCover: @Composable RowScope.(Manga, () -> Unit) -> Unit = { manga, onClick ->
-    MangaCover.Square(
+    MangaCover.Book(
         modifier = Modifier
-            .padding(vertical = MaterialTheme.padding.small)
             .fillMaxHeight(),
         data = manga,
         onClick = onClick,
@@ -57,7 +56,6 @@ private val defaultContent: @Composable RowScope.(Manga) -> Unit = {
             modifier = Modifier
                 .padding(start = MaterialTheme.padding.medium),
             overflow = TextOverflow.Ellipsis,
-            maxLines = 1,
             style = MaterialTheme.typography.bodyMedium,
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
@@ -122,9 +125,16 @@ data class BrowseSourceScreen(
             assistUrl = (screenModel.source as? HttpSource)?.baseUrl
         }
 
+        var topBarHeight by remember { mutableIntStateOf(0) }
         Scaffold(
             topBar = {
-                Column(modifier = Modifier.background(MaterialTheme.colorScheme.surface)) {
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.surface)
+                        .onGloballyPositioned { layoutCoordinates ->
+                            topBarHeight = layoutCoordinates.size.height
+                        },
+                ) {
                     BrowseSourceToolbar(
                         searchQuery = state.toolbarQuery,
                         onSearchQueryChange = screenModel::setToolbarQuery,
@@ -210,6 +220,8 @@ data class BrowseSourceScreen(
                 source = screenModel.source,
                 mangaList = screenModel.mangaPagerFlowFlow.collectAsLazyPagingItems(),
                 columns = screenModel.getColumnsPreference(LocalConfiguration.current.orientation),
+                entries = screenModel.getColumnsPreferenceForCurrentOrientation(LocalConfiguration.current.orientation),
+                topBarHeight = topBarHeight,
                 displayMode = screenModel.displayMode,
                 snackbarHostState = snackbarHostState,
                 contentPadding = paddingValues,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -134,6 +134,16 @@ class BrowseSourceScreenModel(
         return if (columns == 0) GridCells.Adaptive(128.dp) else GridCells.Fixed(columns)
     }
 
+    // returns the number from the size slider
+    fun getColumnsPreferenceForCurrentOrientation(orientation: Int): Int {
+        val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
+        return if (isLandscape) {
+            libraryPreferences.landscapeColumns()
+        } else {
+            libraryPreferences.portraitColumns()
+        }.get()
+    }
+
     fun resetFilters() {
         if (source !is CatalogueSource) return
 

--- a/i18n/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n/src/commonMain/moko-resources/base/plurals.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <plurals name="pref_library_entries_in_column">
+        <item quantity="one">1 entry</item>
+        <item quantity="other">%d entries</item>
+    </plurals>
+
     <plurals name="lock_after_mins">
         <item quantity="one">After %1$s minute</item>
         <item quantity="other">After %1$s minutes</item>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -269,6 +269,7 @@
     <string name="pref_category_display">Display</string>
     <string name="pref_library_columns">Grid size</string>
     <string name="pref_library_columns_per_row">%d per row</string>
+    <string name="pref_library_rows">List size</string>
     <string name="portrait">Portrait</string>
     <string name="landscape">Landscape</string>
 


### PR DESCRIPTION
Copies a feature added to the aniyomi fork. [Here's a visual demonstration of what this adds.](https://github.com/aniyomiorg/aniyomi/pull/1906)

Added a size slider for the List Display Mode. It uses the same size variable as Grids do to determine size. However, the size of the List gets interpreted not as \<number\> of columns per row, but rather as \<number\> of entries of the list visible on the screen at once.

The style of the List was changed: the cover is of Book resolution to match the Grids and for better visibility.

Other two lists (browse list and migration list) don't have editable size, but neither do browse grids, so it's fine. Instead they now have a predetermined size of 76.dp (was 56.dp previously) and are visually changed to match the library list style. Same for the default size of the list.

The size slider also has two additional text fields added, which would need translation (though i assume that's automated).

The max line restriction for titles was removed, allowing for longer names to be fully visible, given the List is set to a big enough size.

closes #1687
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
