### PR TITLE
Fix chapter navigator slider being empty

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/components/ChapterNavigator.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/components/ChapterNavigator.kt
@@ -117,6 +117,7 @@ fun ChapterNavigator(
                                 .padding(horizontal = 8.dp),
                             value = currentPage,
                             valueRange = 1..totalPages,
+                            steps = totalPages - 2,
                             onValueChange = f@{
                                 if (it == currentPage) return@f
                                 onPageIndexChange(it - 1)


### PR DESCRIPTION
Commit e8c9cb2c2e4c24443368f0d653c5283f9671ffec
forgot to update the reworked slider for chapter navigator slider.