### PR TITLE
Added editorconfig indent_style to ensure uniform auto-formating.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,9 @@
+# prevent user settings outside of the project from propagating into this project
+root = true
+
 [*.{kt,kts}]
 max_line_length = 120
+indent_style = space
 indent_size = 4
 insert_final_newline = true
 ij_kotlin_allow_trailing_comma = true


### PR DESCRIPTION
`.editorconfig` is used by this project, and `space` indenting is also used.

However, the following were missing from `.editorconfig`:
1. `root`: user `.editorconfig` settings higher in the directory hierarchy than the project root would get propagated to this project.
2. `indent_style`: user `.editorconfig` settings or IDE settings that specify `indent_style` to tab would get propagated to this project.

This fix ensures tab/spaces is uniform across the project.
Autoformat has not been run across the entire project (results in hundreds of changes if done - mainly newlines and cleanup of unused imports which is not related to this change).