### PR TITLE
new features: migrate downloaded, download cbz in ram

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 [*.{kt,kts}]
 max_line_length = 120
+indent_style = space
 indent_size = 4
 insert_final_newline = true
 ij_kotlin_allow_trailing_comma = true

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -46,6 +46,10 @@ object SettingsDownloadScreen : SearchableSettings {
                 pref = downloadPreferences.saveChaptersAsCBZ(),
                 title = stringResource(MR.strings.save_chapter_as_cbz),
             ),
+	        Preference.PreferenceItem.SwitchPreference(
+		        pref = downloadPreferences.saveChaptersCBZInRAM(),
+		        title = stringResource(MR.strings.save_chapter_cbz_in_ram),
+	        ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = downloadPreferences.splitTallImages(),
                 title = stringResource(MR.strings.split_tall_images),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -46,10 +46,10 @@ object SettingsDownloadScreen : SearchableSettings {
                 pref = downloadPreferences.saveChaptersAsCBZ(),
                 title = stringResource(MR.strings.save_chapter_as_cbz),
             ),
-	        Preference.PreferenceItem.SwitchPreference(
-		        pref = downloadPreferences.saveChaptersCBZInRAM(),
-		        title = stringResource(MR.strings.save_chapter_cbz_in_ram),
-	        ),
+            Preference.PreferenceItem.SwitchPreference(
+                pref = downloadPreferences.saveChaptersCBZInRAM(),
+                title = stringResource(MR.strings.save_chapter_cbz_in_ram),
+            ),
             Preference.PreferenceItem.SwitchPreference(
                 pref = downloadPreferences.splitTallImages(),
                 title = stringResource(MR.strings.split_tall_images),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -38,435 +38,421 @@ import uy.kohesive.injekt.api.get
  * downloaded chapters.
  */
 class DownloadManager(
-	private val context: Context,
-	private val provider: DownloadProvider = Injekt.get(),
-	private val cache: DownloadCache = Injekt.get(),
-	private val getCategories: GetCategories = Injekt.get(),
-	private val sourceManager: SourceManager = Injekt.get(),
-	private val downloadPreferences: DownloadPreferences = Injekt.get(),
-	private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
+    private val context: Context,
+    private val provider: DownloadProvider = Injekt.get(),
+    private val cache: DownloadCache = Injekt.get(),
+    private val getCategories: GetCategories = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadPreferences: DownloadPreferences = Injekt.get(),
+    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
 ) {
 
-	/**
-	 * Downloader whose only task is to download chapters.
-	 */
-	private val downloader = Downloader(context, provider, cache)
+    /**
+     * Downloader whose only task is to download chapters.
+     */
+    private val downloader = Downloader(context, provider, cache)
 
-	val isRunning: Boolean
-		get() = downloader.isRunning
+    val isRunning: Boolean
+        get() = downloader.isRunning
 
-	/**
-	 * Queue to delay the deletion of a list of chapters until triggered.
-	 */
-	private val pendingDeleter = DownloadPendingDeleter(context)
+    /**
+     * Queue to delay the deletion of a list of chapters until triggered.
+     */
+    private val pendingDeleter = DownloadPendingDeleter(context)
 
-	val queueState
-		get() = downloader.queueState
+    val queueState
+        get() = downloader.queueState
 
-	// For use by DownloadService only
-	fun downloaderStart() = downloader.start()
-	fun downloaderStop(reason: String? = null) = downloader.stop(reason)
+    // For use by DownloadService only
+    fun downloaderStart() = downloader.start()
+    fun downloaderStop(reason: String? = null) = downloader.stop(reason)
 
-	val isDownloaderRunning
-		get() = DownloadJob.isRunningFlow(context)
+    val isDownloaderRunning
+        get() = DownloadJob.isRunningFlow(context)
 
-	/**
-	 * Tells the downloader to begin downloads.
-	 */
-	fun startDownloads() {
-		if (downloader.isRunning) return
+    /**
+     * Tells the downloader to begin downloads.
+     */
+    fun startDownloads() {
+        if (downloader.isRunning) return
 
-		if (DownloadJob.isRunning(context)) {
-			downloader.start()
-		} else {
-			DownloadJob.start(context)
-		}
-	}
+        if (DownloadJob.isRunning(context)) {
+            downloader.start()
+        } else {
+            DownloadJob.start(context)
+        }
+    }
 
-	/**
-	 * Tells the downloader to pause downloads.
-	 */
-	fun pauseDownloads() {
-		downloader.pause()
-		downloader.stop()
-	}
+    /**
+     * Tells the downloader to pause downloads.
+     */
+    fun pauseDownloads() {
+        downloader.pause()
+        downloader.stop()
+    }
 
-	/**
-	 * Empties the download queue.
-	 */
-	fun clearQueue() {
-		downloader.clearQueue()
-		downloader.stop()
-	}
+    /**
+     * Empties the download queue.
+     */
+    fun clearQueue() {
+        downloader.clearQueue()
+        downloader.stop()
+    }
 
-	/**
-	 * Returns the download from queue if the chapter is queued for download
-	 * else it will return null which means that the chapter is not queued for download
-	 *
-	 * @param chapterId the chapter to check.
-	 */
-	fun getQueuedDownloadOrNull(chapterId: Long): Download? {
-		return queueState.value.find { it.chapter.id == chapterId }
-	}
+    /**
+     * Returns the download from queue if the chapter is queued for download
+     * else it will return null which means that the chapter is not queued for download
+     *
+     * @param chapterId the chapter to check.
+     */
+    fun getQueuedDownloadOrNull(chapterId: Long): Download? {
+        return queueState.value.find { it.chapter.id == chapterId }
+    }
 
-	fun startDownloadNow(chapterId: Long) {
-		val existingDownload = getQueuedDownloadOrNull(chapterId)
-		// If not in queue try to start a new download
-		val toAdd = existingDownload ?: runBlocking { Download.fromChapterId(chapterId) } ?: return
-		queueState.value.toMutableList().apply {
-			existingDownload?.let { remove(it) }
-			add(0, toAdd)
-			reorderQueue(this)
-		}
-		startDownloads()
-	}
+    fun startDownloadNow(chapterId: Long) {
+        val existingDownload = getQueuedDownloadOrNull(chapterId)
+        // If not in queue try to start a new download
+        val toAdd = existingDownload ?: runBlocking { Download.fromChapterId(chapterId) } ?: return
+        queueState.value.toMutableList().apply {
+            existingDownload?.let { remove(it) }
+            add(0, toAdd)
+            reorderQueue(this)
+        }
+        startDownloads()
+    }
 
-	/**
-	 * Reorders the download queue.
-	 *
-	 * @param downloads value to set the download queue to
-	 */
-	fun reorderQueue(downloads: List<Download>) {
-		downloader.updateQueue(downloads)
-	}
+    /**
+     * Reorders the download queue.
+     *
+     * @param downloads value to set the download queue to
+     */
+    fun reorderQueue(downloads: List<Download>) {
+        downloader.updateQueue(downloads)
+    }
 
-	/**
-	 * Tells the downloader to enqueue the given list of chapters.
-	 *
-	 * @param manga the manga of the chapters.
-	 * @param chapters the list of chapters to enqueue.
-	 * @param autoStart whether to start the downloader after enqueing the chapters.
-	 */
-	fun downloadChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean = true) {
-		downloader.queueChapters(manga, chapters, autoStart)
-	}
+    /**
+     * Tells the downloader to enqueue the given list of chapters.
+     *
+     * @param manga the manga of the chapters.
+     * @param chapters the list of chapters to enqueue.
+     * @param autoStart whether to start the downloader after enqueing the chapters.
+     */
+    fun downloadChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean = true) {
+        downloader.queueChapters(manga, chapters, autoStart)
+    }
 
-	/**
-	 * Tells the downloader to enqueue the given list of downloads at the start of the queue.
-	 *
-	 * @param downloads the list of downloads to enqueue.
-	 */
-	fun addDownloadsToStartOfQueue(downloads: List<Download>) {
-		if (downloads.isEmpty()) return
-		queueState.value.toMutableList().apply {
-			addAll(0, downloads)
-			reorderQueue(this)
-		}
-		if (!DownloadJob.isRunning(context)) startDownloads()
-	}
+    /**
+     * Tells the downloader to enqueue the given list of downloads at the start of the queue.
+     *
+     * @param downloads the list of downloads to enqueue.
+     */
+    fun addDownloadsToStartOfQueue(downloads: List<Download>) {
+        if (downloads.isEmpty()) return
+        queueState.value.toMutableList().apply {
+            addAll(0, downloads)
+            reorderQueue(this)
+        }
+        if (!DownloadJob.isRunning(context)) startDownloads()
+    }
 
-	/**
-	 * Builds the page list of a downloaded chapter.
-	 *
-	 * @param source the source of the chapter.
-	 * @param manga the manga of the chapter.
-	 * @param chapter the downloaded chapter.
-	 * @return the list of pages from the chapter.
-	 */
-	fun buildPageList(source: Source, manga: Manga, chapter: Chapter): List<Page> {
-		val chapterDir = provider.findChapterDir(chapter.name, chapter.scanlator, manga.title, source)
-		val files = chapterDir?.listFiles().orEmpty()
-			.filter { it.isFile && ImageUtil.isImage(it.name) { it.openInputStream() } }
+    /**
+     * Builds the page list of a downloaded chapter.
+     *
+     * @param source the source of the chapter.
+     * @param manga the manga of the chapter.
+     * @param chapter the downloaded chapter.
+     * @return the list of pages from the chapter.
+     */
+    fun buildPageList(source: Source, manga: Manga, chapter: Chapter): List<Page> {
+        val chapterDir = provider.findChapterDir(chapter.name, chapter.scanlator, manga.title, source)
+        val files = chapterDir?.listFiles().orEmpty()
+            .filter { it.isFile && ImageUtil.isImage(it.name) { it.openInputStream() } }
 
-		if (files.isEmpty()) {
-			throw Exception(context.stringResource(MR.strings.page_list_empty_error))
-		}
+        if (files.isEmpty()) {
+            throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+        }
 
-		return files.sortedBy { it.name }
-			.mapIndexed { i, file ->
-				Page(i, uri = file.uri).apply { status = Page.State.READY }
-			}
-	}
+        return files.sortedBy { it.name }.mapIndexed { i, file ->
+                Page(i, uri = file.uri).apply { status = Page.State.READY }
+            }
+    }
 
-	/**
-	 * Returns true if the chapter is downloaded.
-	 *
-	 * @param chapterName the name of the chapter to query.
-	 * @param chapterScanlator scanlator of the chapter to query
-	 * @param mangaTitle the title of the manga to query.
-	 * @param sourceId the id of the source of the chapter.
-	 * @param skipCache whether to skip the directory cache and check in the filesystem.
-	 */
-	fun isChapterDownloaded(
-		chapterName: String,
-		chapterScanlator: String?,
-		mangaTitle: String,
-		sourceId: Long,
-		skipCache: Boolean = false,
-	): Boolean {
-		return cache.isChapterDownloaded(chapterName, chapterScanlator, mangaTitle, sourceId, skipCache)
-	}
+    /**
+     * Returns true if the chapter is downloaded.
+     *
+     * @param chapterName the name of the chapter to query.
+     * @param chapterScanlator scanlator of the chapter to query
+     * @param mangaTitle the title of the manga to query.
+     * @param sourceId the id of the source of the chapter.
+     * @param skipCache whether to skip the directory cache and check in the filesystem.
+     */
+    fun isChapterDownloaded(
+        chapterName: String,
+        chapterScanlator: String?,
+        mangaTitle: String,
+        sourceId: Long,
+        skipCache: Boolean = false,
+    ): Boolean {
+        return cache.isChapterDownloaded(chapterName, chapterScanlator, mangaTitle, sourceId, skipCache)
+    }
 
-	/**
-	 * Returns the amount of downloaded chapters.
-	 */
-	fun getDownloadCount(): Int {
-		return cache.getTotalDownloadCount()
-	}
+    /**
+     * Returns the amount of downloaded chapters.
+     */
+    fun getDownloadCount(): Int {
+        return cache.getTotalDownloadCount()
+    }
 
-	/**
-	 * Returns the amount of downloaded chapters for a manga.
-	 *
-	 * @param manga the manga to check.
-	 */
-	fun getDownloadCount(manga: Manga): Int {
-		return cache.getDownloadCount(manga)
-	}
+    /**
+     * Returns the amount of downloaded chapters for a manga.
+     *
+     * @param manga the manga to check.
+     */
+    fun getDownloadCount(manga: Manga): Int {
+        return cache.getDownloadCount(manga)
+    }
 
-	fun cancelQueuedDownloads(downloads: List<Download>) {
-		removeFromDownloadQueue(downloads.map { it.chapter })
-	}
+    fun cancelQueuedDownloads(downloads: List<Download>) {
+        removeFromDownloadQueue(downloads.map { it.chapter })
+    }
 
-	/**
-	 * Deletes the directories of a list of downloaded chapters.
-	 *
-	 * @param chapters the list of chapters to delete.
-	 * @param manga the manga of the chapters.
-	 * @param source the source of the chapters.
-	 */
-	fun deleteChapters(chapters: List<Chapter>, manga: Manga, source: Source) {
-		launchIO {
-			val filteredChapters = getChaptersToDelete(chapters, manga)
-			if (filteredChapters.isEmpty()) {
-				return@launchIO
-			}
+    /**
+     * Deletes the directories of a list of downloaded chapters.
+     *
+     * @param chapters the list of chapters to delete.
+     * @param manga the manga of the chapters.
+     * @param source the source of the chapters.
+     */
+    fun deleteChapters(chapters: List<Chapter>, manga: Manga, source: Source) {
+        launchIO {
+            val filteredChapters = getChaptersToDelete(chapters, manga)
+            if (filteredChapters.isEmpty()) {
+                return@launchIO
+            }
 
-			removeFromDownloadQueue(filteredChapters)
+            removeFromDownloadQueue(filteredChapters)
 
-			val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
-			chapterDirs.forEach { it.delete() }
-			cache.removeChapters(filteredChapters, manga)
+            val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
+            chapterDirs.forEach { it.delete() }
+            cache.removeChapters(filteredChapters, manga)
 
-			// Delete manga directory if empty
-			if (mangaDir?.listFiles()?.isEmpty() == true) {
-				deleteManga(manga, source, removeQueued = false)
-			}
-		}
-	}
+            // Delete manga directory if empty
+            if (mangaDir?.listFiles()?.isEmpty() == true) {
+                deleteManga(manga, source, removeQueued = false)
+            }
+        }
+    }
 
-	/**
-	 * Deletes the directory of a downloaded manga.
-	 *
-	 * @param oldManga the origin manga for migration..
-	 * @param oldSource the origin source for migration..
-	 * @param newManga the target manga for migration.
-	 * @param newSource the target source for migration.
-	 */
-	fun migrateManga(oldManga: Manga, oldSource: Source, newManga: Manga, newSource: Source) {
-		launchIO {
-			val oldMangaDir = provider.findMangaDir(oldManga.title, oldSource) ?: return@launchIO
-			val newMangaDir = provider.getMangaDir(newManga.title, newSource)
-			val downloadedChapters = oldMangaDir.listFiles()
-			val downloadedChaptersMap =
-				downloadedChapters?.associateBy({ it.nameWithoutExtension }, { it }) ?: return@launchIO
+    /**
+     * Deletes the directory of a downloaded manga.
+     *
+     * @param oldManga the origin manga for migration..
+     * @param oldSource the origin source for migration..
+     * @param newManga the target manga for migration.
+     * @param newSource the target source for migration.
+     */
+    fun migrateManga(oldManga: Manga, oldSource: Source, newManga: Manga, newSource: Source) {
+        launchIO {
+            val oldMangaDir = provider.findMangaDir(oldManga.title, oldSource) ?: return@launchIO
+            val newMangaDir = provider.getMangaDir(newManga.title, newSource)
+            val downloadedChapters = oldMangaDir.listFiles()
+            val downloadedChaptersMap =
+                downloadedChapters?.associateBy({ it.nameWithoutExtension }, { it }) ?: return@launchIO
 
-			// map old chapters to new chapters.  The names may not be the same.
-			val oldChapters = getChaptersByMangaId.await(oldManga.id)
-			val newChapters = getChaptersByMangaId.await(newManga.id)
-			val oldChaptersByChapterNumber = oldChapters.associateBy { it.chapterNumber }
+            // map old chapters to new chapters.  The names may not be the same.
+            val oldChapters = getChaptersByMangaId.await(oldManga.id)
+            val newChapters = getChaptersByMangaId.await(newManga.id)
+            val oldChaptersByChapterNumber = oldChapters.associateBy { it.chapterNumber }
 
-			// If the chapter is downloaded, migrate it.
-			for (chapter in newChapters) {
-				val oldChapter = oldChaptersByChapterNumber[chapter.chapterNumber]
-				if (oldChapter != null) {
-					val oldChapterName = provider.getChapterDirName(oldChapter.name, oldChapter.scanlator)
-					val oldChapterFile = downloadedChaptersMap[oldChapterName]
-					if (oldChapterFile != null) {
-						val newChapterName = if (oldChapterFile.extension == null) {
-							provider.getChapterDirName(chapter.name, chapter.scanlator)
-						} else {
-							provider.getChapterDirName(chapter.name, chapter.scanlator) + "." + oldChapterFile.extension
-						}
+            // If the chapter is downloaded, migrate it.
+            for (chapter in newChapters) {
+                val oldChapter = oldChaptersByChapterNumber[chapter.chapterNumber]
+                if (oldChapter != null) {
+                    val oldChapterName = provider.getChapterDirName(oldChapter.name, oldChapter.scanlator)
+                    val oldChapterFile = downloadedChaptersMap[oldChapterName]
+                    if (oldChapterFile != null) {
+                        val newChapterName = if (oldChapterFile.extension == null) {
+                            provider.getChapterDirName(chapter.name, chapter.scanlator)
+                        } else {
+                            provider.getChapterDirName(chapter.name, chapter.scanlator) + "." + oldChapterFile.extension
+                        }
 
-						// move the file to newMangaDir, renaming the file/folder in the process
-						var chapterUri: Uri? = oldChapterFile.uri
-						chapterUri = chapterUri?.let {
-							DocumentsContract.renameDocument(
-								context.contentResolver,
-								it, newChapterName,
-							)
-						}
-						chapterUri = chapterUri?.let {
-							DocumentsContract.moveDocument(
-								context.contentResolver,
-								it, oldMangaDir.uri, newMangaDir.uri,
-							)
-						}
+                        // move the file to newMangaDir, renaming the file/folder in the process
+                        var chapterUri: Uri? = oldChapterFile.uri
+                        chapterUri = chapterUri?.let {
+                            DocumentsContract.renameDocument(
+                                context.contentResolver,
+                                it, newChapterName,
+                            )
+                        }
+                        chapterUri = chapterUri?.let {
+                            DocumentsContract.moveDocument(
+                                context.contentResolver,
+                                it, oldMangaDir.uri, newMangaDir.uri,
+                            )
+                        }
 
-						cache.removeChapter(oldChapter, oldManga)
-						cache.addChapter(newChapterName, newMangaDir, newManga)
-					}
-				}
-			}
-		}
-	}
+                        cache.removeChapter(oldChapter, oldManga)
+                        cache.addChapter(newChapterName, newMangaDir, newManga)
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 * Deletes the directory of a downloaded manga.
-	 *
-	 * @param manga the manga to delete.
-	 * @param source the source of the manga.
-	 * @param removeQueued whether to also remove queued downloads.
-	 */
-	fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
-		launchIO {
-			if (removeQueued) {
-				downloader.removeFromQueue(manga)
-			}
-			provider.findMangaDir(manga.title, source)?.delete()
-			cache.removeManga(manga)
+    /**
+     * Deletes the directory of a downloaded manga.
+     *
+     * @param manga the manga to delete.
+     * @param source the source of the manga.
+     * @param removeQueued whether to also remove queued downloads.
+     */
+    fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
+        launchIO {
+            if (removeQueued) {
+                downloader.removeFromQueue(manga)
+            }
+            provider.findMangaDir(manga.title, source)?.delete()
+            cache.removeManga(manga)
 
-			// Delete source directory if empty
-			val sourceDir = provider.findSourceDir(source)
-			if (sourceDir?.listFiles()?.isEmpty() == true) {
-				sourceDir.delete()
-				cache.removeSource(source)
-			}
-		}
-	}
+            // Delete source directory if empty
+            val sourceDir = provider.findSourceDir(source)
+            if (sourceDir?.listFiles()?.isEmpty() == true) {
+                sourceDir.delete()
+                cache.removeSource(source)
+            }
+        }
+    }
 
-	private fun removeFromDownloadQueue(chapters: List<Chapter>) {
-		val wasRunning = downloader.isRunning
-		if (wasRunning) {
-			downloader.pause()
-		}
+    private fun removeFromDownloadQueue(chapters: List<Chapter>) {
+        val wasRunning = downloader.isRunning
+        if (wasRunning) {
+            downloader.pause()
+        }
 
-		downloader.removeFromQueue(chapters)
+        downloader.removeFromQueue(chapters)
 
-		if (wasRunning) {
-			if (queueState.value.isEmpty()) {
-				downloader.stop()
-			} else if (queueState.value.isNotEmpty()) {
-				downloader.start()
-			}
-		}
-	}
+        if (wasRunning) {
+            if (queueState.value.isEmpty()) {
+                downloader.stop()
+            } else if (queueState.value.isNotEmpty()) {
+                downloader.start()
+            }
+        }
+    }
 
-	/**
-	 * Adds a list of chapters to be deleted later.
-	 *
-	 * @param chapters the list of chapters to delete.
-	 * @param manga the manga of the chapters.
-	 */
-	suspend fun enqueueChaptersToDelete(chapters: List<Chapter>, manga: Manga) {
-		pendingDeleter.addChapters(getChaptersToDelete(chapters, manga), manga)
-	}
+    /**
+     * Adds a list of chapters to be deleted later.
+     *
+     * @param chapters the list of chapters to delete.
+     * @param manga the manga of the chapters.
+     */
+    suspend fun enqueueChaptersToDelete(chapters: List<Chapter>, manga: Manga) {
+        pendingDeleter.addChapters(getChaptersToDelete(chapters, manga), manga)
+    }
 
-	/**
-	 * Triggers the execution of the deletion of pending chapters.
-	 */
-	fun deletePendingChapters() {
-		val pendingChapters = pendingDeleter.getPendingChapters()
-		for ((manga, chapters) in pendingChapters) {
-			val source = sourceManager.get(manga.source) ?: continue
-			deleteChapters(chapters, manga, source)
-		}
-	}
+    /**
+     * Triggers the execution of the deletion of pending chapters.
+     */
+    fun deletePendingChapters() {
+        val pendingChapters = pendingDeleter.getPendingChapters()
+        for ((manga, chapters) in pendingChapters) {
+            val source = sourceManager.get(manga.source) ?: continue
+            deleteChapters(chapters, manga, source)
+        }
+    }
 
-	/**
-	 * Renames source download folder
-	 *
-	 * @param oldSource the old source.
-	 * @param newSource the new source.
-	 */
-	fun renameSource(oldSource: Source, newSource: Source) {
-		val oldFolder = provider.findSourceDir(oldSource) ?: return
-		val newName = provider.getSourceDirName(newSource)
+    /**
+     * Renames source download folder
+     *
+     * @param oldSource the old source.
+     * @param newSource the new source.
+     */
+    fun renameSource(oldSource: Source, newSource: Source) {
+        val oldFolder = provider.findSourceDir(oldSource) ?: return
+        val newName = provider.getSourceDirName(newSource)
 
-		if (oldFolder.name == newName) return
+        if (oldFolder.name == newName) return
 
-		val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
-		if (capitalizationChanged) {
-			val tempName = newName + Downloader.TMP_DIR_SUFFIX
-			if (!oldFolder.renameTo(tempName)) {
-				logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
-				return
-			}
-		}
+        val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
+        if (capitalizationChanged) {
+            val tempName = newName + Downloader.TMP_DIR_SUFFIX
+            if (!oldFolder.renameTo(tempName)) {
+                logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
+                return
+            }
+        }
 
-		if (!oldFolder.renameTo(newName)) {
-			logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
-		}
-	}
+        if (!oldFolder.renameTo(newName)) {
+            logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
+        }
+    }
 
-	/**
-	 * Renames an already downloaded chapter
-	 *
-	 * @param source the source of the manga.
-	 * @param manga the manga of the chapter.
-	 * @param oldChapter the existing chapter with the old name.
-	 * @param newChapter the target chapter with the new name.
-	 */
-	suspend fun renameChapter(source: Source, manga: Manga, oldChapter: Chapter, newChapter: Chapter) {
-		val oldNames = provider.getValidChapterDirNames(oldChapter.name, oldChapter.scanlator)
-		val mangaDir = provider.getMangaDir(manga.title, source)
+    /**
+     * Renames an already downloaded chapter
+     *
+     * @param source the source of the manga.
+     * @param manga the manga of the chapter.
+     * @param oldChapter the existing chapter with the old name.
+     * @param newChapter the target chapter with the new name.
+     */
+    suspend fun renameChapter(source: Source, manga: Manga, oldChapter: Chapter, newChapter: Chapter) {
+        val oldNames = provider.getValidChapterDirNames(oldChapter.name, oldChapter.scanlator)
+        val mangaDir = provider.getMangaDir(manga.title, source)
 
-		// Assume there's only 1 version of the chapter name formats present
-		val oldDownload = oldNames.asSequence()
-			.mapNotNull { mangaDir.findFile(it) }
-			.firstOrNull() ?: return
+        // Assume there's only 1 version of the chapter name formats present
+        val oldDownload = oldNames.asSequence().mapNotNull { mangaDir.findFile(it) }.firstOrNull() ?: return
 
-		var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator)
-		if (oldDownload.isFile && oldDownload.extension == "cbz") {
-			newName += ".cbz"
-		}
+        var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator)
+        if (oldDownload.isFile && oldDownload.extension == "cbz") {
+            newName += ".cbz"
+        }
 
-		if (oldDownload.name == newName) return
+        if (oldDownload.name == newName) return
 
-		if (oldDownload.renameTo(newName)) {
-			cache.removeChapter(oldChapter, manga)
-			cache.addChapter(newName, mangaDir, manga)
-		} else {
-			logcat(LogPriority.ERROR) { "Could not rename downloaded chapter: ${oldNames.joinToString()}" }
-		}
-	}
+        if (oldDownload.renameTo(newName)) {
+            cache.removeChapter(oldChapter, manga)
+            cache.addChapter(newName, mangaDir, manga)
+        } else {
+            logcat(LogPriority.ERROR) { "Could not rename downloaded chapter: ${oldNames.joinToString()}" }
+        }
+    }
 
-	private suspend fun getChaptersToDelete(chapters: List<Chapter>, manga: Manga): List<Chapter> {
-		// Retrieve the categories that are set to exclude from being deleted on read
-		val categoriesToExclude = downloadPreferences.removeExcludeCategories().get().map(String::toLong)
+    private suspend fun getChaptersToDelete(chapters: List<Chapter>, manga: Manga): List<Chapter> {
+        // Retrieve the categories that are set to exclude from being deleted on read
+        val categoriesToExclude = downloadPreferences.removeExcludeCategories().get().map(String::toLong)
 
-		val categoriesForManga = getCategories.await(manga.id)
-			.map { it.id }
-			.ifEmpty { listOf(0) }
-		val filteredCategoryManga = if (categoriesForManga.intersect(categoriesToExclude).isNotEmpty()) {
-			chapters.filterNot { it.read }
-		} else {
-			chapters
-		}
+        val categoriesForManga = getCategories.await(manga.id).map { it.id }.ifEmpty { listOf(0) }
+        val filteredCategoryManga = if (categoriesForManga.intersect(categoriesToExclude).isNotEmpty()) {
+            chapters.filterNot { it.read }
+        } else {
+            chapters
+        }
 
-		return if (!downloadPreferences.removeBookmarkedChapters().get()) {
-			filteredCategoryManga.filterNot { it.bookmark }
-		} else {
-			filteredCategoryManga
-		}
-	}
+        return if (!downloadPreferences.removeBookmarkedChapters().get()) {
+            filteredCategoryManga.filterNot { it.bookmark }
+        } else {
+            filteredCategoryManga
+        }
+    }
 
-	fun statusFlow(): Flow<Download> = queueState
-		.flatMapLatest { downloads ->
-			downloads
-				.map { download ->
-					download.statusFlow.drop(1).map { download }
-				}
-				.merge()
-		}
-		.onStart {
-			emitAll(
-				queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }.asFlow(),
-			)
-		}
+    fun statusFlow(): Flow<Download> = queueState.flatMapLatest { downloads ->
+            downloads.map { download ->
+                    download.statusFlow.drop(1).map { download }
+                }.merge()
+        }.onStart {
+            emitAll(
+                queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }.asFlow(),
+            )
+        }
 
-	fun progressFlow(): Flow<Download> = queueState
-		.flatMapLatest { downloads ->
-			downloads
-				.map { download ->
-					download.progressFlow.drop(1).map { download }
-				}
-				.merge()
-		}
-		.onStart {
-			emitAll(
-				queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }
-					.asFlow(),
-			)
-		}
+    fun progressFlow(): Flow<Download> = queueState.flatMapLatest { downloads ->
+            downloads.map { download ->
+                    download.progressFlow.drop(1).map { download }
+                }.merge()
+        }.onStart {
+            emitAll(
+                queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }.asFlow(),
+            )
+        }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
@@ -16,10 +18,12 @@ import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
@@ -34,377 +38,435 @@ import uy.kohesive.injekt.api.get
  * downloaded chapters.
  */
 class DownloadManager(
-    private val context: Context,
-    private val provider: DownloadProvider = Injekt.get(),
-    private val cache: DownloadCache = Injekt.get(),
-    private val getCategories: GetCategories = Injekt.get(),
-    private val sourceManager: SourceManager = Injekt.get(),
-    private val downloadPreferences: DownloadPreferences = Injekt.get(),
+	private val context: Context,
+	private val provider: DownloadProvider = Injekt.get(),
+	private val cache: DownloadCache = Injekt.get(),
+	private val getCategories: GetCategories = Injekt.get(),
+	private val sourceManager: SourceManager = Injekt.get(),
+	private val downloadPreferences: DownloadPreferences = Injekt.get(),
+	private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
 ) {
 
-    /**
-     * Downloader whose only task is to download chapters.
-     */
-    private val downloader = Downloader(context, provider, cache)
+	/**
+	 * Downloader whose only task is to download chapters.
+	 */
+	private val downloader = Downloader(context, provider, cache)
 
-    val isRunning: Boolean
-        get() = downloader.isRunning
+	val isRunning: Boolean
+		get() = downloader.isRunning
 
-    /**
-     * Queue to delay the deletion of a list of chapters until triggered.
-     */
-    private val pendingDeleter = DownloadPendingDeleter(context)
+	/**
+	 * Queue to delay the deletion of a list of chapters until triggered.
+	 */
+	private val pendingDeleter = DownloadPendingDeleter(context)
 
-    val queueState
-        get() = downloader.queueState
+	val queueState
+		get() = downloader.queueState
 
-    // For use by DownloadService only
-    fun downloaderStart() = downloader.start()
-    fun downloaderStop(reason: String? = null) = downloader.stop(reason)
+	// For use by DownloadService only
+	fun downloaderStart() = downloader.start()
+	fun downloaderStop(reason: String? = null) = downloader.stop(reason)
 
-    val isDownloaderRunning
-        get() = DownloadJob.isRunningFlow(context)
+	val isDownloaderRunning
+		get() = DownloadJob.isRunningFlow(context)
 
-    /**
-     * Tells the downloader to begin downloads.
-     */
-    fun startDownloads() {
-        if (downloader.isRunning) return
+	/**
+	 * Tells the downloader to begin downloads.
+	 */
+	fun startDownloads() {
+		if (downloader.isRunning) return
 
-        if (DownloadJob.isRunning(context)) {
-            downloader.start()
-        } else {
-            DownloadJob.start(context)
-        }
-    }
+		if (DownloadJob.isRunning(context)) {
+			downloader.start()
+		} else {
+			DownloadJob.start(context)
+		}
+	}
 
-    /**
-     * Tells the downloader to pause downloads.
-     */
-    fun pauseDownloads() {
-        downloader.pause()
-        downloader.stop()
-    }
+	/**
+	 * Tells the downloader to pause downloads.
+	 */
+	fun pauseDownloads() {
+		downloader.pause()
+		downloader.stop()
+	}
 
-    /**
-     * Empties the download queue.
-     */
-    fun clearQueue() {
-        downloader.clearQueue()
-        downloader.stop()
-    }
+	/**
+	 * Empties the download queue.
+	 */
+	fun clearQueue() {
+		downloader.clearQueue()
+		downloader.stop()
+	}
 
-    /**
-     * Returns the download from queue if the chapter is queued for download
-     * else it will return null which means that the chapter is not queued for download
-     *
-     * @param chapterId the chapter to check.
-     */
-    fun getQueuedDownloadOrNull(chapterId: Long): Download? {
-        return queueState.value.find { it.chapter.id == chapterId }
-    }
+	/**
+	 * Returns the download from queue if the chapter is queued for download
+	 * else it will return null which means that the chapter is not queued for download
+	 *
+	 * @param chapterId the chapter to check.
+	 */
+	fun getQueuedDownloadOrNull(chapterId: Long): Download? {
+		return queueState.value.find { it.chapter.id == chapterId }
+	}
 
-    fun startDownloadNow(chapterId: Long) {
-        val existingDownload = getQueuedDownloadOrNull(chapterId)
-        // If not in queue try to start a new download
-        val toAdd = existingDownload ?: runBlocking { Download.fromChapterId(chapterId) } ?: return
-        queueState.value.toMutableList().apply {
-            existingDownload?.let { remove(it) }
-            add(0, toAdd)
-            reorderQueue(this)
-        }
-        startDownloads()
-    }
+	fun startDownloadNow(chapterId: Long) {
+		val existingDownload = getQueuedDownloadOrNull(chapterId)
+		// If not in queue try to start a new download
+		val toAdd = existingDownload ?: runBlocking { Download.fromChapterId(chapterId) } ?: return
+		queueState.value.toMutableList().apply {
+			existingDownload?.let { remove(it) }
+			add(0, toAdd)
+			reorderQueue(this)
+		}
+		startDownloads()
+	}
 
-    /**
-     * Reorders the download queue.
-     *
-     * @param downloads value to set the download queue to
-     */
-    fun reorderQueue(downloads: List<Download>) {
-        downloader.updateQueue(downloads)
-    }
+	/**
+	 * Reorders the download queue.
+	 *
+	 * @param downloads value to set the download queue to
+	 */
+	fun reorderQueue(downloads: List<Download>) {
+		downloader.updateQueue(downloads)
+	}
 
-    /**
-     * Tells the downloader to enqueue the given list of chapters.
-     *
-     * @param manga the manga of the chapters.
-     * @param chapters the list of chapters to enqueue.
-     * @param autoStart whether to start the downloader after enqueing the chapters.
-     */
-    fun downloadChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean = true) {
-        downloader.queueChapters(manga, chapters, autoStart)
-    }
+	/**
+	 * Tells the downloader to enqueue the given list of chapters.
+	 *
+	 * @param manga the manga of the chapters.
+	 * @param chapters the list of chapters to enqueue.
+	 * @param autoStart whether to start the downloader after enqueing the chapters.
+	 */
+	fun downloadChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean = true) {
+		downloader.queueChapters(manga, chapters, autoStart)
+	}
 
-    /**
-     * Tells the downloader to enqueue the given list of downloads at the start of the queue.
-     *
-     * @param downloads the list of downloads to enqueue.
-     */
-    fun addDownloadsToStartOfQueue(downloads: List<Download>) {
-        if (downloads.isEmpty()) return
-        queueState.value.toMutableList().apply {
-            addAll(0, downloads)
-            reorderQueue(this)
-        }
-        if (!DownloadJob.isRunning(context)) startDownloads()
-    }
+	/**
+	 * Tells the downloader to enqueue the given list of downloads at the start of the queue.
+	 *
+	 * @param downloads the list of downloads to enqueue.
+	 */
+	fun addDownloadsToStartOfQueue(downloads: List<Download>) {
+		if (downloads.isEmpty()) return
+		queueState.value.toMutableList().apply {
+			addAll(0, downloads)
+			reorderQueue(this)
+		}
+		if (!DownloadJob.isRunning(context)) startDownloads()
+	}
 
-    /**
-     * Builds the page list of a downloaded chapter.
-     *
-     * @param source the source of the chapter.
-     * @param manga the manga of the chapter.
-     * @param chapter the downloaded chapter.
-     * @return the list of pages from the chapter.
-     */
-    fun buildPageList(source: Source, manga: Manga, chapter: Chapter): List<Page> {
-        val chapterDir = provider.findChapterDir(chapter.name, chapter.scanlator, manga.title, source)
-        val files = chapterDir?.listFiles().orEmpty()
-            .filter { it.isFile && ImageUtil.isImage(it.name) { it.openInputStream() } }
+	/**
+	 * Builds the page list of a downloaded chapter.
+	 *
+	 * @param source the source of the chapter.
+	 * @param manga the manga of the chapter.
+	 * @param chapter the downloaded chapter.
+	 * @return the list of pages from the chapter.
+	 */
+	fun buildPageList(source: Source, manga: Manga, chapter: Chapter): List<Page> {
+		val chapterDir = provider.findChapterDir(chapter.name, chapter.scanlator, manga.title, source)
+		val files = chapterDir?.listFiles().orEmpty()
+			.filter { it.isFile && ImageUtil.isImage(it.name) { it.openInputStream() } }
 
-        if (files.isEmpty()) {
-            throw Exception(context.stringResource(MR.strings.page_list_empty_error))
-        }
+		if (files.isEmpty()) {
+			throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+		}
 
-        return files.sortedBy { it.name }
-            .mapIndexed { i, file ->
-                Page(i, uri = file.uri).apply { status = Page.State.READY }
-            }
-    }
+		return files.sortedBy { it.name }
+			.mapIndexed { i, file ->
+				Page(i, uri = file.uri).apply { status = Page.State.READY }
+			}
+	}
 
-    /**
-     * Returns true if the chapter is downloaded.
-     *
-     * @param chapterName the name of the chapter to query.
-     * @param chapterScanlator scanlator of the chapter to query
-     * @param mangaTitle the title of the manga to query.
-     * @param sourceId the id of the source of the chapter.
-     * @param skipCache whether to skip the directory cache and check in the filesystem.
-     */
-    fun isChapterDownloaded(
-        chapterName: String,
-        chapterScanlator: String?,
-        mangaTitle: String,
-        sourceId: Long,
-        skipCache: Boolean = false,
-    ): Boolean {
-        return cache.isChapterDownloaded(chapterName, chapterScanlator, mangaTitle, sourceId, skipCache)
-    }
+	/**
+	 * Returns true if the chapter is downloaded.
+	 *
+	 * @param chapterName the name of the chapter to query.
+	 * @param chapterScanlator scanlator of the chapter to query
+	 * @param mangaTitle the title of the manga to query.
+	 * @param sourceId the id of the source of the chapter.
+	 * @param skipCache whether to skip the directory cache and check in the filesystem.
+	 */
+	fun isChapterDownloaded(
+		chapterName: String,
+		chapterScanlator: String?,
+		mangaTitle: String,
+		sourceId: Long,
+		skipCache: Boolean = false,
+	): Boolean {
+		return cache.isChapterDownloaded(chapterName, chapterScanlator, mangaTitle, sourceId, skipCache)
+	}
 
-    /**
-     * Returns the amount of downloaded chapters.
-     */
-    fun getDownloadCount(): Int {
-        return cache.getTotalDownloadCount()
-    }
+	/**
+	 * Returns the amount of downloaded chapters.
+	 */
+	fun getDownloadCount(): Int {
+		return cache.getTotalDownloadCount()
+	}
 
-    /**
-     * Returns the amount of downloaded chapters for a manga.
-     *
-     * @param manga the manga to check.
-     */
-    fun getDownloadCount(manga: Manga): Int {
-        return cache.getDownloadCount(manga)
-    }
+	/**
+	 * Returns the amount of downloaded chapters for a manga.
+	 *
+	 * @param manga the manga to check.
+	 */
+	fun getDownloadCount(manga: Manga): Int {
+		return cache.getDownloadCount(manga)
+	}
 
-    fun cancelQueuedDownloads(downloads: List<Download>) {
-        removeFromDownloadQueue(downloads.map { it.chapter })
-    }
+	fun cancelQueuedDownloads(downloads: List<Download>) {
+		removeFromDownloadQueue(downloads.map { it.chapter })
+	}
 
-    /**
-     * Deletes the directories of a list of downloaded chapters.
-     *
-     * @param chapters the list of chapters to delete.
-     * @param manga the manga of the chapters.
-     * @param source the source of the chapters.
-     */
-    fun deleteChapters(chapters: List<Chapter>, manga: Manga, source: Source) {
-        launchIO {
-            val filteredChapters = getChaptersToDelete(chapters, manga)
-            if (filteredChapters.isEmpty()) {
-                return@launchIO
-            }
+	/**
+	 * Deletes the directories of a list of downloaded chapters.
+	 *
+	 * @param chapters the list of chapters to delete.
+	 * @param manga the manga of the chapters.
+	 * @param source the source of the chapters.
+	 */
+	fun deleteChapters(chapters: List<Chapter>, manga: Manga, source: Source) {
+		launchIO {
+			val filteredChapters = getChaptersToDelete(chapters, manga)
+			if (filteredChapters.isEmpty()) {
+				return@launchIO
+			}
 
-            removeFromDownloadQueue(filteredChapters)
+			removeFromDownloadQueue(filteredChapters)
 
-            val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
-            chapterDirs.forEach { it.delete() }
-            cache.removeChapters(filteredChapters, manga)
+			val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
+			chapterDirs.forEach { it.delete() }
+			cache.removeChapters(filteredChapters, manga)
 
-            // Delete manga directory if empty
-            if (mangaDir?.listFiles()?.isEmpty() == true) {
-                deleteManga(manga, source, removeQueued = false)
-            }
-        }
-    }
+			// Delete manga directory if empty
+			if (mangaDir?.listFiles()?.isEmpty() == true) {
+				deleteManga(manga, source, removeQueued = false)
+			}
+		}
+	}
 
-    /**
-     * Deletes the directory of a downloaded manga.
-     *
-     * @param manga the manga to delete.
-     * @param source the source of the manga.
-     * @param removeQueued whether to also remove queued downloads.
-     */
-    fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
-        launchIO {
-            if (removeQueued) {
-                downloader.removeFromQueue(manga)
-            }
-            provider.findMangaDir(manga.title, source)?.delete()
-            cache.removeManga(manga)
+	/**
+	 * Deletes the directory of a downloaded manga.
+	 *
+	 * @param oldManga the origin manga for migration..
+	 * @param oldSource the origin source for migration..
+	 * @param newManga the target manga for migration.
+	 * @param newSource the target source for migration.
+	 */
+	fun migrateManga(oldManga: Manga, oldSource: Source, newManga: Manga, newSource: Source) {
+		launchIO {
+			val oldMangaDir = provider.findMangaDir(oldManga.title, oldSource) ?: return@launchIO
+			val newMangaDir = provider.getMangaDir(newManga.title, newSource)
+			val downloadedChapters = oldMangaDir.listFiles()
+			val downloadedChaptersMap =
+				downloadedChapters?.associateBy({ it.nameWithoutExtension }, { it }) ?: return@launchIO
 
-            // Delete source directory if empty
-            val sourceDir = provider.findSourceDir(source)
-            if (sourceDir?.listFiles()?.isEmpty() == true) {
-                sourceDir.delete()
-                cache.removeSource(source)
-            }
-        }
-    }
+			// map old chapters to new chapters.  The names may not be the same.
+			val oldChapters = getChaptersByMangaId.await(oldManga.id)
+			val newChapters = getChaptersByMangaId.await(newManga.id)
+			val oldChaptersByChapterNumber = oldChapters.associateBy { it.chapterNumber }
 
-    private fun removeFromDownloadQueue(chapters: List<Chapter>) {
-        val wasRunning = downloader.isRunning
-        if (wasRunning) {
-            downloader.pause()
-        }
+			// If the chapter is downloaded, migrate it.
+			for (chapter in newChapters) {
+				val oldChapter = oldChaptersByChapterNumber[chapter.chapterNumber]
+				if (oldChapter != null) {
+					val oldChapterName = provider.getChapterDirName(oldChapter.name, oldChapter.scanlator)
+					val oldChapterFile = downloadedChaptersMap[oldChapterName]
+					if (oldChapterFile != null) {
+						val newChapterName = if (oldChapterFile.extension == null) {
+							provider.getChapterDirName(chapter.name, chapter.scanlator)
+						} else {
+							provider.getChapterDirName(chapter.name, chapter.scanlator) + "." + oldChapterFile.extension
+						}
 
-        downloader.removeFromQueue(chapters)
+						// move the file to newMangaDir, renaming the file/folder in the process
+						var chapterUri: Uri? = oldChapterFile.uri
+						chapterUri = chapterUri?.let {
+							DocumentsContract.renameDocument(
+								context.contentResolver,
+								it, newChapterName,
+							)
+						}
+						chapterUri = chapterUri?.let {
+							DocumentsContract.moveDocument(
+								context.contentResolver,
+								it, oldMangaDir.uri, newMangaDir.uri,
+							)
+						}
 
-        if (wasRunning) {
-            if (queueState.value.isEmpty()) {
-                downloader.stop()
-            } else if (queueState.value.isNotEmpty()) {
-                downloader.start()
-            }
-        }
-    }
+						cache.removeChapter(oldChapter, oldManga)
+						cache.addChapter(newChapterName, newMangaDir, newManga)
+					}
+				}
+			}
+		}
+	}
 
-    /**
-     * Adds a list of chapters to be deleted later.
-     *
-     * @param chapters the list of chapters to delete.
-     * @param manga the manga of the chapters.
-     */
-    suspend fun enqueueChaptersToDelete(chapters: List<Chapter>, manga: Manga) {
-        pendingDeleter.addChapters(getChaptersToDelete(chapters, manga), manga)
-    }
+	/**
+	 * Deletes the directory of a downloaded manga.
+	 *
+	 * @param manga the manga to delete.
+	 * @param source the source of the manga.
+	 * @param removeQueued whether to also remove queued downloads.
+	 */
+	fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
+		launchIO {
+			if (removeQueued) {
+				downloader.removeFromQueue(manga)
+			}
+			provider.findMangaDir(manga.title, source)?.delete()
+			cache.removeManga(manga)
 
-    /**
-     * Triggers the execution of the deletion of pending chapters.
-     */
-    fun deletePendingChapters() {
-        val pendingChapters = pendingDeleter.getPendingChapters()
-        for ((manga, chapters) in pendingChapters) {
-            val source = sourceManager.get(manga.source) ?: continue
-            deleteChapters(chapters, manga, source)
-        }
-    }
+			// Delete source directory if empty
+			val sourceDir = provider.findSourceDir(source)
+			if (sourceDir?.listFiles()?.isEmpty() == true) {
+				sourceDir.delete()
+				cache.removeSource(source)
+			}
+		}
+	}
 
-    /**
-     * Renames source download folder
-     *
-     * @param oldSource the old source.
-     * @param newSource the new source.
-     */
-    fun renameSource(oldSource: Source, newSource: Source) {
-        val oldFolder = provider.findSourceDir(oldSource) ?: return
-        val newName = provider.getSourceDirName(newSource)
+	private fun removeFromDownloadQueue(chapters: List<Chapter>) {
+		val wasRunning = downloader.isRunning
+		if (wasRunning) {
+			downloader.pause()
+		}
 
-        if (oldFolder.name == newName) return
+		downloader.removeFromQueue(chapters)
 
-        val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
-        if (capitalizationChanged) {
-            val tempName = newName + Downloader.TMP_DIR_SUFFIX
-            if (!oldFolder.renameTo(tempName)) {
-                logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
-                return
-            }
-        }
+		if (wasRunning) {
+			if (queueState.value.isEmpty()) {
+				downloader.stop()
+			} else if (queueState.value.isNotEmpty()) {
+				downloader.start()
+			}
+		}
+	}
 
-        if (!oldFolder.renameTo(newName)) {
-            logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
-        }
-    }
+	/**
+	 * Adds a list of chapters to be deleted later.
+	 *
+	 * @param chapters the list of chapters to delete.
+	 * @param manga the manga of the chapters.
+	 */
+	suspend fun enqueueChaptersToDelete(chapters: List<Chapter>, manga: Manga) {
+		pendingDeleter.addChapters(getChaptersToDelete(chapters, manga), manga)
+	}
 
-    /**
-     * Renames an already downloaded chapter
-     *
-     * @param source the source of the manga.
-     * @param manga the manga of the chapter.
-     * @param oldChapter the existing chapter with the old name.
-     * @param newChapter the target chapter with the new name.
-     */
-    suspend fun renameChapter(source: Source, manga: Manga, oldChapter: Chapter, newChapter: Chapter) {
-        val oldNames = provider.getValidChapterDirNames(oldChapter.name, oldChapter.scanlator)
-        val mangaDir = provider.getMangaDir(manga.title, source)
+	/**
+	 * Triggers the execution of the deletion of pending chapters.
+	 */
+	fun deletePendingChapters() {
+		val pendingChapters = pendingDeleter.getPendingChapters()
+		for ((manga, chapters) in pendingChapters) {
+			val source = sourceManager.get(manga.source) ?: continue
+			deleteChapters(chapters, manga, source)
+		}
+	}
 
-        // Assume there's only 1 version of the chapter name formats present
-        val oldDownload = oldNames.asSequence()
-            .mapNotNull { mangaDir.findFile(it) }
-            .firstOrNull() ?: return
+	/**
+	 * Renames source download folder
+	 *
+	 * @param oldSource the old source.
+	 * @param newSource the new source.
+	 */
+	fun renameSource(oldSource: Source, newSource: Source) {
+		val oldFolder = provider.findSourceDir(oldSource) ?: return
+		val newName = provider.getSourceDirName(newSource)
 
-        var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator)
-        if (oldDownload.isFile && oldDownload.extension == "cbz") {
-            newName += ".cbz"
-        }
+		if (oldFolder.name == newName) return
 
-        if (oldDownload.name == newName) return
+		val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
+		if (capitalizationChanged) {
+			val tempName = newName + Downloader.TMP_DIR_SUFFIX
+			if (!oldFolder.renameTo(tempName)) {
+				logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
+				return
+			}
+		}
 
-        if (oldDownload.renameTo(newName)) {
-            cache.removeChapter(oldChapter, manga)
-            cache.addChapter(newName, mangaDir, manga)
-        } else {
-            logcat(LogPriority.ERROR) { "Could not rename downloaded chapter: ${oldNames.joinToString()}" }
-        }
-    }
+		if (!oldFolder.renameTo(newName)) {
+			logcat(LogPriority.ERROR) { "Failed to rename source download folder: ${oldFolder.name}" }
+		}
+	}
 
-    private suspend fun getChaptersToDelete(chapters: List<Chapter>, manga: Manga): List<Chapter> {
-        // Retrieve the categories that are set to exclude from being deleted on read
-        val categoriesToExclude = downloadPreferences.removeExcludeCategories().get().map(String::toLong)
+	/**
+	 * Renames an already downloaded chapter
+	 *
+	 * @param source the source of the manga.
+	 * @param manga the manga of the chapter.
+	 * @param oldChapter the existing chapter with the old name.
+	 * @param newChapter the target chapter with the new name.
+	 */
+	suspend fun renameChapter(source: Source, manga: Manga, oldChapter: Chapter, newChapter: Chapter) {
+		val oldNames = provider.getValidChapterDirNames(oldChapter.name, oldChapter.scanlator)
+		val mangaDir = provider.getMangaDir(manga.title, source)
 
-        val categoriesForManga = getCategories.await(manga.id)
-            .map { it.id }
-            .ifEmpty { listOf(0) }
-        val filteredCategoryManga = if (categoriesForManga.intersect(categoriesToExclude).isNotEmpty()) {
-            chapters.filterNot { it.read }
-        } else {
-            chapters
-        }
+		// Assume there's only 1 version of the chapter name formats present
+		val oldDownload = oldNames.asSequence()
+			.mapNotNull { mangaDir.findFile(it) }
+			.firstOrNull() ?: return
 
-        return if (!downloadPreferences.removeBookmarkedChapters().get()) {
-            filteredCategoryManga.filterNot { it.bookmark }
-        } else {
-            filteredCategoryManga
-        }
-    }
+		var newName = provider.getChapterDirName(newChapter.name, newChapter.scanlator)
+		if (oldDownload.isFile && oldDownload.extension == "cbz") {
+			newName += ".cbz"
+		}
 
-    fun statusFlow(): Flow<Download> = queueState
-        .flatMapLatest { downloads ->
-            downloads
-                .map { download ->
-                    download.statusFlow.drop(1).map { download }
-                }
-                .merge()
-        }
-        .onStart {
-            emitAll(
-                queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }.asFlow(),
-            )
-        }
+		if (oldDownload.name == newName) return
 
-    fun progressFlow(): Flow<Download> = queueState
-        .flatMapLatest { downloads ->
-            downloads
-                .map { download ->
-                    download.progressFlow.drop(1).map { download }
-                }
-                .merge()
-        }
-        .onStart {
-            emitAll(
-                queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }
-                    .asFlow(),
-            )
-        }
+		if (oldDownload.renameTo(newName)) {
+			cache.removeChapter(oldChapter, manga)
+			cache.addChapter(newName, mangaDir, manga)
+		} else {
+			logcat(LogPriority.ERROR) { "Could not rename downloaded chapter: ${oldNames.joinToString()}" }
+		}
+	}
+
+	private suspend fun getChaptersToDelete(chapters: List<Chapter>, manga: Manga): List<Chapter> {
+		// Retrieve the categories that are set to exclude from being deleted on read
+		val categoriesToExclude = downloadPreferences.removeExcludeCategories().get().map(String::toLong)
+
+		val categoriesForManga = getCategories.await(manga.id)
+			.map { it.id }
+			.ifEmpty { listOf(0) }
+		val filteredCategoryManga = if (categoriesForManga.intersect(categoriesToExclude).isNotEmpty()) {
+			chapters.filterNot { it.read }
+		} else {
+			chapters
+		}
+
+		return if (!downloadPreferences.removeBookmarkedChapters().get()) {
+			filteredCategoryManga.filterNot { it.bookmark }
+		} else {
+			filteredCategoryManga
+		}
+	}
+
+	fun statusFlow(): Flow<Download> = queueState
+		.flatMapLatest { downloads ->
+			downloads
+				.map { download ->
+					download.statusFlow.drop(1).map { download }
+				}
+				.merge()
+		}
+		.onStart {
+			emitAll(
+				queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }.asFlow(),
+			)
+		}
+
+	fun progressFlow(): Flow<Download> = queueState
+		.flatMapLatest { downloads ->
+			downloads
+				.map { download ->
+					download.progressFlow.drop(1).map { download }
+				}
+				.merge()
+		}
+		.onStart {
+			emitAll(
+				queueState.value.filter { download -> download.status == Download.State.DOWNLOADING }
+					.asFlow(),
+			)
+		}
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -73,309 +73,309 @@ import java.util.zip.ZipOutputStream
  * Its queue contains the list of chapters to download.
  */
 class Downloader(
-	private val context: Context,
-	private val provider: DownloadProvider,
-	private val cache: DownloadCache,
-	private val sourceManager: SourceManager = Injekt.get(),
-	private val chapterCache: ChapterCache = Injekt.get(),
-	private val downloadPreferences: DownloadPreferences = Injekt.get(),
-	private val xml: XML = Injekt.get(),
-	private val getCategories: GetCategories = Injekt.get(),
-	private val getTracks: GetTracks = Injekt.get(),
+    private val context: Context,
+    private val provider: DownloadProvider,
+    private val cache: DownloadCache,
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val chapterCache: ChapterCache = Injekt.get(),
+    private val downloadPreferences: DownloadPreferences = Injekt.get(),
+    private val xml: XML = Injekt.get(),
+    private val getCategories: GetCategories = Injekt.get(),
+    private val getTracks: GetTracks = Injekt.get(),
 ) {
 
-	/**
-	 * Store for persisting downloads across restarts.
-	 */
-	private val store = DownloadStore(context)
+    /**
+     * Store for persisting downloads across restarts.
+     */
+    private val store = DownloadStore(context)
 
-	/**
-	 * Queue where active downloads are kept.
-	 */
-	private val _queueState = MutableStateFlow<List<Download>>(emptyList())
-	val queueState = _queueState.asStateFlow()
+    /**
+     * Queue where active downloads are kept.
+     */
+    private val _queueState = MutableStateFlow<List<Download>>(emptyList())
+    val queueState = _queueState.asStateFlow()
 
-	/**
-	 * Notifier for the downloader state and progress.
-	 */
-	private val notifier by lazy { DownloadNotifier(context) }
+    /**
+     * Notifier for the downloader state and progress.
+     */
+    private val notifier by lazy { DownloadNotifier(context) }
 
-	private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-	private var downloaderJob: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var downloaderJob: Job? = null
 
-	/**
-	 * Whether the downloader is running.
-	 */
-	val isRunning: Boolean
-		get() = downloaderJob?.isActive ?: false
+    /**
+     * Whether the downloader is running.
+     */
+    val isRunning: Boolean
+        get() = downloaderJob?.isActive ?: false
 
-	/**
-	 * Whether the downloader is paused
-	 */
-	@Volatile
-	var isPaused: Boolean = false
+    /**
+     * Whether the downloader is paused
+     */
+    @Volatile
+    var isPaused: Boolean = false
 
-	init {
-		launchNow {
-			val chapters = async { store.restore() }
-			addAllToQueue(chapters.await())
-		}
-	}
+    init {
+        launchNow {
+            val chapters = async { store.restore() }
+            addAllToQueue(chapters.await())
+        }
+    }
 
-	/**
-	 * Starts the downloader. It doesn't do anything if it's already running or there isn't anything
-	 * to download.
-	 *
-	 * @return true if the downloader is started, false otherwise.
-	 */
-	fun start(): Boolean {
-		if (isRunning || queueState.value.isEmpty()) {
-			return false
-		}
+    /**
+     * Starts the downloader. It doesn't do anything if it's already running or there isn't anything
+     * to download.
+     *
+     * @return true if the downloader is started, false otherwise.
+     */
+    fun start(): Boolean {
+        if (isRunning || queueState.value.isEmpty()) {
+            return false
+        }
 
-		val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
-		pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
+        val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
+        pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
 
-		isPaused = false
+        isPaused = false
 
-		launchDownloaderJob()
+        launchDownloaderJob()
 
-		return pending.isNotEmpty()
-	}
+        return pending.isNotEmpty()
+    }
 
-	/**
-	 * Stops the downloader.
-	 */
-	fun stop(reason: String? = null) {
-		cancelDownloaderJob()
-		queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.ERROR }
+    /**
+     * Stops the downloader.
+     */
+    fun stop(reason: String? = null) {
+        cancelDownloaderJob()
+        queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.ERROR }
 
-		if (reason != null) {
-			notifier.onWarning(reason)
-			return
-		}
+        if (reason != null) {
+            notifier.onWarning(reason)
+            return
+        }
 
-		if (isPaused && queueState.value.isNotEmpty()) {
-			notifier.onPaused()
-		} else {
-			notifier.onComplete()
-		}
+        if (isPaused && queueState.value.isNotEmpty()) {
+            notifier.onPaused()
+        } else {
+            notifier.onComplete()
+        }
 
-		isPaused = false
+        isPaused = false
 
-		DownloadJob.stop(context)
-	}
+        DownloadJob.stop(context)
+    }
 
-	/**
-	 * Pauses the downloader
-	 */
-	fun pause() {
-		cancelDownloaderJob()
-		queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.QUEUE }
-		isPaused = true
-	}
+    /**
+     * Pauses the downloader
+     */
+    fun pause() {
+        cancelDownloaderJob()
+        queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.QUEUE }
+        isPaused = true
+    }
 
-	/**
-	 * Removes everything from the queue.
-	 */
-	fun clearQueue() {
-		cancelDownloaderJob()
+    /**
+     * Removes everything from the queue.
+     */
+    fun clearQueue() {
+        cancelDownloaderJob()
 
-		internalClearQueue()
-		notifier.dismissProgress()
-	}
+        internalClearQueue()
+        notifier.dismissProgress()
+    }
 
-	/**
-	 * Prepares the subscriptions to start downloading.
-	 */
-	private fun launchDownloaderJob() {
-		if (isRunning) return
+    /**
+     * Prepares the subscriptions to start downloading.
+     */
+    private fun launchDownloaderJob() {
+        if (isRunning) return
 
-		downloaderJob = scope.launch {
-			val activeDownloadsFlow = queueState.transformLatest { queue ->
-				while (true) {
-					val activeDownloads = queue.asSequence()
-						// Ignore completed downloads, leave them in the queue
-						.filter { it.status.value <= Download.State.DOWNLOADING.value }.groupBy { it.source }.toList()
-						// Concurrently download from 5 different sources
-						.take(5).map { (_, downloads) -> downloads.first() }
-					emit(activeDownloads)
+        downloaderJob = scope.launch {
+            val activeDownloadsFlow = queueState.transformLatest { queue ->
+                while (true) {
+                    val activeDownloads = queue.asSequence()
+                        // Ignore completed downloads, leave them in the queue
+                        .filter { it.status.value <= Download.State.DOWNLOADING.value }.groupBy { it.source }.toList()
+                        // Concurrently download from 5 different sources
+                        .take(5).map { (_, downloads) -> downloads.first() }
+                    emit(activeDownloads)
 
-					if (activeDownloads.isEmpty()) break
-					// Suspend until a download enters the ERROR state
-					val activeDownloadsErroredFlow = combine(activeDownloads.map(Download::statusFlow)) { states ->
-						states.contains(Download.State.ERROR)
-					}.filter { it }
-					activeDownloadsErroredFlow.first()
-				}
-			}.distinctUntilChanged()
+                    if (activeDownloads.isEmpty()) break
+                    // Suspend until a download enters the ERROR state
+                    val activeDownloadsErroredFlow = combine(activeDownloads.map(Download::statusFlow)) { states ->
+                        states.contains(Download.State.ERROR)
+                    }.filter { it }
+                    activeDownloadsErroredFlow.first()
+                }
+            }.distinctUntilChanged()
 
-			// Use supervisorScope to cancel child jobs when the downloader job is cancelled
-			supervisorScope {
-				val downloadJobs = mutableMapOf<Download, Job>()
+            // Use supervisorScope to cancel child jobs when the downloader job is cancelled
+            supervisorScope {
+                val downloadJobs = mutableMapOf<Download, Job>()
 
-				activeDownloadsFlow.collectLatest { activeDownloads ->
-					val downloadJobsToStop = downloadJobs.filter { it.key !in activeDownloads }
-					downloadJobsToStop.forEach { (download, job) ->
-						job.cancel()
-						downloadJobs.remove(download)
-					}
+                activeDownloadsFlow.collectLatest { activeDownloads ->
+                    val downloadJobsToStop = downloadJobs.filter { it.key !in activeDownloads }
+                    downloadJobsToStop.forEach { (download, job) ->
+                        job.cancel()
+                        downloadJobs.remove(download)
+                    }
 
-					val downloadsToStart = activeDownloads.filter { it !in downloadJobs }
-					downloadsToStart.forEach { download ->
-						downloadJobs[download] = launchDownloadJob(download)
-					}
-				}
-			}
-		}
-	}
+                    val downloadsToStart = activeDownloads.filter { it !in downloadJobs }
+                    downloadsToStart.forEach { download ->
+                        downloadJobs[download] = launchDownloadJob(download)
+                    }
+                }
+            }
+        }
+    }
 
-	private fun CoroutineScope.launchDownloadJob(download: Download) = launchIO {
-		try {
-			downloadChapter(download)
+    private fun CoroutineScope.launchDownloadJob(download: Download) = launchIO {
+        try {
+            downloadChapter(download)
 
-			// Remove successful download from queue
-			if (download.status == Download.State.DOWNLOADED) {
-				removeFromQueue(download)
-			}
-			if (areAllDownloadsFinished()) {
-				stop()
-			}
-		} catch (e: Throwable) {
-			if (e is CancellationException) throw e
-			logcat(LogPriority.ERROR, e)
-			notifier.onError(e.message)
-			stop()
-		}
-	}
+            // Remove successful download from queue
+            if (download.status == Download.State.DOWNLOADED) {
+                removeFromQueue(download)
+            }
+            if (areAllDownloadsFinished()) {
+                stop()
+            }
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            logcat(LogPriority.ERROR, e)
+            notifier.onError(e.message)
+            stop()
+        }
+    }
 
-	/**
-	 * Destroys the downloader subscriptions.
-	 */
-	private fun cancelDownloaderJob() {
-		downloaderJob?.cancel()
-		downloaderJob = null
-	}
+    /**
+     * Destroys the downloader subscriptions.
+     */
+    private fun cancelDownloaderJob() {
+        downloaderJob?.cancel()
+        downloaderJob = null
+    }
 
-	/**
-	 * Creates a download object for every chapter and adds them to the downloads queue.
-	 *
-	 * @param manga the manga of the chapters to download.
-	 * @param chapters the list of chapters to download.
-	 * @param autoStart whether to start the downloader after enqueing the chapters.
-	 */
-	fun queueChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean) {
-		if (chapters.isEmpty()) return
+    /**
+     * Creates a download object for every chapter and adds them to the downloads queue.
+     *
+     * @param manga the manga of the chapters to download.
+     * @param chapters the list of chapters to download.
+     * @param autoStart whether to start the downloader after enqueing the chapters.
+     */
+    fun queueChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean) {
+        if (chapters.isEmpty()) return
 
-		val source = sourceManager.get(manga.source) as? HttpSource ?: return
-		val wasEmpty = queueState.value.isEmpty()
-		val chaptersToQueue = chapters.asSequence()
-			// Filter out those already downloaded.
-			.filter { provider.findChapterDir(it.name, it.scanlator, manga.title, source) == null }
-			// Add chapters to queue from the start.
-			.sortedByDescending { it.sourceOrder }
-			// Filter out those already enqueued.
-			.filter { chapter -> queueState.value.none { it.chapter.id == chapter.id } }
-			// Create a download for each one.
-			.map { Download(source, manga, it) }.toList()
+        val source = sourceManager.get(manga.source) as? HttpSource ?: return
+        val wasEmpty = queueState.value.isEmpty()
+        val chaptersToQueue = chapters.asSequence()
+            // Filter out those already downloaded.
+            .filter { provider.findChapterDir(it.name, it.scanlator, manga.title, source) == null }
+            // Add chapters to queue from the start.
+            .sortedByDescending { it.sourceOrder }
+            // Filter out those already enqueued.
+            .filter { chapter -> queueState.value.none { it.chapter.id == chapter.id } }
+            // Create a download for each one.
+            .map { Download(source, manga, it) }.toList()
 
-		if (chaptersToQueue.isNotEmpty()) {
-			addAllToQueue(chaptersToQueue)
+        if (chaptersToQueue.isNotEmpty()) {
+            addAllToQueue(chaptersToQueue)
 
-			// Start downloader if needed
-			if (autoStart && wasEmpty) {
-				val queuedDownloads = queueState.value.count { it.source !is UnmeteredSource }
-				val maxDownloadsFromSource =
-					queueState.value.groupBy { it.source }.filterKeys { it !is UnmeteredSource }
-						.maxOfOrNull { it.value.size } ?: 0
-				if (queuedDownloads > DOWNLOADS_QUEUED_WARNING_THRESHOLD || maxDownloadsFromSource > CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD) {
-					notifier.onWarning(
-						context.stringResource(MR.strings.download_queue_size_warning),
-						WARNING_NOTIF_TIMEOUT_MS,
-						NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
-					)
-				}
-				DownloadJob.start(context)
-			}
-		}
-	}
+            // Start downloader if needed
+            if (autoStart && wasEmpty) {
+                val queuedDownloads = queueState.value.count { it.source !is UnmeteredSource }
+                val maxDownloadsFromSource =
+                    queueState.value.groupBy { it.source }.filterKeys { it !is UnmeteredSource }
+                        .maxOfOrNull { it.value.size } ?: 0
+                if (queuedDownloads > DOWNLOADS_QUEUED_WARNING_THRESHOLD || maxDownloadsFromSource > CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD) {
+                    notifier.onWarning(
+                        context.stringResource(MR.strings.download_queue_size_warning),
+                        WARNING_NOTIF_TIMEOUT_MS,
+                        NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
+                    )
+                }
+                DownloadJob.start(context)
+            }
+        }
+    }
 
-	/**
-	 * Downloads a chapter.
-	 *
-	 * @param download the chapter to be downloaded.
-	 */
-	private suspend fun downloadChapter(download: Download) {
-		val mangaDir = provider.getMangaDir(download.manga.title, download.source)
+    /**
+     * Downloads a chapter.
+     *
+     * @param download the chapter to be downloaded.
+     */
+    private suspend fun downloadChapter(download: Download) {
+        val mangaDir = provider.getMangaDir(download.manga.title, download.source)
 
-		val availSpace = DiskUtil.getAvailableStorageSpace(mangaDir)
-		if (availSpace != -1L && availSpace < MIN_DISK_SPACE) {
-			download.status = Download.State.ERROR
-			notifier.onError(
-				context.stringResource(MR.strings.download_insufficient_space),
-				download.chapter.name,
-				download.manga.title,
-				download.manga.id,
-			)
-			return
-		}
+        val availSpace = DiskUtil.getAvailableStorageSpace(mangaDir)
+        if (availSpace != -1L && availSpace < MIN_DISK_SPACE) {
+            download.status = Download.State.ERROR
+            notifier.onError(
+                context.stringResource(MR.strings.download_insufficient_space),
+                download.chapter.name,
+                download.manga.title,
+                download.manga.id,
+            )
+            return
+        }
 
-		val chapterDirname = provider.getChapterDirName(download.chapter.name, download.chapter.scanlator)
+        val chapterDirname = provider.getChapterDirName(download.chapter.name, download.chapter.scanlator)
 
-		if (downloadPreferences.saveChaptersAsCBZ().get() && downloadPreferences.saveChaptersCBZInRAM().get()) {
-			// create tmpDir as an in-memory file
-			downloadChapterInRam(download, mangaDir, chapterDirname)
-		} else {
-			downloadChapterInStorage(download, mangaDir, chapterDirname)
-		}
-	}
+        if (downloadPreferences.saveChaptersAsCBZ().get() && downloadPreferences.saveChaptersCBZInRAM().get()) {
+            // create tmpDir as an in-memory file
+            downloadChapterInRam(download, mangaDir, chapterDirname)
+        } else {
+            downloadChapterInStorage(download, mangaDir, chapterDirname)
+        }
+    }
 
-	private suspend fun downloadChapterInRam(download: Download, mangaDir: UniFile, chapterDirname: String) {
-		try {
-			// If the page list already exists, start from the file
-			val pageList = download.pages ?: run {
-				// Otherwise, pull page list from network and add them to download object
-				val pages = download.source.getPageList(download.chapter.toSChapter())
+    private suspend fun downloadChapterInRam(download: Download, mangaDir: UniFile, chapterDirname: String) {
+        try {
+            // If the page list already exists, start from the file
+            val pageList = download.pages ?: run {
+                // Otherwise, pull page list from network and add them to download object
+                val pages = download.source.getPageList(download.chapter.toSChapter())
 
-				if (pages.isEmpty()) {
-					throw Exception(context.stringResource(MR.strings.page_list_empty_error))
-				}
-				// Don't trust index from source
-				val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
-				download.pages = reIndexedPages
-				reIndexedPages
-			}
+                if (pages.isEmpty()) {
+                    throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+                }
+                // Don't trust index from source
+                val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
+                download.pages = reIndexedPages
+                reIndexedPages
+            }
 
-			download.status = Download.State.DOWNLOADING
-			val pds = ArrayList<PageData>()
+            download.status = Download.State.DOWNLOADING
+            val pds = ArrayList<PageData>()
 
-			// Start downloading images, consider we can have downloaded images already
-			// Concurrently do 2 pages at a time
-			pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
-				flow {
-					// Fetch image URL if necessary
-					if (page.imageUrl.isNullOrEmpty()) {
-						page.status = Page.State.LOAD_PAGE
-						try {
-							page.imageUrl = download.source.getImageUrl(page)
-						} catch (e: Throwable) {
-							page.status = Page.State.ERROR
-						}
-					}
+            // Start downloading images, consider we can have downloaded images already
+            // Concurrently do 2 pages at a time
+            pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
+                flow {
+                    // Fetch image URL if necessary
+                    if (page.imageUrl.isNullOrEmpty()) {
+                        page.status = Page.State.LOAD_PAGE
+                        try {
+                            page.imageUrl = download.source.getImageUrl(page)
+                        } catch (e: Throwable) {
+                            page.status = Page.State.ERROR
+                        }
+                    }
 
-					withIOContext { getOrDownloadImageData(page, download, pds) }
-					emit(page)
-				}.flowOn(Dispatchers.IO)
-			}.collect {
-				// Do when page is downloaded.
-				notifier.onProgressChange(download)
-			}
+                    withIOContext { getOrDownloadImageData(page, download, pds) }
+                    emit(page)
+                }.flowOn(Dispatchers.IO)
+            }.collect {
+                // Do when page is downloaded.
+                notifier.onProgressChange(download)
+            }
 
-			// Do after download completes
-			if (!isDownloadSuccessful(download, pds)) {
-				download.status = Download.State.ERROR
-				return
-			}
+            // Do after download completes
+            if (!isDownloadSuccessful(download, pds)) {
+                download.status = Download.State.ERROR
+                return
+            }
 
 //			val ci = createComicInfoData(
 //				download.manga,
@@ -383,519 +383,519 @@ class Downloader(
 //				download.source,
 //			)
 
-			// Create zip of the downloaded data
-			val zip = mangaDir.createFile("$chapterDirname.cbz$TMP_DIR_SUFFIX")!!
-			ZipOutputStream(zip.openOutputStream()).use { zipOut ->
-				pds.forEach { pd ->
-					val ze = ZipEntry(pd.name)
-					zipOut.putNextEntry(ze)
-					zipOut.write(pd.data)
-					zipOut.closeEntry()
-				}
-			}
+            // Create zip of the downloaded data
+            val zip = mangaDir.createFile("$chapterDirname.cbz$TMP_DIR_SUFFIX")!!
+            ZipOutputStream(zip.openOutputStream()).use { zipOut ->
+                pds.forEach { pd ->
+                    val ze = ZipEntry(pd.name)
+                    zipOut.putNextEntry(ze)
+                    zipOut.write(pd.data)
+                    zipOut.closeEntry()
+                }
+            }
 
-			zip.renameTo("$chapterDirname.cbz")
+            zip.renameTo("$chapterDirname.cbz")
 
-			cache.addChapter(chapterDirname, mangaDir, download.manga)
+            cache.addChapter(chapterDirname, mangaDir, download.manga)
 
-			download.status = Download.State.DOWNLOADED
-		} catch (error: Throwable) {
-			if (error is CancellationException) throw error
-			// If the page list threw, it will resume here
-			logcat(LogPriority.ERROR, error)
-			download.status = Download.State.ERROR
-			notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
-		}
-	}
+            download.status = Download.State.DOWNLOADED
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            // If the page list threw, it will resume here
+            logcat(LogPriority.ERROR, error)
+            download.status = Download.State.ERROR
+            notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
+        }
+    }
 
-	private suspend fun downloadChapterInStorage(download: Download, mangaDir: UniFile, chapterDirname: String) {
-		val tmpDir = mangaDir.createDirectory(chapterDirname + TMP_DIR_SUFFIX)!!
+    private suspend fun downloadChapterInStorage(download: Download, mangaDir: UniFile, chapterDirname: String) {
+        val tmpDir = mangaDir.createDirectory(chapterDirname + TMP_DIR_SUFFIX)!!
 
-		try {
-			// If the page list already exists, start from the file
-			val pageList = download.pages ?: run {
-				// Otherwise, pull page list from network and add them to download object
-				val pages = download.source.getPageList(download.chapter.toSChapter())
+        try {
+            // If the page list already exists, start from the file
+            val pageList = download.pages ?: run {
+                // Otherwise, pull page list from network and add them to download object
+                val pages = download.source.getPageList(download.chapter.toSChapter())
 
-				if (pages.isEmpty()) {
-					throw Exception(context.stringResource(MR.strings.page_list_empty_error))
-				}
-				// Don't trust index from source
-				val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
-				download.pages = reIndexedPages
-				reIndexedPages
-			}
+                if (pages.isEmpty()) {
+                    throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+                }
+                // Don't trust index from source
+                val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
+                download.pages = reIndexedPages
+                reIndexedPages
+            }
 
-			// Delete all temporary (unfinished) files
-			tmpDir.listFiles()?.filter { it.extension == "tmp" }?.forEach { it.delete() }
+            // Delete all temporary (unfinished) files
+            tmpDir.listFiles()?.filter { it.extension == "tmp" }?.forEach { it.delete() }
 
-			download.status = Download.State.DOWNLOADING
+            download.status = Download.State.DOWNLOADING
 
-			// Start downloading images, consider we can have downloaded images already
-			// Concurrently do 2 pages at a time
-			pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
-				flow {
-					// Fetch image URL if necessary
-					if (page.imageUrl.isNullOrEmpty()) {
-						page.status = Page.State.LOAD_PAGE
-						try {
-							page.imageUrl = download.source.getImageUrl(page)
-						} catch (e: Throwable) {
-							page.status = Page.State.ERROR
-						}
-					}
+            // Start downloading images, consider we can have downloaded images already
+            // Concurrently do 2 pages at a time
+            pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
+                flow {
+                    // Fetch image URL if necessary
+                    if (page.imageUrl.isNullOrEmpty()) {
+                        page.status = Page.State.LOAD_PAGE
+                        try {
+                            page.imageUrl = download.source.getImageUrl(page)
+                        } catch (e: Throwable) {
+                            page.status = Page.State.ERROR
+                        }
+                    }
 
-					withIOContext { getOrDownloadImage(page, download, tmpDir) }
-					emit(page)
-				}.flowOn(Dispatchers.IO)
-			}.collect {
-				// Do when page is downloaded.
-				notifier.onProgressChange(download)
-			}
+                    withIOContext { getOrDownloadImage(page, download, tmpDir) }
+                    emit(page)
+                }.flowOn(Dispatchers.IO)
+            }.collect {
+                // Do when page is downloaded.
+                notifier.onProgressChange(download)
+            }
 
-			// Do after download completes
+            // Do after download completes
 
-			if (!isDownloadSuccessful(download, tmpDir)) {
-				download.status = Download.State.ERROR
-				return
-			}
+            if (!isDownloadSuccessful(download, tmpDir)) {
+                download.status = Download.State.ERROR
+                return
+            }
 
-			createComicInfoFile(
-				tmpDir,
-				download.manga,
-				download.chapter,
-				download.source,
-			)
+            createComicInfoFile(
+                tmpDir,
+                download.manga,
+                download.chapter,
+                download.source,
+            )
 
-			// Only rename the directory if it's downloaded
-			if (downloadPreferences.saveChaptersAsCBZ().get()) {
-				archiveChapter(mangaDir, chapterDirname, tmpDir)
-			} else {
-				tmpDir.renameTo(chapterDirname)
-			}
-			cache.addChapter(chapterDirname, mangaDir, download.manga)
+            // Only rename the directory if it's downloaded
+            if (downloadPreferences.saveChaptersAsCBZ().get()) {
+                archiveChapter(mangaDir, chapterDirname, tmpDir)
+            } else {
+                tmpDir.renameTo(chapterDirname)
+            }
+            cache.addChapter(chapterDirname, mangaDir, download.manga)
 
-			DiskUtil.createNoMediaFile(tmpDir, context)
+            DiskUtil.createNoMediaFile(tmpDir, context)
 
-			download.status = Download.State.DOWNLOADED
-		} catch (error: Throwable) {
-			if (error is CancellationException) throw error
-			// If the page list threw, it will resume here
-			logcat(LogPriority.ERROR, error)
-			download.status = Download.State.ERROR
-			notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
-		}
-	}
+            download.status = Download.State.DOWNLOADED
+        } catch (error: Throwable) {
+            if (error is CancellationException) throw error
+            // If the page list threw, it will resume here
+            logcat(LogPriority.ERROR, error)
+            download.status = Download.State.ERROR
+            notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
+        }
+    }
 
-	/**
-	 * Gets the image from the filesystem if it exists or downloads it otherwise.
-	 *
-	 * @param page the page to download.
-	 * @param download the download of the page.
-	 * @param tmpDir the temporary directory of the download.
-	 */
-	private suspend fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile) {
-		// If the image URL is empty, do nothing
-		if (page.imageUrl == null) {
-			return
-		}
+    /**
+     * Gets the image from the filesystem if it exists or downloads it otherwise.
+     *
+     * @param page the page to download.
+     * @param download the download of the page.
+     * @param tmpDir the temporary directory of the download.
+     */
+    private suspend fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile) {
+        // If the image URL is empty, do nothing
+        if (page.imageUrl == null) {
+            return
+        }
 
-		val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
-		val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
-		val tmpFile = tmpDir.findFile("$filename.tmp")
+        val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
+        val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
+        val tmpFile = tmpDir.findFile("$filename.tmp")
 
-		// Delete temp file if it exists
-		tmpFile?.delete()
+        // Delete temp file if it exists
+        tmpFile?.delete()
 
-		// Try to find the image file
-		val imageFile = tmpDir.listFiles()?.firstOrNull {
-			it.name!!.startsWith("$filename.") || it.name!!.startsWith("${filename}__001")
-		}
+        // Try to find the image file
+        val imageFile = tmpDir.listFiles()?.firstOrNull {
+            it.name!!.startsWith("$filename.") || it.name!!.startsWith("${filename}__001")
+        }
 
-		try {
-			// If the image is already downloaded, do nothing. Otherwise download from network
-			val file = when {
-				imageFile != null -> imageFile
-				chapterCache.isImageInCache(
-					page.imageUrl!!,
-				) -> copyImageFromCache(chapterCache.getImageFile(page.imageUrl!!), tmpDir, filename)
+        try {
+            // If the image is already downloaded, do nothing. Otherwise download from network
+            val file = when {
+                imageFile != null -> imageFile
+                chapterCache.isImageInCache(
+                    page.imageUrl!!,
+                ) -> copyImageFromCache(chapterCache.getImageFile(page.imageUrl!!), tmpDir, filename)
 
-				else -> downloadImage(page, download.source, tmpDir, filename)
-			}
+                else -> downloadImage(page, download.source, tmpDir, filename)
+            }
 
-			// When the page is ready, set page path, progress (just in case) and status
-			splitTallImageIfNeeded(page, tmpDir)
+            // When the page is ready, set page path, progress (just in case) and status
+            splitTallImageIfNeeded(page, tmpDir)
 
-			page.uri = file.uri
-			page.progress = 100
-			page.status = Page.State.READY
-		} catch (e: Throwable) {
-			if (e is CancellationException) throw e
-			// Mark this page as error and allow to download the remaining
-			page.progress = 0
-			page.status = Page.State.ERROR
-			notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
-		}
-	}
+            page.uri = file.uri
+            page.progress = 100
+            page.status = Page.State.READY
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            // Mark this page as error and allow to download the remaining
+            page.progress = 0
+            page.status = Page.State.ERROR
+            notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
+        }
+    }
 
-	/**
-	 * Downloads the image from network to a file in tmpDir.
-	 *
-	 * @param page the page to download.
-	 * @param source the source of the page.
-	 * @param tmpDir the temporary directory of the download.
-	 * @param filename the filename of the image.
-	 */
-	private suspend fun downloadImage(page: Page, source: HttpSource, tmpDir: UniFile, filename: String): UniFile {
-		page.status = Page.State.DOWNLOAD_IMAGE
-		page.progress = 0
-		return flow {
-			val response = source.getImage(page)
-			val file = tmpDir.createFile("$filename.tmp")!!
-			try {
-				response.body.source().saveTo(file.openOutputStream())
-				val extension = getImageExtension(response, file)
-				file.renameTo("$filename.$extension")
-			} catch (e: Exception) {
-				response.close()
-				file.delete()
-				throw e
-			}
-			emit(file)
-		}
-			// Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
-			.retryWhen { _, attempt ->
-				if (attempt < 3) {
-					delay((2L shl attempt.toInt()) * 1000)
-					true
-				} else {
-					false
-				}
-			}.first()
-	}
+    /**
+     * Downloads the image from network to a file in tmpDir.
+     *
+     * @param page the page to download.
+     * @param source the source of the page.
+     * @param tmpDir the temporary directory of the download.
+     * @param filename the filename of the image.
+     */
+    private suspend fun downloadImage(page: Page, source: HttpSource, tmpDir: UniFile, filename: String): UniFile {
+        page.status = Page.State.DOWNLOAD_IMAGE
+        page.progress = 0
+        return flow {
+            val response = source.getImage(page)
+            val file = tmpDir.createFile("$filename.tmp")!!
+            try {
+                response.body.source().saveTo(file.openOutputStream())
+                val extension = getImageExtension(response, file)
+                file.renameTo("$filename.$extension")
+            } catch (e: Exception) {
+                response.close()
+                file.delete()
+                throw e
+            }
+            emit(file)
+        }
+            // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
+            .retryWhen { _, attempt ->
+                if (attempt < 3) {
+                    delay((2L shl attempt.toInt()) * 1000)
+                    true
+                } else {
+                    false
+                }
+            }.first()
+    }
 
-	/**
-	 * Gets the image from the filesystem if it exists or downloads it otherwise.
-	 *
-	 * @param page the page to download.
-	 * @param download the download of the page.
-	 */
-	private suspend fun getOrDownloadImageData(page: Page, download: Download, pds: MutableList<PageData>) {
-		// If the image URL is empty, do nothing
-		if (page.imageUrl == null) {
-			return
-		}
+    /**
+     * Gets the image from the filesystem if it exists or downloads it otherwise.
+     *
+     * @param page the page to download.
+     * @param download the download of the page.
+     */
+    private suspend fun getOrDownloadImageData(page: Page, download: Download, pds: MutableList<PageData>) {
+        // If the image URL is empty, do nothing
+        if (page.imageUrl == null) {
+            return
+        }
 
-		val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
-		val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
+        val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
+        val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
 
-		try {
-			pds.add(downloadImageData(page, download.source, filename))
-			page.progress = 100
-			page.status = Page.State.READY
-		} catch (e: Throwable) {
-			if (e is CancellationException) throw e
-			// Mark this page as error and allow to download the remaining
-			page.progress = 0
-			page.status = Page.State.ERROR
-			notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
-		}
-	}
+        try {
+            pds.add(downloadImageData(page, download.source, filename))
+            page.progress = 100
+            page.status = Page.State.READY
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            // Mark this page as error and allow to download the remaining
+            page.progress = 0
+            page.status = Page.State.ERROR
+            notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
+        }
+    }
 
-	/**
-	 * Downloads the image from network to a file in tmpDir.
-	 *
-	 * @param page the page to download.
-	 * @param source the source of the page.
-	 * @param filename the filename of the image.
-	 */
-	private suspend fun downloadImageData(page: Page, source: HttpSource, filename: String): PageData {
-		page.status = Page.State.DOWNLOAD_IMAGE
-		page.progress = 0
+    /**
+     * Downloads the image from network to a file in tmpDir.
+     *
+     * @param page the page to download.
+     * @param source the source of the page.
+     * @param filename the filename of the image.
+     */
+    private suspend fun downloadImageData(page: Page, source: HttpSource, filename: String): PageData {
+        page.status = Page.State.DOWNLOAD_IMAGE
+        page.progress = 0
 
-		return flow {
-			val response = source.getImage(page)
-			try {
-				val baos = ByteArrayOutputStream()
-				response.body.source().saveTo(baos)
-				val imgData = baos.toByteArray()
-				val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
-				val extension = ImageUtil.getExtensionFromMimeType(mime) { ByteArrayInputStream(imgData) }
+        return flow {
+            val response = source.getImage(page)
+            try {
+                val baos = ByteArrayOutputStream()
+                response.body.source().saveTo(baos)
+                val imgData = baos.toByteArray()
+                val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
+                val extension = ImageUtil.getExtensionFromMimeType(mime) { ByteArrayInputStream(imgData) }
 
-				emit(PageData("$filename.$extension", imgData))
-			} catch (e: Exception) {
-				response.close()
-				throw e
-			}
-		}.retryWhen { _, attempt ->
-			// Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
-			if (attempt < 3) {
-				delay((2L shl attempt.toInt()) * 1000)
-				true
-			} else {
-				false
-			}
-		}.first()
-	}
+                emit(PageData("$filename.$extension", imgData))
+            } catch (e: Exception) {
+                response.close()
+                throw e
+            }
+        }.retryWhen { _, attempt ->
+            // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
+            if (attempt < 3) {
+                delay((2L shl attempt.toInt()) * 1000)
+                true
+            } else {
+                false
+            }
+        }.first()
+    }
 
-	/**
-	 * Copies the image from cache to file in tmpDir.
-	 *
-	 * @param cacheFile the file from cache.
-	 * @param tmpDir the temporary directory of the download.
-	 * @param filename the filename of the image.
-	 */
-	private fun copyImageFromCache(cacheFile: File, tmpDir: UniFile, filename: String): UniFile {
-		val tmpFile = tmpDir.createFile("$filename.tmp")!!
-		cacheFile.inputStream().use { input ->
-			tmpFile.openOutputStream().use { output ->
-				input.copyTo(output)
-			}
-		}
-		val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
-		tmpFile.renameTo("$filename.${extension.extension}")
-		cacheFile.delete()
-		return tmpFile
-	}
+    /**
+     * Copies the image from cache to file in tmpDir.
+     *
+     * @param cacheFile the file from cache.
+     * @param tmpDir the temporary directory of the download.
+     * @param filename the filename of the image.
+     */
+    private fun copyImageFromCache(cacheFile: File, tmpDir: UniFile, filename: String): UniFile {
+        val tmpFile = tmpDir.createFile("$filename.tmp")!!
+        cacheFile.inputStream().use { input ->
+            tmpFile.openOutputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+        val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
+        tmpFile.renameTo("$filename.${extension.extension}")
+        cacheFile.delete()
+        return tmpFile
+    }
 
-	/**
-	 * Returns the extension of the downloaded image from the network response, or if it's null,
-	 * analyze the file. If everything fails, assume it's a jpg.
-	 *
-	 * @param response the network response of the image.
-	 * @param file the file where the image is already downloaded.
-	 */
-	private fun getImageExtension(response: Response, file: UniFile): String {
-		val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
-		return ImageUtil.getExtensionFromMimeType(mime) { file.openInputStream() }
-	}
+    /**
+     * Returns the extension of the downloaded image from the network response, or if it's null,
+     * analyze the file. If everything fails, assume it's a jpg.
+     *
+     * @param response the network response of the image.
+     * @param file the file where the image is already downloaded.
+     */
+    private fun getImageExtension(response: Response, file: UniFile): String {
+        val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
+        return ImageUtil.getExtensionFromMimeType(mime) { file.openInputStream() }
+    }
 
-	private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {
-		if (!downloadPreferences.splitTallImages().get()) return
+    private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {
+        if (!downloadPreferences.splitTallImages().get()) return
 
-		try {
-			val filenamePrefix = "%03d".format(Locale.ENGLISH, page.number)
-			val imageFile = tmpDir.listFiles()?.firstOrNull { it.name.orEmpty().startsWith(filenamePrefix) } ?: error(
-				context.stringResource(MR.strings.download_notifier_split_page_not_found, page.number),
-			)
+        try {
+            val filenamePrefix = "%03d".format(Locale.ENGLISH, page.number)
+            val imageFile = tmpDir.listFiles()?.firstOrNull { it.name.orEmpty().startsWith(filenamePrefix) } ?: error(
+                context.stringResource(MR.strings.download_notifier_split_page_not_found, page.number),
+            )
 
-			// If the original page was previously split, then skip
-			if (imageFile.name.orEmpty().startsWith("${filenamePrefix}__")) return
+            // If the original page was previously split, then skip
+            if (imageFile.name.orEmpty().startsWith("${filenamePrefix}__")) return
 
-			ImageUtil.splitTallImage(tmpDir, imageFile, filenamePrefix)
-		} catch (e: Exception) {
-			logcat(LogPriority.ERROR, e) { "Failed to split downloaded image" }
-		}
-	}
+            ImageUtil.splitTallImage(tmpDir, imageFile, filenamePrefix)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to split downloaded image" }
+        }
+    }
 
-	/**
-	 * Checks if the download was successful.
-	 *
-	 * @param download the download to check.
-	 * @param tmpDir the directory where the download is currently stored.
-	 */
-	private fun isDownloadSuccessful(
-		download: Download,
-		tmpDir: UniFile,
-	): Boolean {
-		// Page list hasn't been initialized
-		val downloadPageCount = download.pages?.size ?: return false
+    /**
+     * Checks if the download was successful.
+     *
+     * @param download the download to check.
+     * @param tmpDir the directory where the download is currently stored.
+     */
+    private fun isDownloadSuccessful(
+        download: Download,
+        tmpDir: UniFile,
+    ): Boolean {
+        // Page list hasn't been initialized
+        val downloadPageCount = download.pages?.size ?: return false
 
-		// Ensure that all pages have been downloaded
-		if (download.downloadedImages != downloadPageCount) {
-			return false
-		}
+        // Ensure that all pages have been downloaded
+        if (download.downloadedImages != downloadPageCount) {
+            return false
+        }
 
-		// Ensure that the chapter folder has all the pages
-		val downloadedImagesCount = tmpDir.listFiles().orEmpty().count {
-			val fileName = it.name.orEmpty()
-			when {
-				fileName in listOf(COMIC_INFO_FILE, NOMEDIA_FILE) -> false
-				fileName.endsWith(".tmp") -> false
-				// Only count the first split page and not the others
-				fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
-				else -> true
-			}
-		}
-		return downloadedImagesCount == downloadPageCount
-	}
+        // Ensure that the chapter folder has all the pages
+        val downloadedImagesCount = tmpDir.listFiles().orEmpty().count {
+            val fileName = it.name.orEmpty()
+            when {
+                fileName in listOf(COMIC_INFO_FILE, NOMEDIA_FILE) -> false
+                fileName.endsWith(".tmp") -> false
+                // Only count the first split page and not the others
+                fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
+                else -> true
+            }
+        }
+        return downloadedImagesCount == downloadPageCount
+    }
 
-	/**
-	 * Checks if the download was successful.
-	 *
-	 * @param download the download to check.
-	 * @param pds list of downloaded data.
-	 */
-	private fun isDownloadSuccessful(
-		download: Download,
-		pds: List<PageData>,
-	): Boolean {
-		// Page list hasn't been initialized
-		val downloadPageCount = download.pages?.size ?: return false
+    /**
+     * Checks if the download was successful.
+     *
+     * @param download the download to check.
+     * @param pds list of downloaded data.
+     */
+    private fun isDownloadSuccessful(
+        download: Download,
+        pds: List<PageData>,
+    ): Boolean {
+        // Page list hasn't been initialized
+        val downloadPageCount = download.pages?.size ?: return false
 
-		// Ensure that all pages have been downloaded
-		if (download.downloadedImages != downloadPageCount) {
-			return false
-		}
+        // Ensure that all pages have been downloaded
+        if (download.downloadedImages != downloadPageCount) {
+            return false
+        }
 
-		// Ensure that pds has all the pages
-		val downloadedImagesCount = pds.count {
-			val fileName = it.name
-			when {
-				fileName.endsWith(".tmp") -> false
-				// Only count the first split page and not the others
-				fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
-				else -> true
-			}
-		}
-		return downloadedImagesCount == downloadPageCount
-	}
+        // Ensure that pds has all the pages
+        val downloadedImagesCount = pds.count {
+            val fileName = it.name
+            when {
+                fileName.endsWith(".tmp") -> false
+                // Only count the first split page and not the others
+                fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
+                else -> true
+            }
+        }
+        return downloadedImagesCount == downloadPageCount
+    }
 
-	/**
-	 * Archive the chapter pages as a CBZ.
-	 */
-	private fun archiveChapter(
-		mangaDir: UniFile,
-		dirname: String,
-		tmpDir: UniFile,
-	) {
-		val zip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
-		ZipWriter(context, zip).use { writer ->
-			tmpDir.listFiles()?.forEach { file ->
-				writer.write(file)
-			}
-		}
-		zip.renameTo("$dirname.cbz")
-		tmpDir.delete()
-	}
+    /**
+     * Archive the chapter pages as a CBZ.
+     */
+    private fun archiveChapter(
+        mangaDir: UniFile,
+        dirname: String,
+        tmpDir: UniFile,
+    ) {
+        val zip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
+        ZipWriter(context, zip).use { writer ->
+            tmpDir.listFiles()?.forEach { file ->
+                writer.write(file)
+            }
+        }
+        zip.renameTo("$dirname.cbz")
+        tmpDir.delete()
+    }
 
-	/**
-	 * Creates a ComicInfo.xml file inside the given directory.
-	 */
-	private suspend fun createComicInfoData(
-		manga: Manga,
-		chapter: Chapter,
-		source: HttpSource,
-	): ByteArray {
-		val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-		val urls = getTracks.await(manga.id).mapNotNull { track ->
-			track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
-		}.plus(source.getChapterUrl(chapter.toSChapter()).trim()).distinct()
+    /**
+     * Creates a ComicInfo.xml file inside the given directory.
+     */
+    private suspend fun createComicInfoData(
+        manga: Manga,
+        chapter: Chapter,
+        source: HttpSource,
+    ): ByteArray {
+        val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
+        val urls = getTracks.await(manga.id).mapNotNull { track ->
+            track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
+        }.plus(source.getChapterUrl(chapter.toSChapter()).trim()).distinct()
 
-		val comicInfo = getComicInfo(
-			manga,
-			chapter,
-			urls,
-			categories,
-			source.name,
-		)
+        val comicInfo = getComicInfo(
+            manga,
+            chapter,
+            urls,
+            categories,
+            source.name,
+        )
 
-		// Remove the old file
-		val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
-		return comicInfoString.toByteArray()
-	}
+        // Remove the old file
+        val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
+        return comicInfoString.toByteArray()
+    }
 
-	/**
-	 * Creates a ComicInfo.xml file inside the given directory.
-	 */
-	private suspend fun createComicInfoFile(
-		dir: UniFile,
-		manga: Manga,
-		chapter: Chapter,
-		source: HttpSource,
-	) {
-		// Remove the old file
-		dir.findFile(COMIC_INFO_FILE)?.delete()
-		dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {
-			it.write(createComicInfoData(manga, chapter, source))
-		}
-	}
+    /**
+     * Creates a ComicInfo.xml file inside the given directory.
+     */
+    private suspend fun createComicInfoFile(
+        dir: UniFile,
+        manga: Manga,
+        chapter: Chapter,
+        source: HttpSource,
+    ) {
+        // Remove the old file
+        dir.findFile(COMIC_INFO_FILE)?.delete()
+        dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {
+            it.write(createComicInfoData(manga, chapter, source))
+        }
+    }
 
-	/**
-	 * Returns true if all the queued downloads are in DOWNLOADED or ERROR state.
-	 */
-	private fun areAllDownloadsFinished(): Boolean {
-		return queueState.value.none { it.status.value <= Download.State.DOWNLOADING.value }
-	}
+    /**
+     * Returns true if all the queued downloads are in DOWNLOADED or ERROR state.
+     */
+    private fun areAllDownloadsFinished(): Boolean {
+        return queueState.value.none { it.status.value <= Download.State.DOWNLOADING.value }
+    }
 
-	private fun addAllToQueue(downloads: List<Download>) {
-		_queueState.update {
-			downloads.forEach { download ->
-				download.status = Download.State.QUEUE
-			}
-			store.addAll(downloads)
-			it + downloads
-		}
-	}
+    private fun addAllToQueue(downloads: List<Download>) {
+        _queueState.update {
+            downloads.forEach { download ->
+                download.status = Download.State.QUEUE
+            }
+            store.addAll(downloads)
+            it + downloads
+        }
+    }
 
-	private fun removeFromQueue(download: Download) {
-		_queueState.update {
-			store.remove(download)
-			if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-				download.status = Download.State.NOT_DOWNLOADED
-			}
-			it - download
-		}
-	}
+    private fun removeFromQueue(download: Download) {
+        _queueState.update {
+            store.remove(download)
+            if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+                download.status = Download.State.NOT_DOWNLOADED
+            }
+            it - download
+        }
+    }
 
-	private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-		_queueState.update { queue ->
-			val downloads = queue.filter { predicate(it) }
-			store.removeAll(downloads)
-			downloads.forEach { download ->
-				if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-					download.status = Download.State.NOT_DOWNLOADED
-				}
-			}
-			queue - downloads
-		}
-	}
+    private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
+        _queueState.update { queue ->
+            val downloads = queue.filter { predicate(it) }
+            store.removeAll(downloads)
+            downloads.forEach { download ->
+                if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+                    download.status = Download.State.NOT_DOWNLOADED
+                }
+            }
+            queue - downloads
+        }
+    }
 
-	fun removeFromQueue(chapters: List<Chapter>) {
-		val chapterIds = chapters.map { it.id }
-		removeFromQueueIf { it.chapter.id in chapterIds }
-	}
+    fun removeFromQueue(chapters: List<Chapter>) {
+        val chapterIds = chapters.map { it.id }
+        removeFromQueueIf { it.chapter.id in chapterIds }
+    }
 
-	fun removeFromQueue(manga: Manga) {
-		removeFromQueueIf { it.manga.id == manga.id }
-	}
+    fun removeFromQueue(manga: Manga) {
+        removeFromQueueIf { it.manga.id == manga.id }
+    }
 
-	private fun internalClearQueue() {
-		_queueState.update {
-			it.forEach { download ->
-				if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-					download.status = Download.State.NOT_DOWNLOADED
-				}
-			}
-			store.clear()
-			emptyList()
-		}
-	}
+    private fun internalClearQueue() {
+        _queueState.update {
+            it.forEach { download ->
+                if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+                    download.status = Download.State.NOT_DOWNLOADED
+                }
+            }
+            store.clear()
+            emptyList()
+        }
+    }
 
-	fun updateQueue(downloads: List<Download>) {
-		val wasRunning = isRunning
+    fun updateQueue(downloads: List<Download>) {
+        val wasRunning = isRunning
 
-		if (downloads.isEmpty()) {
-			clearQueue()
-			stop()
-			return
-		}
+        if (downloads.isEmpty()) {
+            clearQueue()
+            stop()
+            return
+        }
 
-		pause()
-		internalClearQueue()
-		addAllToQueue(downloads)
+        pause()
+        internalClearQueue()
+        addAllToQueue(downloads)
 
-		if (wasRunning) {
-			start()
-		}
-	}
+        if (wasRunning) {
+            start()
+        }
+    }
 
-	companion object {
-		const val TMP_DIR_SUFFIX = "_tmp"
-		const val WARNING_NOTIF_TIMEOUT_MS = 30_000L
-		const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
-		private const val DOWNLOADS_QUEUED_WARNING_THRESHOLD = 30
-	}
+    companion object {
+        const val TMP_DIR_SUFFIX = "_tmp"
+        const val WARNING_NOTIF_TIMEOUT_MS = 30_000L
+        const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
+        private const val DOWNLOADS_QUEUED_WARNING_THRESHOLD = 30
+    }
 }
 
 // Arbitrary minimum required space to start a download: 200 MB

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateNotifier
 import eu.kanade.tachiyomi.data.notification.NotificationHandler
 import eu.kanade.tachiyomi.source.UnmeteredSource
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.PageData
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.DiskUtil.NOMEDIA_FILE
@@ -59,8 +60,12 @@ import tachiyomi.domain.track.interactor.GetTracks
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 /**
  * This class is the one in charge of downloading chapters.
@@ -68,654 +73,829 @@ import java.util.Locale
  * Its queue contains the list of chapters to download.
  */
 class Downloader(
-    private val context: Context,
-    private val provider: DownloadProvider,
-    private val cache: DownloadCache,
-    private val sourceManager: SourceManager = Injekt.get(),
-    private val chapterCache: ChapterCache = Injekt.get(),
-    private val downloadPreferences: DownloadPreferences = Injekt.get(),
-    private val xml: XML = Injekt.get(),
-    private val getCategories: GetCategories = Injekt.get(),
-    private val getTracks: GetTracks = Injekt.get(),
+	private val context: Context,
+	private val provider: DownloadProvider,
+	private val cache: DownloadCache,
+	private val sourceManager: SourceManager = Injekt.get(),
+	private val chapterCache: ChapterCache = Injekt.get(),
+	private val downloadPreferences: DownloadPreferences = Injekt.get(),
+	private val xml: XML = Injekt.get(),
+	private val getCategories: GetCategories = Injekt.get(),
+	private val getTracks: GetTracks = Injekt.get(),
 ) {
 
-    /**
-     * Store for persisting downloads across restarts.
-     */
-    private val store = DownloadStore(context)
-
-    /**
-     * Queue where active downloads are kept.
-     */
-    private val _queueState = MutableStateFlow<List<Download>>(emptyList())
-    val queueState = _queueState.asStateFlow()
-
-    /**
-     * Notifier for the downloader state and progress.
-     */
-    private val notifier by lazy { DownloadNotifier(context) }
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var downloaderJob: Job? = null
-
-    /**
-     * Whether the downloader is running.
-     */
-    val isRunning: Boolean
-        get() = downloaderJob?.isActive ?: false
-
-    /**
-     * Whether the downloader is paused
-     */
-    @Volatile
-    var isPaused: Boolean = false
-
-    init {
-        launchNow {
-            val chapters = async { store.restore() }
-            addAllToQueue(chapters.await())
-        }
-    }
-
-    /**
-     * Starts the downloader. It doesn't do anything if it's already running or there isn't anything
-     * to download.
-     *
-     * @return true if the downloader is started, false otherwise.
-     */
-    fun start(): Boolean {
-        if (isRunning || queueState.value.isEmpty()) {
-            return false
-        }
-
-        val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
-        pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
-
-        isPaused = false
-
-        launchDownloaderJob()
-
-        return pending.isNotEmpty()
-    }
-
-    /**
-     * Stops the downloader.
-     */
-    fun stop(reason: String? = null) {
-        cancelDownloaderJob()
-        queueState.value
-            .filter { it.status == Download.State.DOWNLOADING }
-            .forEach { it.status = Download.State.ERROR }
-
-        if (reason != null) {
-            notifier.onWarning(reason)
-            return
-        }
-
-        if (isPaused && queueState.value.isNotEmpty()) {
-            notifier.onPaused()
-        } else {
-            notifier.onComplete()
-        }
-
-        isPaused = false
-
-        DownloadJob.stop(context)
-    }
-
-    /**
-     * Pauses the downloader
-     */
-    fun pause() {
-        cancelDownloaderJob()
-        queueState.value
-            .filter { it.status == Download.State.DOWNLOADING }
-            .forEach { it.status = Download.State.QUEUE }
-        isPaused = true
-    }
-
-    /**
-     * Removes everything from the queue.
-     */
-    fun clearQueue() {
-        cancelDownloaderJob()
-
-        internalClearQueue()
-        notifier.dismissProgress()
-    }
-
-    /**
-     * Prepares the subscriptions to start downloading.
-     */
-    private fun launchDownloaderJob() {
-        if (isRunning) return
-
-        downloaderJob = scope.launch {
-            val activeDownloadsFlow = queueState.transformLatest { queue ->
-                while (true) {
-                    val activeDownloads = queue.asSequence()
-                        // Ignore completed downloads, leave them in the queue
-                        .filter { it.status.value <= Download.State.DOWNLOADING.value }
-                        .groupBy { it.source }
-                        .toList()
-                        // Concurrently download from 5 different sources
-                        .take(5)
-                        .map { (_, downloads) -> downloads.first() }
-                    emit(activeDownloads)
-
-                    if (activeDownloads.isEmpty()) break
-                    // Suspend until a download enters the ERROR state
-                    val activeDownloadsErroredFlow =
-                        combine(activeDownloads.map(Download::statusFlow)) { states ->
-                            states.contains(Download.State.ERROR)
-                        }.filter { it }
-                    activeDownloadsErroredFlow.first()
-                }
-            }.distinctUntilChanged()
-
-            // Use supervisorScope to cancel child jobs when the downloader job is cancelled
-            supervisorScope {
-                val downloadJobs = mutableMapOf<Download, Job>()
-
-                activeDownloadsFlow.collectLatest { activeDownloads ->
-                    val downloadJobsToStop = downloadJobs.filter { it.key !in activeDownloads }
-                    downloadJobsToStop.forEach { (download, job) ->
-                        job.cancel()
-                        downloadJobs.remove(download)
-                    }
-
-                    val downloadsToStart = activeDownloads.filter { it !in downloadJobs }
-                    downloadsToStart.forEach { download ->
-                        downloadJobs[download] = launchDownloadJob(download)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun CoroutineScope.launchDownloadJob(download: Download) = launchIO {
-        try {
-            downloadChapter(download)
-
-            // Remove successful download from queue
-            if (download.status == Download.State.DOWNLOADED) {
-                removeFromQueue(download)
-            }
-            if (areAllDownloadsFinished()) {
-                stop()
-            }
-        } catch (e: Throwable) {
-            if (e is CancellationException) throw e
-            logcat(LogPriority.ERROR, e)
-            notifier.onError(e.message)
-            stop()
-        }
-    }
-
-    /**
-     * Destroys the downloader subscriptions.
-     */
-    private fun cancelDownloaderJob() {
-        downloaderJob?.cancel()
-        downloaderJob = null
-    }
-
-    /**
-     * Creates a download object for every chapter and adds them to the downloads queue.
-     *
-     * @param manga the manga of the chapters to download.
-     * @param chapters the list of chapters to download.
-     * @param autoStart whether to start the downloader after enqueing the chapters.
-     */
-    fun queueChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean) {
-        if (chapters.isEmpty()) return
-
-        val source = sourceManager.get(manga.source) as? HttpSource ?: return
-        val wasEmpty = queueState.value.isEmpty()
-        val chaptersToQueue = chapters.asSequence()
-            // Filter out those already downloaded.
-            .filter { provider.findChapterDir(it.name, it.scanlator, manga.title, source) == null }
-            // Add chapters to queue from the start.
-            .sortedByDescending { it.sourceOrder }
-            // Filter out those already enqueued.
-            .filter { chapter -> queueState.value.none { it.chapter.id == chapter.id } }
-            // Create a download for each one.
-            .map { Download(source, manga, it) }
-            .toList()
-
-        if (chaptersToQueue.isNotEmpty()) {
-            addAllToQueue(chaptersToQueue)
-
-            // Start downloader if needed
-            if (autoStart && wasEmpty) {
-                val queuedDownloads = queueState.value.count { it.source !is UnmeteredSource }
-                val maxDownloadsFromSource = queueState.value
-                    .groupBy { it.source }
-                    .filterKeys { it !is UnmeteredSource }
-                    .maxOfOrNull { it.value.size }
-                    ?: 0
-                if (
-                    queuedDownloads > DOWNLOADS_QUEUED_WARNING_THRESHOLD ||
-                    maxDownloadsFromSource > CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD
-                ) {
-                    notifier.onWarning(
-                        context.stringResource(MR.strings.download_queue_size_warning),
-                        WARNING_NOTIF_TIMEOUT_MS,
-                        NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
-                    )
-                }
-                DownloadJob.start(context)
-            }
-        }
-    }
-
-    /**
-     * Downloads a chapter.
-     *
-     * @param download the chapter to be downloaded.
-     */
-    private suspend fun downloadChapter(download: Download) {
-        val mangaDir = provider.getMangaDir(download.manga.title, download.source)
-
-        val availSpace = DiskUtil.getAvailableStorageSpace(mangaDir)
-        if (availSpace != -1L && availSpace < MIN_DISK_SPACE) {
-            download.status = Download.State.ERROR
-            notifier.onError(
-                context.stringResource(MR.strings.download_insufficient_space),
-                download.chapter.name,
-                download.manga.title,
-                download.manga.id,
-            )
-            return
-        }
-
-        val chapterDirname = provider.getChapterDirName(download.chapter.name, download.chapter.scanlator)
-        val tmpDir = mangaDir.createDirectory(chapterDirname + TMP_DIR_SUFFIX)!!
-
-        try {
-            // If the page list already exists, start from the file
-            val pageList = download.pages ?: run {
-                // Otherwise, pull page list from network and add them to download object
-                val pages = download.source.getPageList(download.chapter.toSChapter())
-
-                if (pages.isEmpty()) {
-                    throw Exception(context.stringResource(MR.strings.page_list_empty_error))
-                }
-                // Don't trust index from source
-                val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
-                download.pages = reIndexedPages
-                reIndexedPages
-            }
-
-            // Delete all temporary (unfinished) files
-            tmpDir.listFiles()
-                ?.filter { it.extension == "tmp" }
-                ?.forEach { it.delete() }
-
-            download.status = Download.State.DOWNLOADING
-
-            // Start downloading images, consider we can have downloaded images already
-            // Concurrently do 2 pages at a time
-            pageList.asFlow()
-                .flatMapMerge(concurrency = 2) { page ->
-                    flow {
-                        // Fetch image URL if necessary
-                        if (page.imageUrl.isNullOrEmpty()) {
-                            page.status = Page.State.LOAD_PAGE
-                            try {
-                                page.imageUrl = download.source.getImageUrl(page)
-                            } catch (e: Throwable) {
-                                page.status = Page.State.ERROR
-                            }
-                        }
-
-                        withIOContext { getOrDownloadImage(page, download, tmpDir) }
-                        emit(page)
-                    }.flowOn(Dispatchers.IO)
-                }
-                .collect {
-                    // Do when page is downloaded.
-                    notifier.onProgressChange(download)
-                }
-
-            // Do after download completes
-
-            if (!isDownloadSuccessful(download, tmpDir)) {
-                download.status = Download.State.ERROR
-                return
-            }
-
-            createComicInfoFile(
-                tmpDir,
-                download.manga,
-                download.chapter,
-                download.source,
-            )
-
-            // Only rename the directory if it's downloaded
-            if (downloadPreferences.saveChaptersAsCBZ().get()) {
-                archiveChapter(mangaDir, chapterDirname, tmpDir)
-            } else {
-                tmpDir.renameTo(chapterDirname)
-            }
-            cache.addChapter(chapterDirname, mangaDir, download.manga)
-
-            DiskUtil.createNoMediaFile(tmpDir, context)
-
-            download.status = Download.State.DOWNLOADED
-        } catch (error: Throwable) {
-            if (error is CancellationException) throw error
-            // If the page list threw, it will resume here
-            logcat(LogPriority.ERROR, error)
-            download.status = Download.State.ERROR
-            notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
-        }
-    }
-
-    /**
-     * Gets the image from the filesystem if it exists or downloads it otherwise.
-     *
-     * @param page the page to download.
-     * @param download the download of the page.
-     * @param tmpDir the temporary directory of the download.
-     */
-    private suspend fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile) {
-        // If the image URL is empty, do nothing
-        if (page.imageUrl == null) {
-            return
-        }
-
-        val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
-        val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
-        val tmpFile = tmpDir.findFile("$filename.tmp")
-
-        // Delete temp file if it exists
-        tmpFile?.delete()
-
-        // Try to find the image file
-        val imageFile = tmpDir.listFiles()?.firstOrNull {
-            it.name!!.startsWith("$filename.") || it.name!!.startsWith("${filename}__001")
-        }
-
-        try {
-            // If the image is already downloaded, do nothing. Otherwise download from network
-            val file = when {
-                imageFile != null -> imageFile
-                chapterCache.isImageInCache(
-                    page.imageUrl!!,
-                ) -> copyImageFromCache(chapterCache.getImageFile(page.imageUrl!!), tmpDir, filename)
-                else -> downloadImage(page, download.source, tmpDir, filename)
-            }
-
-            // When the page is ready, set page path, progress (just in case) and status
-            splitTallImageIfNeeded(page, tmpDir)
-
-            page.uri = file.uri
-            page.progress = 100
-            page.status = Page.State.READY
-        } catch (e: Throwable) {
-            if (e is CancellationException) throw e
-            // Mark this page as error and allow to download the remaining
-            page.progress = 0
-            page.status = Page.State.ERROR
-            notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
-        }
-    }
-
-    /**
-     * Downloads the image from network to a file in tmpDir.
-     *
-     * @param page the page to download.
-     * @param source the source of the page.
-     * @param tmpDir the temporary directory of the download.
-     * @param filename the filename of the image.
-     */
-    private suspend fun downloadImage(page: Page, source: HttpSource, tmpDir: UniFile, filename: String): UniFile {
-        page.status = Page.State.DOWNLOAD_IMAGE
-        page.progress = 0
-        return flow {
-            val response = source.getImage(page)
-            val file = tmpDir.createFile("$filename.tmp")!!
-            try {
-                response.body.source().saveTo(file.openOutputStream())
-                val extension = getImageExtension(response, file)
-                file.renameTo("$filename.$extension")
-            } catch (e: Exception) {
-                response.close()
-                file.delete()
-                throw e
-            }
-            emit(file)
-        }
-            // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
-            .retryWhen { _, attempt ->
-                if (attempt < 3) {
-                    delay((2L shl attempt.toInt()) * 1000)
-                    true
-                } else {
-                    false
-                }
-            }
-            .first()
-    }
-
-    /**
-     * Copies the image from cache to file in tmpDir.
-     *
-     * @param cacheFile the file from cache.
-     * @param tmpDir the temporary directory of the download.
-     * @param filename the filename of the image.
-     */
-    private fun copyImageFromCache(cacheFile: File, tmpDir: UniFile, filename: String): UniFile {
-        val tmpFile = tmpDir.createFile("$filename.tmp")!!
-        cacheFile.inputStream().use { input ->
-            tmpFile.openOutputStream().use { output ->
-                input.copyTo(output)
-            }
-        }
-        val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
-        tmpFile.renameTo("$filename.${extension.extension}")
-        cacheFile.delete()
-        return tmpFile
-    }
-
-    /**
-     * Returns the extension of the downloaded image from the network response, or if it's null,
-     * analyze the file. If everything fails, assume it's a jpg.
-     *
-     * @param response the network response of the image.
-     * @param file the file where the image is already downloaded.
-     */
-    private fun getImageExtension(response: Response, file: UniFile): String {
-        val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
-        return ImageUtil.getExtensionFromMimeType(mime) { file.openInputStream() }
-    }
-
-    private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {
-        if (!downloadPreferences.splitTallImages().get()) return
-
-        try {
-            val filenamePrefix = "%03d".format(Locale.ENGLISH, page.number)
-            val imageFile = tmpDir.listFiles()?.firstOrNull { it.name.orEmpty().startsWith(filenamePrefix) }
-                ?: error(context.stringResource(MR.strings.download_notifier_split_page_not_found, page.number))
-
-            // If the original page was previously split, then skip
-            if (imageFile.name.orEmpty().startsWith("${filenamePrefix}__")) return
-
-            ImageUtil.splitTallImage(tmpDir, imageFile, filenamePrefix)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e) { "Failed to split downloaded image" }
-        }
-    }
-
-    /**
-     * Checks if the download was successful.
-     *
-     * @param download the download to check.
-     * @param tmpDir the directory where the download is currently stored.
-     */
-    private fun isDownloadSuccessful(
-        download: Download,
-        tmpDir: UniFile,
-    ): Boolean {
-        // Page list hasn't been initialized
-        val downloadPageCount = download.pages?.size ?: return false
-
-        // Ensure that all pages have been downloaded
-        if (download.downloadedImages != downloadPageCount) {
-            return false
-        }
-
-        // Ensure that the chapter folder has all the pages
-        val downloadedImagesCount = tmpDir.listFiles().orEmpty().count {
-            val fileName = it.name.orEmpty()
-            when {
-                fileName in listOf(COMIC_INFO_FILE, NOMEDIA_FILE) -> false
-                fileName.endsWith(".tmp") -> false
-                // Only count the first split page and not the others
-                fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
-                else -> true
-            }
-        }
-        return downloadedImagesCount == downloadPageCount
-    }
-
-    /**
-     * Archive the chapter pages as a CBZ.
-     */
-    private fun archiveChapter(
-        mangaDir: UniFile,
-        dirname: String,
-        tmpDir: UniFile,
-    ) {
-        val zip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
-        ZipWriter(context, zip).use { writer ->
-            tmpDir.listFiles()?.forEach { file ->
-                writer.write(file)
-            }
-        }
-        zip.renameTo("$dirname.cbz")
-        tmpDir.delete()
-    }
-
-    /**
-     * Creates a ComicInfo.xml file inside the given directory.
-     */
-    private suspend fun createComicInfoFile(
-        dir: UniFile,
-        manga: Manga,
-        chapter: Chapter,
-        source: HttpSource,
-    ) {
-        val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
-        val urls = getTracks.await(manga.id)
-            .mapNotNull { track ->
-                track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
-            }
-            .plus(source.getChapterUrl(chapter.toSChapter()).trim())
-            .distinct()
-
-        val comicInfo = getComicInfo(
-            manga,
-            chapter,
-            urls,
-            categories,
-            source.name,
-        )
-
-        // Remove the old file
-        dir.findFile(COMIC_INFO_FILE)?.delete()
-        dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {
-            val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
-            it.write(comicInfoString.toByteArray())
-        }
-    }
-
-    /**
-     * Returns true if all the queued downloads are in DOWNLOADED or ERROR state.
-     */
-    private fun areAllDownloadsFinished(): Boolean {
-        return queueState.value.none { it.status.value <= Download.State.DOWNLOADING.value }
-    }
-
-    private fun addAllToQueue(downloads: List<Download>) {
-        _queueState.update {
-            downloads.forEach { download ->
-                download.status = Download.State.QUEUE
-            }
-            store.addAll(downloads)
-            it + downloads
-        }
-    }
-
-    private fun removeFromQueue(download: Download) {
-        _queueState.update {
-            store.remove(download)
-            if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-                download.status = Download.State.NOT_DOWNLOADED
-            }
-            it - download
-        }
-    }
-
-    private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
-        _queueState.update { queue ->
-            val downloads = queue.filter { predicate(it) }
-            store.removeAll(downloads)
-            downloads.forEach { download ->
-                if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-                    download.status = Download.State.NOT_DOWNLOADED
-                }
-            }
-            queue - downloads
-        }
-    }
-
-    fun removeFromQueue(chapters: List<Chapter>) {
-        val chapterIds = chapters.map { it.id }
-        removeFromQueueIf { it.chapter.id in chapterIds }
-    }
-
-    fun removeFromQueue(manga: Manga) {
-        removeFromQueueIf { it.manga.id == manga.id }
-    }
-
-    private fun internalClearQueue() {
-        _queueState.update {
-            it.forEach { download ->
-                if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
-                    download.status = Download.State.NOT_DOWNLOADED
-                }
-            }
-            store.clear()
-            emptyList()
-        }
-    }
-
-    fun updateQueue(downloads: List<Download>) {
-        val wasRunning = isRunning
-
-        if (downloads.isEmpty()) {
-            clearQueue()
-            stop()
-            return
-        }
-
-        pause()
-        internalClearQueue()
-        addAllToQueue(downloads)
-
-        if (wasRunning) {
-            start()
-        }
-    }
-
-    companion object {
-        const val TMP_DIR_SUFFIX = "_tmp"
-        const val WARNING_NOTIF_TIMEOUT_MS = 30_000L
-        const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
-        private const val DOWNLOADS_QUEUED_WARNING_THRESHOLD = 30
-    }
+	/**
+	 * Store for persisting downloads across restarts.
+	 */
+	private val store = DownloadStore(context)
+
+	/**
+	 * Queue where active downloads are kept.
+	 */
+	private val _queueState = MutableStateFlow<List<Download>>(emptyList())
+	val queueState = _queueState.asStateFlow()
+
+	/**
+	 * Notifier for the downloader state and progress.
+	 */
+	private val notifier by lazy { DownloadNotifier(context) }
+
+	private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+	private var downloaderJob: Job? = null
+
+	/**
+	 * Whether the downloader is running.
+	 */
+	val isRunning: Boolean
+		get() = downloaderJob?.isActive ?: false
+
+	/**
+	 * Whether the downloader is paused
+	 */
+	@Volatile
+	var isPaused: Boolean = false
+
+	init {
+		launchNow {
+			val chapters = async { store.restore() }
+			addAllToQueue(chapters.await())
+		}
+	}
+
+	/**
+	 * Starts the downloader. It doesn't do anything if it's already running or there isn't anything
+	 * to download.
+	 *
+	 * @return true if the downloader is started, false otherwise.
+	 */
+	fun start(): Boolean {
+		if (isRunning || queueState.value.isEmpty()) {
+			return false
+		}
+
+		val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
+		pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
+
+		isPaused = false
+
+		launchDownloaderJob()
+
+		return pending.isNotEmpty()
+	}
+
+	/**
+	 * Stops the downloader.
+	 */
+	fun stop(reason: String? = null) {
+		cancelDownloaderJob()
+		queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.ERROR }
+
+		if (reason != null) {
+			notifier.onWarning(reason)
+			return
+		}
+
+		if (isPaused && queueState.value.isNotEmpty()) {
+			notifier.onPaused()
+		} else {
+			notifier.onComplete()
+		}
+
+		isPaused = false
+
+		DownloadJob.stop(context)
+	}
+
+	/**
+	 * Pauses the downloader
+	 */
+	fun pause() {
+		cancelDownloaderJob()
+		queueState.value.filter { it.status == Download.State.DOWNLOADING }.forEach { it.status = Download.State.QUEUE }
+		isPaused = true
+	}
+
+	/**
+	 * Removes everything from the queue.
+	 */
+	fun clearQueue() {
+		cancelDownloaderJob()
+
+		internalClearQueue()
+		notifier.dismissProgress()
+	}
+
+	/**
+	 * Prepares the subscriptions to start downloading.
+	 */
+	private fun launchDownloaderJob() {
+		if (isRunning) return
+
+		downloaderJob = scope.launch {
+			val activeDownloadsFlow = queueState.transformLatest { queue ->
+				while (true) {
+					val activeDownloads = queue.asSequence()
+						// Ignore completed downloads, leave them in the queue
+						.filter { it.status.value <= Download.State.DOWNLOADING.value }.groupBy { it.source }.toList()
+						// Concurrently download from 5 different sources
+						.take(5).map { (_, downloads) -> downloads.first() }
+					emit(activeDownloads)
+
+					if (activeDownloads.isEmpty()) break
+					// Suspend until a download enters the ERROR state
+					val activeDownloadsErroredFlow = combine(activeDownloads.map(Download::statusFlow)) { states ->
+						states.contains(Download.State.ERROR)
+					}.filter { it }
+					activeDownloadsErroredFlow.first()
+				}
+			}.distinctUntilChanged()
+
+			// Use supervisorScope to cancel child jobs when the downloader job is cancelled
+			supervisorScope {
+				val downloadJobs = mutableMapOf<Download, Job>()
+
+				activeDownloadsFlow.collectLatest { activeDownloads ->
+					val downloadJobsToStop = downloadJobs.filter { it.key !in activeDownloads }
+					downloadJobsToStop.forEach { (download, job) ->
+						job.cancel()
+						downloadJobs.remove(download)
+					}
+
+					val downloadsToStart = activeDownloads.filter { it !in downloadJobs }
+					downloadsToStart.forEach { download ->
+						downloadJobs[download] = launchDownloadJob(download)
+					}
+				}
+			}
+		}
+	}
+
+	private fun CoroutineScope.launchDownloadJob(download: Download) = launchIO {
+		try {
+			downloadChapter(download)
+
+			// Remove successful download from queue
+			if (download.status == Download.State.DOWNLOADED) {
+				removeFromQueue(download)
+			}
+			if (areAllDownloadsFinished()) {
+				stop()
+			}
+		} catch (e: Throwable) {
+			if (e is CancellationException) throw e
+			logcat(LogPriority.ERROR, e)
+			notifier.onError(e.message)
+			stop()
+		}
+	}
+
+	/**
+	 * Destroys the downloader subscriptions.
+	 */
+	private fun cancelDownloaderJob() {
+		downloaderJob?.cancel()
+		downloaderJob = null
+	}
+
+	/**
+	 * Creates a download object for every chapter and adds them to the downloads queue.
+	 *
+	 * @param manga the manga of the chapters to download.
+	 * @param chapters the list of chapters to download.
+	 * @param autoStart whether to start the downloader after enqueing the chapters.
+	 */
+	fun queueChapters(manga: Manga, chapters: List<Chapter>, autoStart: Boolean) {
+		if (chapters.isEmpty()) return
+
+		val source = sourceManager.get(manga.source) as? HttpSource ?: return
+		val wasEmpty = queueState.value.isEmpty()
+		val chaptersToQueue = chapters.asSequence()
+			// Filter out those already downloaded.
+			.filter { provider.findChapterDir(it.name, it.scanlator, manga.title, source) == null }
+			// Add chapters to queue from the start.
+			.sortedByDescending { it.sourceOrder }
+			// Filter out those already enqueued.
+			.filter { chapter -> queueState.value.none { it.chapter.id == chapter.id } }
+			// Create a download for each one.
+			.map { Download(source, manga, it) }.toList()
+
+		if (chaptersToQueue.isNotEmpty()) {
+			addAllToQueue(chaptersToQueue)
+
+			// Start downloader if needed
+			if (autoStart && wasEmpty) {
+				val queuedDownloads = queueState.value.count { it.source !is UnmeteredSource }
+				val maxDownloadsFromSource =
+					queueState.value.groupBy { it.source }.filterKeys { it !is UnmeteredSource }
+						.maxOfOrNull { it.value.size } ?: 0
+				if (queuedDownloads > DOWNLOADS_QUEUED_WARNING_THRESHOLD || maxDownloadsFromSource > CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD) {
+					notifier.onWarning(
+						context.stringResource(MR.strings.download_queue_size_warning),
+						WARNING_NOTIF_TIMEOUT_MS,
+						NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
+					)
+				}
+				DownloadJob.start(context)
+			}
+		}
+	}
+
+	/**
+	 * Downloads a chapter.
+	 *
+	 * @param download the chapter to be downloaded.
+	 */
+	private suspend fun downloadChapter(download: Download) {
+		val mangaDir = provider.getMangaDir(download.manga.title, download.source)
+
+		val availSpace = DiskUtil.getAvailableStorageSpace(mangaDir)
+		if (availSpace != -1L && availSpace < MIN_DISK_SPACE) {
+			download.status = Download.State.ERROR
+			notifier.onError(
+				context.stringResource(MR.strings.download_insufficient_space),
+				download.chapter.name,
+				download.manga.title,
+				download.manga.id,
+			)
+			return
+		}
+
+		val chapterDirname = provider.getChapterDirName(download.chapter.name, download.chapter.scanlator)
+
+		if (downloadPreferences.saveChaptersAsCBZ().get() && downloadPreferences.saveChaptersCBZInRAM().get()) {
+			// create tmpDir as an in-memory file
+			downloadChapterInRam(download, mangaDir, chapterDirname)
+		} else {
+			downloadChapterInStorage(download, mangaDir, chapterDirname)
+		}
+	}
+
+	private suspend fun downloadChapterInRam(download: Download, mangaDir: UniFile, chapterDirname: String) {
+		try {
+			// If the page list already exists, start from the file
+			val pageList = download.pages ?: run {
+				// Otherwise, pull page list from network and add them to download object
+				val pages = download.source.getPageList(download.chapter.toSChapter())
+
+				if (pages.isEmpty()) {
+					throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+				}
+				// Don't trust index from source
+				val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
+				download.pages = reIndexedPages
+				reIndexedPages
+			}
+
+			download.status = Download.State.DOWNLOADING
+			val pds = ArrayList<PageData>()
+
+			// Start downloading images, consider we can have downloaded images already
+			// Concurrently do 2 pages at a time
+			pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
+				flow {
+					// Fetch image URL if necessary
+					if (page.imageUrl.isNullOrEmpty()) {
+						page.status = Page.State.LOAD_PAGE
+						try {
+							page.imageUrl = download.source.getImageUrl(page)
+						} catch (e: Throwable) {
+							page.status = Page.State.ERROR
+						}
+					}
+
+					withIOContext { getOrDownloadImageData(page, download, pds) }
+					emit(page)
+				}.flowOn(Dispatchers.IO)
+			}.collect {
+				// Do when page is downloaded.
+				notifier.onProgressChange(download)
+			}
+
+			// Do after download completes
+			if (!isDownloadSuccessful(download, pds)) {
+				download.status = Download.State.ERROR
+				return
+			}
+
+//			val ci = createComicInfoData(
+//				download.manga,
+//				download.chapter,
+//				download.source,
+//			)
+
+			// Create zip of the downloaded data
+			val zip = mangaDir.createFile("$chapterDirname.cbz$TMP_DIR_SUFFIX")!!
+			ZipOutputStream(zip.openOutputStream()).use { zipOut ->
+				pds.forEach { pd ->
+					val ze = ZipEntry(pd.name)
+					zipOut.putNextEntry(ze)
+					zipOut.write(pd.data)
+					zipOut.closeEntry()
+				}
+			}
+
+			zip.renameTo("$chapterDirname.cbz")
+
+			cache.addChapter(chapterDirname, mangaDir, download.manga)
+
+			download.status = Download.State.DOWNLOADED
+		} catch (error: Throwable) {
+			if (error is CancellationException) throw error
+			// If the page list threw, it will resume here
+			logcat(LogPriority.ERROR, error)
+			download.status = Download.State.ERROR
+			notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
+		}
+	}
+
+	private suspend fun downloadChapterInStorage(download: Download, mangaDir: UniFile, chapterDirname: String) {
+		val tmpDir = mangaDir.createDirectory(chapterDirname + TMP_DIR_SUFFIX)!!
+
+		try {
+			// If the page list already exists, start from the file
+			val pageList = download.pages ?: run {
+				// Otherwise, pull page list from network and add them to download object
+				val pages = download.source.getPageList(download.chapter.toSChapter())
+
+				if (pages.isEmpty()) {
+					throw Exception(context.stringResource(MR.strings.page_list_empty_error))
+				}
+				// Don't trust index from source
+				val reIndexedPages = pages.mapIndexed { index, page -> Page(index, page.url, page.imageUrl, page.uri) }
+				download.pages = reIndexedPages
+				reIndexedPages
+			}
+
+			// Delete all temporary (unfinished) files
+			tmpDir.listFiles()?.filter { it.extension == "tmp" }?.forEach { it.delete() }
+
+			download.status = Download.State.DOWNLOADING
+
+			// Start downloading images, consider we can have downloaded images already
+			// Concurrently do 2 pages at a time
+			pageList.asFlow().flatMapMerge(concurrency = 2) { page ->
+				flow {
+					// Fetch image URL if necessary
+					if (page.imageUrl.isNullOrEmpty()) {
+						page.status = Page.State.LOAD_PAGE
+						try {
+							page.imageUrl = download.source.getImageUrl(page)
+						} catch (e: Throwable) {
+							page.status = Page.State.ERROR
+						}
+					}
+
+					withIOContext { getOrDownloadImage(page, download, tmpDir) }
+					emit(page)
+				}.flowOn(Dispatchers.IO)
+			}.collect {
+				// Do when page is downloaded.
+				notifier.onProgressChange(download)
+			}
+
+			// Do after download completes
+
+			if (!isDownloadSuccessful(download, tmpDir)) {
+				download.status = Download.State.ERROR
+				return
+			}
+
+			createComicInfoFile(
+				tmpDir,
+				download.manga,
+				download.chapter,
+				download.source,
+			)
+
+			// Only rename the directory if it's downloaded
+			if (downloadPreferences.saveChaptersAsCBZ().get()) {
+				archiveChapter(mangaDir, chapterDirname, tmpDir)
+			} else {
+				tmpDir.renameTo(chapterDirname)
+			}
+			cache.addChapter(chapterDirname, mangaDir, download.manga)
+
+			DiskUtil.createNoMediaFile(tmpDir, context)
+
+			download.status = Download.State.DOWNLOADED
+		} catch (error: Throwable) {
+			if (error is CancellationException) throw error
+			// If the page list threw, it will resume here
+			logcat(LogPriority.ERROR, error)
+			download.status = Download.State.ERROR
+			notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
+		}
+	}
+
+	/**
+	 * Gets the image from the filesystem if it exists or downloads it otherwise.
+	 *
+	 * @param page the page to download.
+	 * @param download the download of the page.
+	 * @param tmpDir the temporary directory of the download.
+	 */
+	private suspend fun getOrDownloadImage(page: Page, download: Download, tmpDir: UniFile) {
+		// If the image URL is empty, do nothing
+		if (page.imageUrl == null) {
+			return
+		}
+
+		val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
+		val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
+		val tmpFile = tmpDir.findFile("$filename.tmp")
+
+		// Delete temp file if it exists
+		tmpFile?.delete()
+
+		// Try to find the image file
+		val imageFile = tmpDir.listFiles()?.firstOrNull {
+			it.name!!.startsWith("$filename.") || it.name!!.startsWith("${filename}__001")
+		}
+
+		try {
+			// If the image is already downloaded, do nothing. Otherwise download from network
+			val file = when {
+				imageFile != null -> imageFile
+				chapterCache.isImageInCache(
+					page.imageUrl!!,
+				) -> copyImageFromCache(chapterCache.getImageFile(page.imageUrl!!), tmpDir, filename)
+
+				else -> downloadImage(page, download.source, tmpDir, filename)
+			}
+
+			// When the page is ready, set page path, progress (just in case) and status
+			splitTallImageIfNeeded(page, tmpDir)
+
+			page.uri = file.uri
+			page.progress = 100
+			page.status = Page.State.READY
+		} catch (e: Throwable) {
+			if (e is CancellationException) throw e
+			// Mark this page as error and allow to download the remaining
+			page.progress = 0
+			page.status = Page.State.ERROR
+			notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
+		}
+	}
+
+	/**
+	 * Downloads the image from network to a file in tmpDir.
+	 *
+	 * @param page the page to download.
+	 * @param source the source of the page.
+	 * @param tmpDir the temporary directory of the download.
+	 * @param filename the filename of the image.
+	 */
+	private suspend fun downloadImage(page: Page, source: HttpSource, tmpDir: UniFile, filename: String): UniFile {
+		page.status = Page.State.DOWNLOAD_IMAGE
+		page.progress = 0
+		return flow {
+			val response = source.getImage(page)
+			val file = tmpDir.createFile("$filename.tmp")!!
+			try {
+				response.body.source().saveTo(file.openOutputStream())
+				val extension = getImageExtension(response, file)
+				file.renameTo("$filename.$extension")
+			} catch (e: Exception) {
+				response.close()
+				file.delete()
+				throw e
+			}
+			emit(file)
+		}
+			// Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
+			.retryWhen { _, attempt ->
+				if (attempt < 3) {
+					delay((2L shl attempt.toInt()) * 1000)
+					true
+				} else {
+					false
+				}
+			}.first()
+	}
+
+	/**
+	 * Gets the image from the filesystem if it exists or downloads it otherwise.
+	 *
+	 * @param page the page to download.
+	 * @param download the download of the page.
+	 */
+	private suspend fun getOrDownloadImageData(page: Page, download: Download, pds: MutableList<PageData>) {
+		// If the image URL is empty, do nothing
+		if (page.imageUrl == null) {
+			return
+		}
+
+		val digitCount = (download.pages?.size ?: 0).toString().length.coerceAtLeast(3)
+		val filename = "%0${digitCount}d".format(Locale.ENGLISH, page.number)
+
+		try {
+			pds.add(downloadImageData(page, download.source, filename))
+			page.progress = 100
+			page.status = Page.State.READY
+		} catch (e: Throwable) {
+			if (e is CancellationException) throw e
+			// Mark this page as error and allow to download the remaining
+			page.progress = 0
+			page.status = Page.State.ERROR
+			notifier.onError(e.message, download.chapter.name, download.manga.title, download.manga.id)
+		}
+	}
+
+	/**
+	 * Downloads the image from network to a file in tmpDir.
+	 *
+	 * @param page the page to download.
+	 * @param source the source of the page.
+	 * @param filename the filename of the image.
+	 */
+	private suspend fun downloadImageData(page: Page, source: HttpSource, filename: String): PageData {
+		page.status = Page.State.DOWNLOAD_IMAGE
+		page.progress = 0
+
+		return flow {
+			val response = source.getImage(page)
+			try {
+				val baos = ByteArrayOutputStream()
+				response.body.source().saveTo(baos)
+				val imgData = baos.toByteArray()
+				val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
+				val extension = ImageUtil.getExtensionFromMimeType(mime) { ByteArrayInputStream(imgData) }
+
+				emit(PageData("$filename.$extension", imgData))
+			} catch (e: Exception) {
+				response.close()
+				throw e
+			}
+		}.retryWhen { _, attempt ->
+			// Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
+			if (attempt < 3) {
+				delay((2L shl attempt.toInt()) * 1000)
+				true
+			} else {
+				false
+			}
+		}.first()
+	}
+
+	/**
+	 * Copies the image from cache to file in tmpDir.
+	 *
+	 * @param cacheFile the file from cache.
+	 * @param tmpDir the temporary directory of the download.
+	 * @param filename the filename of the image.
+	 */
+	private fun copyImageFromCache(cacheFile: File, tmpDir: UniFile, filename: String): UniFile {
+		val tmpFile = tmpDir.createFile("$filename.tmp")!!
+		cacheFile.inputStream().use { input ->
+			tmpFile.openOutputStream().use { output ->
+				input.copyTo(output)
+			}
+		}
+		val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
+		tmpFile.renameTo("$filename.${extension.extension}")
+		cacheFile.delete()
+		return tmpFile
+	}
+
+	/**
+	 * Returns the extension of the downloaded image from the network response, or if it's null,
+	 * analyze the file. If everything fails, assume it's a jpg.
+	 *
+	 * @param response the network response of the image.
+	 * @param file the file where the image is already downloaded.
+	 */
+	private fun getImageExtension(response: Response, file: UniFile): String {
+		val mime = response.body.contentType()?.run { if (type == "image") "image/$subtype" else null }
+		return ImageUtil.getExtensionFromMimeType(mime) { file.openInputStream() }
+	}
+
+	private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {
+		if (!downloadPreferences.splitTallImages().get()) return
+
+		try {
+			val filenamePrefix = "%03d".format(Locale.ENGLISH, page.number)
+			val imageFile = tmpDir.listFiles()?.firstOrNull { it.name.orEmpty().startsWith(filenamePrefix) } ?: error(
+				context.stringResource(MR.strings.download_notifier_split_page_not_found, page.number),
+			)
+
+			// If the original page was previously split, then skip
+			if (imageFile.name.orEmpty().startsWith("${filenamePrefix}__")) return
+
+			ImageUtil.splitTallImage(tmpDir, imageFile, filenamePrefix)
+		} catch (e: Exception) {
+			logcat(LogPriority.ERROR, e) { "Failed to split downloaded image" }
+		}
+	}
+
+	/**
+	 * Checks if the download was successful.
+	 *
+	 * @param download the download to check.
+	 * @param tmpDir the directory where the download is currently stored.
+	 */
+	private fun isDownloadSuccessful(
+		download: Download,
+		tmpDir: UniFile,
+	): Boolean {
+		// Page list hasn't been initialized
+		val downloadPageCount = download.pages?.size ?: return false
+
+		// Ensure that all pages have been downloaded
+		if (download.downloadedImages != downloadPageCount) {
+			return false
+		}
+
+		// Ensure that the chapter folder has all the pages
+		val downloadedImagesCount = tmpDir.listFiles().orEmpty().count {
+			val fileName = it.name.orEmpty()
+			when {
+				fileName in listOf(COMIC_INFO_FILE, NOMEDIA_FILE) -> false
+				fileName.endsWith(".tmp") -> false
+				// Only count the first split page and not the others
+				fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
+				else -> true
+			}
+		}
+		return downloadedImagesCount == downloadPageCount
+	}
+
+	/**
+	 * Checks if the download was successful.
+	 *
+	 * @param download the download to check.
+	 * @param pds list of downloaded data.
+	 */
+	private fun isDownloadSuccessful(
+		download: Download,
+		pds: List<PageData>,
+	): Boolean {
+		// Page list hasn't been initialized
+		val downloadPageCount = download.pages?.size ?: return false
+
+		// Ensure that all pages have been downloaded
+		if (download.downloadedImages != downloadPageCount) {
+			return false
+		}
+
+		// Ensure that pds has all the pages
+		val downloadedImagesCount = pds.count {
+			val fileName = it.name
+			when {
+				fileName.endsWith(".tmp") -> false
+				// Only count the first split page and not the others
+				fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
+				else -> true
+			}
+		}
+		return downloadedImagesCount == downloadPageCount
+	}
+
+	/**
+	 * Archive the chapter pages as a CBZ.
+	 */
+	private fun archiveChapter(
+		mangaDir: UniFile,
+		dirname: String,
+		tmpDir: UniFile,
+	) {
+		val zip = mangaDir.createFile("$dirname.cbz$TMP_DIR_SUFFIX")!!
+		ZipWriter(context, zip).use { writer ->
+			tmpDir.listFiles()?.forEach { file ->
+				writer.write(file)
+			}
+		}
+		zip.renameTo("$dirname.cbz")
+		tmpDir.delete()
+	}
+
+	/**
+	 * Creates a ComicInfo.xml file inside the given directory.
+	 */
+	private suspend fun createComicInfoData(
+		manga: Manga,
+		chapter: Chapter,
+		source: HttpSource,
+	): ByteArray {
+		val categories = getCategories.await(manga.id).map { it.name.trim() }.takeUnless { it.isEmpty() }
+		val urls = getTracks.await(manga.id).mapNotNull { track ->
+			track.remoteUrl.takeUnless { url -> url.isBlank() }?.trim()
+		}.plus(source.getChapterUrl(chapter.toSChapter()).trim()).distinct()
+
+		val comicInfo = getComicInfo(
+			manga,
+			chapter,
+			urls,
+			categories,
+			source.name,
+		)
+
+		// Remove the old file
+		val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
+		return comicInfoString.toByteArray()
+	}
+
+	/**
+	 * Creates a ComicInfo.xml file inside the given directory.
+	 */
+	private suspend fun createComicInfoFile(
+		dir: UniFile,
+		manga: Manga,
+		chapter: Chapter,
+		source: HttpSource,
+	) {
+		// Remove the old file
+		dir.findFile(COMIC_INFO_FILE)?.delete()
+		dir.createFile(COMIC_INFO_FILE)!!.openOutputStream().use {
+			it.write(createComicInfoData(manga, chapter, source))
+		}
+	}
+
+	/**
+	 * Returns true if all the queued downloads are in DOWNLOADED or ERROR state.
+	 */
+	private fun areAllDownloadsFinished(): Boolean {
+		return queueState.value.none { it.status.value <= Download.State.DOWNLOADING.value }
+	}
+
+	private fun addAllToQueue(downloads: List<Download>) {
+		_queueState.update {
+			downloads.forEach { download ->
+				download.status = Download.State.QUEUE
+			}
+			store.addAll(downloads)
+			it + downloads
+		}
+	}
+
+	private fun removeFromQueue(download: Download) {
+		_queueState.update {
+			store.remove(download)
+			if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+				download.status = Download.State.NOT_DOWNLOADED
+			}
+			it - download
+		}
+	}
+
+	private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
+		_queueState.update { queue ->
+			val downloads = queue.filter { predicate(it) }
+			store.removeAll(downloads)
+			downloads.forEach { download ->
+				if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+					download.status = Download.State.NOT_DOWNLOADED
+				}
+			}
+			queue - downloads
+		}
+	}
+
+	fun removeFromQueue(chapters: List<Chapter>) {
+		val chapterIds = chapters.map { it.id }
+		removeFromQueueIf { it.chapter.id in chapterIds }
+	}
+
+	fun removeFromQueue(manga: Manga) {
+		removeFromQueueIf { it.manga.id == manga.id }
+	}
+
+	private fun internalClearQueue() {
+		_queueState.update {
+			it.forEach { download ->
+				if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
+					download.status = Download.State.NOT_DOWNLOADED
+				}
+			}
+			store.clear()
+			emptyList()
+		}
+	}
+
+	fun updateQueue(downloads: List<Download>) {
+		val wasRunning = isRunning
+
+		if (downloads.isEmpty()) {
+			clearQueue()
+			stop()
+			return
+		}
+
+		pause()
+		internalClearQueue()
+		addAllToQueue(downloads)
+
+		if (wasRunning) {
+			start()
+		}
+	}
+
+	companion object {
+		const val TMP_DIR_SUFFIX = "_tmp"
+		const val WARNING_NOTIF_TIMEOUT_MS = 30_000L
+		const val CHAPTERS_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 15
+		private const val DOWNLOADS_QUEUED_WARNING_THRESHOLD = 30
+	}
 }
 
 // Arbitrary minimum required space to start a download: 200 MB

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
@@ -29,26 +29,35 @@ object MigrationFlags {
     private const val CHAPTERS = 0b00001
     private const val CATEGORIES = 0b00010
     private const val CUSTOM_COVER = 0b01000
+	private const val MIGRATE_DOWNLOADED = 0b100000
     private const val DELETE_DOWNLOADED = 0b10000
 
     private val coverCache: CoverCache by injectLazy()
     private val downloadCache: DownloadCache by injectLazy()
 
     fun hasChapters(value: Int): Boolean {
-        return value and CHAPTERS != 0
+	    return isFlagSet(value, CHAPTERS)
     }
 
     fun hasCategories(value: Int): Boolean {
-        return value and CATEGORIES != 0
+	    return isFlagSet(value, CATEGORIES)
     }
 
     fun hasCustomCover(value: Int): Boolean {
-        return value and CUSTOM_COVER != 0
+	    return isFlagSet(value, CUSTOM_COVER)
     }
 
-    fun hasDeleteDownloaded(value: Int): Boolean {
-        return value and DELETE_DOWNLOADED != 0
+    fun hasMigrateDownloaded(value: Int): Boolean {
+	    return isFlagSet(value, MIGRATE_DOWNLOADED)
     }
+
+	fun hasDeleteDownloaded(value: Int): Boolean {
+		return isFlagSet(value, DELETE_DOWNLOADED)
+	}
+
+	private fun isFlagSet(value: Int, flag: Int): Boolean {
+		return (value and flag) == flag
+	}
 
     /** Returns information about applicable flags with default selections. */
     fun getFlags(manga: Manga?, defaultSelectedBitMap: Int): List<MigrationFlag> {
@@ -61,6 +70,7 @@ object MigrationFlags {
                 flags += MigrationFlag.create(CUSTOM_COVER, defaultSelectedBitMap, MR.strings.custom_cover)
             }
             if (downloadCache.getDownloadCount(manga) > 0) {
+	            flags += MigrationFlag.create(MIGRATE_DOWNLOADED, defaultSelectedBitMap, MR.strings.migrate_downloaded)
                 flags += MigrationFlag.create(DELETE_DOWNLOADED, defaultSelectedBitMap, MR.strings.delete_downloaded)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
@@ -29,35 +29,35 @@ object MigrationFlags {
     private const val CHAPTERS = 0b00001
     private const val CATEGORIES = 0b00010
     private const val CUSTOM_COVER = 0b01000
-	private const val MIGRATE_DOWNLOADED = 0b100000
+    private const val MIGRATE_DOWNLOADED = 0b100000
     private const val DELETE_DOWNLOADED = 0b10000
 
     private val coverCache: CoverCache by injectLazy()
     private val downloadCache: DownloadCache by injectLazy()
 
     fun hasChapters(value: Int): Boolean {
-	    return isFlagSet(value, CHAPTERS)
+        return isFlagSet(value, CHAPTERS)
     }
 
     fun hasCategories(value: Int): Boolean {
-	    return isFlagSet(value, CATEGORIES)
+        return isFlagSet(value, CATEGORIES)
     }
 
     fun hasCustomCover(value: Int): Boolean {
-	    return isFlagSet(value, CUSTOM_COVER)
+        return isFlagSet(value, CUSTOM_COVER)
     }
 
     fun hasMigrateDownloaded(value: Int): Boolean {
-	    return isFlagSet(value, MIGRATE_DOWNLOADED)
+        return isFlagSet(value, MIGRATE_DOWNLOADED)
     }
 
-	fun hasDeleteDownloaded(value: Int): Boolean {
-		return isFlagSet(value, DELETE_DOWNLOADED)
-	}
+    fun hasDeleteDownloaded(value: Int): Boolean {
+        return isFlagSet(value, DELETE_DOWNLOADED)
+    }
 
-	private fun isFlagSet(value: Int, flag: Int): Boolean {
-		return (value and flag) == flag
-	}
+    private fun isFlagSet(value: Int, flag: Int): Boolean {
+        return (value and flag) == flag
+    }
 
     /** Returns information about applicable flags with default selections. */
     fun getFlags(manga: Manga?, defaultSelectedBitMap: Int): List<MigrationFlag> {
@@ -70,7 +70,7 @@ object MigrationFlags {
                 flags += MigrationFlag.create(CUSTOM_COVER, defaultSelectedBitMap, MR.strings.custom_cover)
             }
             if (downloadCache.getDownloadCount(manga) > 0) {
-	            flags += MigrationFlag.create(MIGRATE_DOWNLOADED, defaultSelectedBitMap, MR.strings.migrate_downloaded)
+                flags += MigrationFlag.create(MIGRATE_DOWNLOADED, defaultSelectedBitMap, MR.strings.migrate_downloaded)
                 flags += MigrationFlag.create(DELETE_DOWNLOADED, defaultSelectedBitMap, MR.strings.delete_downloaded)
             }
         }
@@ -82,10 +82,7 @@ object MigrationFlags {
         selectedFlags: List<Boolean>,
         flags: List<MigrationFlag>,
     ): Int {
-        return selectedFlags
-            .zip(flags)
-            .filter { (isSelected, _) -> isSelected }
-            .map { (_, flag) -> flag.flag }
+        return selectedFlags.zip(flags).filter { (isSelected, _) -> isSelected }.map { (_, flag) -> flag.flag }
             .reduceOrNull { acc, mask -> acc or mask } ?: 0
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -72,8 +72,7 @@ internal fun MigrateDialog(
 
     if (state.isMigrating) {
         LoadingScreen(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.background.copy(alpha = 0.7f)),
+            modifier = Modifier.background(MaterialTheme.colorScheme.background.copy(alpha = 0.7f)),
         )
     } else {
         AlertDialog(
@@ -212,7 +211,7 @@ internal class MigrateDialogScreenModel(
         val migrateChapters = MigrationFlags.hasChapters(flags)
         val migrateCategories = MigrationFlags.hasCategories(flags)
         val migrateCustomCover = MigrationFlags.hasCustomCover(flags)
-	    val migrateDownloaded = MigrationFlags.hasMigrateDownloaded(flags)
+        val migrateDownloaded = MigrationFlags.hasMigrateDownloaded(flags)
         val deleteDownloaded = MigrationFlags.hasDeleteDownloaded(flags)
 
         try {
@@ -226,15 +225,13 @@ internal class MigrateDialogScreenModel(
             val prevMangaChapters = getChaptersByMangaId.await(oldManga.id)
             val mangaChapters = getChaptersByMangaId.await(newManga.id)
 
-            val maxChapterRead = prevMangaChapters
-                .filter { it.read }
-                .maxOfOrNull { it.chapterNumber }
+            val maxChapterRead = prevMangaChapters.filter { it.read }.maxOfOrNull { it.chapterNumber }
 
             val updatedMangaChapters = mangaChapters.map { mangaChapter ->
                 var updatedChapter = mangaChapter
                 if (updatedChapter.isRecognizedNumber) {
-                    val prevChapter = prevMangaChapters
-                        .find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
+                    val prevChapter =
+                        prevMangaChapters.find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
 
                     if (prevChapter != null) {
                         updatedChapter = updatedChapter.copy(
@@ -265,24 +262,21 @@ internal class MigrateDialogScreenModel(
         getTracks.await(oldManga.id).mapNotNull { track ->
             val updatedTrack = track.copy(mangaId = newManga.id)
 
-            val service = enhancedServices
-                .firstOrNull { it.isTrackFrom(updatedTrack, oldManga, oldSource) }
+            val service = enhancedServices.firstOrNull { it.isTrackFrom(updatedTrack, oldManga, oldSource) }
 
             if (service != null) {
                 service.migrateTrack(updatedTrack, newManga, newSource)
             } else {
                 updatedTrack
             }
-        }
-            .takeIf { it.isNotEmpty() }
-            ?.let { insertTrack.awaitAll(it) }
+        }.takeIf { it.isNotEmpty() }?.let { insertTrack.awaitAll(it) }
 
-	    // Delete downloaded
-	    if (migrateDownloaded) {
-		    if (oldSource != null) {
-			    downloadManager.migrateManga(oldManga, oldSource, newManga, newSource)
-		    }
-	    }
+        // Delete downloaded
+        if (migrateDownloaded) {
+            if (oldSource != null) {
+                downloadManager.migrateManga(oldManga, oldSource, newManga, newSource)
+            }
+        }
 
         // Delete downloaded
         if (deleteDownloaded) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -212,6 +212,7 @@ internal class MigrateDialogScreenModel(
         val migrateChapters = MigrationFlags.hasChapters(flags)
         val migrateCategories = MigrationFlags.hasCategories(flags)
         val migrateCustomCover = MigrationFlags.hasCustomCover(flags)
+	    val migrateDownloaded = MigrationFlags.hasMigrateDownloaded(flags)
         val deleteDownloaded = MigrationFlags.hasDeleteDownloaded(flags)
 
         try {
@@ -275,6 +276,13 @@ internal class MigrateDialogScreenModel(
         }
             .takeIf { it.isNotEmpty() }
             ?.let { insertTrack.awaitAll(it) }
+
+	    // Delete downloaded
+	    if (migrateDownloaded) {
+		    if (oldSource != null) {
+			    downloadManager.migrateManga(oldManga, oldSource, newManga, newSource)
+		    }
+	    }
 
         // Delete downloaded
         if (deleteDownloaded) {

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -12,7 +12,8 @@ class DownloadPreferences(
     )
 
     fun saveChaptersAsCBZ() = preferenceStore.getBoolean("save_chapter_as_cbz", true)
-	fun saveChaptersCBZInRAM() = preferenceStore.getBoolean("save_chapter_cbz_in_ram", true)
+
+    fun saveChaptersCBZInRAM() = preferenceStore.getBoolean("save_chapter_cbz_in_ram", true)
 
     fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", true)
 

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -12,6 +12,7 @@ class DownloadPreferences(
     )
 
     fun saveChaptersAsCBZ() = preferenceStore.getBoolean("save_chapter_as_cbz", true)
+	fun saveChaptersCBZInRAM() = preferenceStore.getBoolean("save_chapter_cbz_in_ram", true)
 
     fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", true)
 

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -13,7 +13,7 @@ class DownloadPreferences(
 
     fun saveChaptersAsCBZ() = preferenceStore.getBoolean("save_chapter_as_cbz", true)
 
-    fun saveChaptersCBZInRAM() = preferenceStore.getBoolean("save_chapter_cbz_in_ram", true)
+    fun saveChaptersCBZInRAM() = preferenceStore.getBoolean("save_chapter_cbz_in_ram", false)
 
     fun splitTallImages() = preferenceStore.getBoolean("split_tall_images", true)
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -16,6 +16,7 @@
     <string name="manga">Library entries</string>
     <string name="chapters">Chapters</string>
     <string name="track">Tracking</string>
+    <string name="migrate_downloaded">Migrate downloaded</string>
     <string name="delete_downloaded">Delete downloaded</string>
     <string name="history">History</string>
     <string name="scanlator">Scanlator</string>
@@ -508,6 +509,7 @@
     <string name="auto_download_while_reading">Auto download while reading</string>
     <string name="download_ahead_info">Only works if the current chapter + the next one are already downloaded.</string>
     <string name="save_chapter_as_cbz">Save as CBZ archive</string>
+    <string name="save_chapter_cbz_in_ram">Download CBZ pages in memory</string>
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/PageData.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/PageData.kt
@@ -1,0 +1,3 @@
+package eu.kanade.tachiyomi.source.model
+
+class PageData(val name: String, val data: ByteArray)


### PR DESCRIPTION
Introduced 2 new features:
1. add migrate downloaded
2. add download cbz in ram

issues:
1. migrate downloaded vs delete downloaded functionality may be unclear to users.  What migrate downloaded does is to move/rename downloaded files from one source to the other via meta-data matching.  Any files that are not matched will remain in the source folder unchanged.  Delete downloaded will clean up these orphan files.
2. download cbz in ram toggle not disabled when cbz is disabled.  This function uses the java standard zip functionality rather than libarchive due to fstat not being available.

This change was done as a response to the recent decommissioning of mangasee/mangalife, where migrating from these sources to weeb central is a real pain factor.