### PR TITLE
Fix: null (visual) categories in Settings/Downloads/Exclude

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -107,6 +107,14 @@ object SettingsDownloadScreen : SearchableSettings {
         return Preference.PreferenceItem.MultiSelectListPreference(
             pref = downloadPreferences.removeExcludeCategories(),
             title = stringResource(MR.strings.pref_remove_exclude_categories),
+            subtitleProvider = { v, e ->
+                val combined = remember(v, e) {
+                    v.map { e[it] }
+                        .takeIf { it.isNotEmpty() }
+                        ?.joinToString()
+                } ?: stringResource(MR.strings.none)
+                "%s".format(combined)
+            },
             entries = categories()
                 .associate { it.id.toString() to it.visualName }
                 .toImmutableMap(),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0001fb53-81d7-4140-b49e-2d7e669df449)
