### PR TITLE
Feature: Migrate Downloaded Chapters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,9 @@
+# prevent user settings outside of the project from propagating into this project
+root = true
+
 [*.{kt,kts}]
 max_line_length = 120
+indent_style = space
 indent_size = 4
 insert_final_newline = true
 ij_kotlin_allow_trailing_comma = true

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
@@ -16,10 +18,12 @@ import kotlinx.coroutines.runBlocking
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.storage.nameWithoutExtension
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
@@ -40,6 +44,7 @@ class DownloadManager(
     private val getCategories: GetCategories = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
+    private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
 ) {
 
     /**
@@ -235,6 +240,69 @@ class DownloadManager(
             // Delete manga directory if empty
             if (mangaDir?.listFiles()?.isEmpty() == true) {
                 deleteManga(manga, source, removeQueued = false)
+            }
+        }
+    }
+
+    /**
+     * Migrates manga from one source to another.
+     *
+     * @param oldManga the origin manga for migration..
+     * @param oldSource the origin source for migration..
+     * @param newManga the target manga for migration.
+     * @param newSource the target source for migration.
+     */
+    fun migrateManga(oldManga: Manga, oldSource: Source, newManga: Manga, newSource: Source) {
+        launchIO {
+            val oldMangaDir = provider.findMangaDir(oldManga.title, oldSource) ?: return@launchIO
+            val newMangaDir = provider.getMangaDir(newManga.title, newSource)
+            val downloadedChapters = oldMangaDir.listFiles()
+            val downloadedChaptersMap =
+                downloadedChapters?.associateBy({ it.nameWithoutExtension }, { it }) ?: return@launchIO
+
+            // map old chapters to new chapters.  The names may not be the same.
+            val oldChapters = getChaptersByMangaId.await(oldManga.id)
+            val newChapters = getChaptersByMangaId.await(newManga.id)
+            val oldChaptersByChapterNumber = oldChapters.associateBy { it.chapterNumber }
+
+            // If the chapter is downloaded, migrate it.
+            for (chapter in newChapters) {
+                val oldChapter = oldChaptersByChapterNumber[chapter.chapterNumber]
+                if (oldChapter != null) {
+                    val oldChapterName = provider.getChapterDirName(oldChapter.name, oldChapter.scanlator)
+                    val oldChapterFile = downloadedChaptersMap[oldChapterName]
+                    if (oldChapterFile != null) {
+                        val newChapterName = if (oldChapterFile.extension == null) {
+                            provider.getChapterDirName(chapter.name, chapter.scanlator)
+                        } else {
+                            provider.getChapterDirName(chapter.name, chapter.scanlator) + "." + oldChapterFile.extension
+                        }
+
+                        // move the file to newMangaDir, renaming the file/folder in the process
+                        var chapterUri: Uri? = oldChapterFile.uri
+
+                        // Rename the file.
+                        chapterUri = chapterUri?.let {
+                            DocumentsContract.renameDocument(
+                                context.contentResolver,
+                                it, newChapterName,
+                            )
+                        }
+
+                        // Move the file to the new source folder.
+                        chapterUri = chapterUri?.let {
+                            DocumentsContract.moveDocument(
+                                context.contentResolver,
+                                it, oldMangaDir.uri, newMangaDir.uri,
+                            )
+                        }
+
+                        // Can save chapterUri somewhere here if needed.
+
+                        cache.removeChapter(oldChapter, oldManga)
+                        cache.addChapter(newChapterName, newMangaDir, newManga)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
@@ -30,24 +30,33 @@ object MigrationFlags {
     private const val CATEGORIES = 0b00010
     private const val CUSTOM_COVER = 0b01000
     private const val DELETE_DOWNLOADED = 0b10000
+    private const val MIGRATE_DOWNLOADED = 0b100000
 
     private val coverCache: CoverCache by injectLazy()
     private val downloadCache: DownloadCache by injectLazy()
 
     fun hasChapters(value: Int): Boolean {
-        return value and CHAPTERS != 0
+        return isFlagSet(value, CHAPTERS)
     }
 
     fun hasCategories(value: Int): Boolean {
-        return value and CATEGORIES != 0
+        return isFlagSet(value, CATEGORIES)
     }
 
     fun hasCustomCover(value: Int): Boolean {
-        return value and CUSTOM_COVER != 0
+        return isFlagSet(value, CUSTOM_COVER)
+    }
+
+    fun hasMigrateDownloaded(value: Int): Boolean {
+        return isFlagSet(value, MIGRATE_DOWNLOADED)
     }
 
     fun hasDeleteDownloaded(value: Int): Boolean {
-        return value and DELETE_DOWNLOADED != 0
+        return isFlagSet(value, DELETE_DOWNLOADED)
+    }
+
+    private fun isFlagSet(value: Int, flag: Int): Boolean {
+        return (value and flag) == flag
     }
 
     /** Returns information about applicable flags with default selections. */
@@ -61,6 +70,7 @@ object MigrationFlags {
                 flags += MigrationFlag.create(CUSTOM_COVER, defaultSelectedBitMap, MR.strings.custom_cover)
             }
             if (downloadCache.getDownloadCount(manga) > 0) {
+                flags += MigrationFlag.create(MIGRATE_DOWNLOADED, defaultSelectedBitMap, MR.strings.migrate_downloaded)
                 flags += MigrationFlag.create(DELETE_DOWNLOADED, defaultSelectedBitMap, MR.strings.delete_downloaded)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -212,6 +212,7 @@ internal class MigrateDialogScreenModel(
         val migrateChapters = MigrationFlags.hasChapters(flags)
         val migrateCategories = MigrationFlags.hasCategories(flags)
         val migrateCustomCover = MigrationFlags.hasCustomCover(flags)
+        val migrateDownloaded = MigrationFlags.hasMigrateDownloaded(flags)
         val deleteDownloaded = MigrationFlags.hasDeleteDownloaded(flags)
 
         try {
@@ -275,6 +276,13 @@ internal class MigrateDialogScreenModel(
         }
             .takeIf { it.isNotEmpty() }
             ?.let { insertTrack.awaitAll(it) }
+
+        // Migrate downloaded chapters
+        if (migrateDownloaded) {
+            if (oldSource != null) {
+                downloadManager.migrateManga(oldManga, oldSource, newManga, newSource)
+            }
+        }
 
         // Delete downloaded
         if (deleteDownloaded) {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -16,6 +16,7 @@
     <string name="manga">Library entries</string>
     <string name="chapters">Chapters</string>
     <string name="track">Tracking</string>
+    <string name="migrate_downloaded">Migrate downloaded</string>
     <string name="delete_downloaded">Delete downloaded</string>
     <string name="history">History</string>
     <string name="scanlator">Scanlator</string>


### PR DESCRIPTION
Split from https://github.com/mihonapp/mihon/pull/1718

This is a QoL improvement feature for source migration of manga.

Currently, downloaded chapters cannot be migrated, and they must either be:
1. Deleted and redownloaded
2. Migrated manually via file system operations

There are problems with both approaches.
1. Delete + Redownload
    1. Can take a long time to download again.
    2. Unnecessarily erodes flash storage endurance.
    3. Unnecessary internet bandwidth consumption.
2. Migrate Manually
    1. Very time consuming for the user.
        1. User must download a sample of chapters to figure out the file naming pattern under the new source
        2. Rename the chapters according to the new source's chapter naming pattern
        3. Move the renamed chapters to the correct folder under the new source.
    2. Cache is out of sync with application until cache is invalidated.

This feature addresses the above issues with migrate.

Sample title for migration
![mihon_migrate_1](https://github.com/user-attachments/assets/4a90cb14-0a43-483f-98ea-b6254dd446f7)

Files in storage before migration
![mihon_migrate_1a](https://github.com/user-attachments/assets/9a5ac281-1b61-483e-89e7-8beae8bc70a9)

Migration interface (new checkbox for "Migrate downloaded")
![mihon_migrate_2](https://github.com/user-attachments/assets/0a7f4341-a0da-4b68-bac5-3560c45e0955)

Sample title post-migration
![mihon_migrate_3](https://github.com/user-attachments/assets/f13f443d-b1ca-4d3b-baf7-053d237f4da1)

Files in storage post-migration
![mihon_migrate_3a](https://github.com/user-attachments/assets/fedc82c9-c4e4-47d4-8ff0-0beae43f9127)
