### PR TITLE
remove reference to Preferences of deleting category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))
 - Fix Bangumi and MAL tracking 401 errors due to Mihon sending expired credentials ([@MajorTanya](https://github.com/MajorTanya)) ([#1681](https://github.com/mihonapp/mihon/pull/1681), [#1682](https://github.com/mihonapp/mihon/pull/1682))
 - Fix certain Infinix devices being unable to use any "Open link in browser" actions, including tracker setup ([@MajorTanya](https://github.com/MajorTanya)) ([#1684](https://github.com/mihonapp/mihon/pull/1684))
+- Fix deleted categories not correctly update App's setting preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 
 ### Other
 - Add zoned "Current time" to debug info and include year & timezone in logcat output ([@MajorTanya](https://github.com/MajorTanya)) ([#1672](https://github.com/mihonapp/mihon/pull/1672))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))
 - Fix Bangumi and MAL tracking 401 errors due to Mihon sending expired credentials ([@MajorTanya](https://github.com/MajorTanya)) ([#1681](https://github.com/mihonapp/mihon/pull/1681), [#1682](https://github.com/mihonapp/mihon/pull/1682))
 - Fix certain Infinix devices being unable to use any "Open link in browser" actions, including tracker setup ([@MajorTanya](https://github.com/MajorTanya)) ([#1684](https://github.com/mihonapp/mihon/pull/1684))
-- Fix deleted categories not correctly update App's setting preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
+- Fix App's preferences referencing deleted categories ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 
 ### Other
 - Add zoned "Current time" to debug info and include year & timezone in logcat output ([@MajorTanya](https://github.com/MajorTanya)) ([#1672](https://github.com/mihonapp/mihon/pull/1672))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
     defaultConfig {
         applicationId = "app.mihon"
 
-        versionCode = 9
+        versionCode = 10
         versionName = "0.17.1"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -111,7 +111,7 @@ class DomainModule : InjektModule {
         addFactory { RenameCategory(get()) }
         addFactory { ReorderCategory(get()) }
         addFactory { UpdateCategory(get()) }
-        addFactory { DeleteCategory(get()) }
+        addFactory { DeleteCategory(get(), get(), get()) }
 
         addSingletonFactory<MangaRepository> { MangaRepositoryImpl(get()) }
         addFactory { GetDuplicateLibraryManga(get()) }

--- a/app/src/main/java/mihon/core/migration/migrations/CategoryPreferencesCleanupMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/CategoryPreferencesCleanupMigration.kt
@@ -6,8 +6,6 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class CategoryPreferencesCleanupMigration : Migration {
     override val version: Float = 10f
@@ -16,7 +14,7 @@ class CategoryPreferencesCleanupMigration : Migration {
         val libraryPreferences = migrationContext.get<LibraryPreferences>() ?: return@withIOContext false
         val downloadPreferences = migrationContext.get<DownloadPreferences>() ?: return@withIOContext false
 
-        val getCategories = Injekt.get<GetCategories>()
+        val getCategories = migrationContext.get<GetCategories>() ?: return@withIOContext false
         val allCategories = getCategories.await().map { it.id.toString() }.toSet()
 
         val defaultCategory = libraryPreferences.defaultCategory().get()

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -7,5 +7,5 @@ val migrations: List<Migration>
         SetupBackupCreateMigration(),
         SetupLibraryUpdateMigration(),
         TrustExtensionRepositoryMigration(),
-        RemoveNonReferredCategoryPreferencesMigration(),
+        CategoryPreferencesCleanupMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -7,4 +7,5 @@ val migrations: List<Migration>
         SetupBackupCreateMigration(),
         SetupLibraryUpdateMigration(),
         TrustExtensionRepositoryMigration(),
+        RemoveNonReferredCategoryPreferencesMigration(),
     )

--- a/app/src/main/java/mihon/core/migration/migrations/RemoveNonReferredCategoryPreferencesMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/RemoveNonReferredCategoryPreferencesMigration.kt
@@ -1,0 +1,46 @@
+package mihon.core.migration.migrations
+
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.library.service.LibraryPreferences
+
+class RemoveNonReferredCategoryPreferencesMigration : Migration {
+    override val version: Float = 10f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
+        val handler = migrationContext.get<DatabaseHandler>() ?: return@withIOContext false
+        val libraryPreferences = migrationContext.get<LibraryPreferences>() ?: return@withIOContext false
+        val downloadPreferences = migrationContext.get<DownloadPreferences>() ?: return@withIOContext false
+
+        val allCategoryIds = handler.awaitList { categoriesQueries.getCategories() }.map { it.id.toString() }
+
+        val defaultCategory = libraryPreferences.defaultCategory().get()
+        if (defaultCategory.toString() !in allCategoryIds) {
+            libraryPreferences.defaultCategory().delete()
+        }
+
+        val categoriesPrefs = listOf(
+            libraryPreferences.updateCategories(),
+            libraryPreferences.updateCategoriesExclude(),
+            downloadPreferences.removeExcludeCategories(),
+            downloadPreferences.downloadNewChapterCategories(),
+            downloadPreferences.downloadNewChapterCategoriesExclude(),
+        )
+        categoriesPrefs.forEach { pref ->
+            val categoriesSet = pref.get()
+            val removingList = emptySet<String>().toMutableSet()
+            categoriesSet.forEach { setId ->
+                if (setId !in allCategoryIds) {
+                    removingList += setId
+                }
+            }
+            pref.set(
+                categoriesSet.minus(removingList),
+            )
+        }
+        return@withIOContext true
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
@@ -7,13 +7,11 @@ import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.category.repository.CategoryRepository
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 class DeleteCategory(
     private val categoryRepository: CategoryRepository,
-    private val libraryPreferences: LibraryPreferences = Injekt.get(),
-    private val downloadPreferences: DownloadPreferences = Injekt.get(),
+    private val libraryPreferences: LibraryPreferences,
+    private val downloadPreferences: DownloadPreferences,
 ) {
 
     suspend fun await(categoryId: Long) = withNonCancellableContext {

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
@@ -48,7 +48,7 @@ class DeleteCategory(
             val categoriesSet = pref.get()
             if (categoriesSet.any { it == categoryId.toString() }) {
                 pref.set(
-                    categoriesSet.minus(categoryId.toString())
+                    categoriesSet.minus(categoryId.toString()),
                 )
             }
         }

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
@@ -37,20 +37,18 @@ class DeleteCategory(
             libraryPreferences.defaultCategory().delete()
         }
 
-        val categoriesPrefs = listOf(
+        val categoryPreferences = listOf(
             libraryPreferences.updateCategories(),
             libraryPreferences.updateCategoriesExclude(),
             downloadPreferences.removeExcludeCategories(),
             downloadPreferences.downloadNewChapterCategories(),
             downloadPreferences.downloadNewChapterCategoriesExclude(),
         )
-        categoriesPrefs.forEach { pref ->
-            val categoriesSet = pref.get()
-            if (categoriesSet.any { it == categoryId.toString() }) {
-                pref.set(
-                    categoriesSet.minus(categoryId.toString()),
-                )
-            }
+        val categoryIdString = categoryId.toString()
+        categoryPreferences.forEach { preference ->
+            val ids = preference.get()
+            if (categoryIdString !in ids) return@forEach
+            preference.set(ids.minus(categoryIdString))
         }
 
         try {

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
@@ -12,6 +12,8 @@ import uy.kohesive.injekt.api.get
 
 class DeleteCategory(
     private val categoryRepository: CategoryRepository,
+    private val libraryPreferences: LibraryPreferences = Injekt.get(),
+    private val downloadPreferences: DownloadPreferences = Injekt.get(),
 ) {
 
     suspend fun await(categoryId: Long) = withNonCancellableContext {
@@ -30,13 +32,11 @@ class DeleteCategory(
             )
         }
 
-        val libraryPreferences = Injekt.get<LibraryPreferences>()
         val defaultCategory = libraryPreferences.defaultCategory().get()
         if (defaultCategory == categoryId.toInt()) {
             libraryPreferences.defaultCategory().delete()
         }
 
-        val downloadPreferences = Injekt.get<DownloadPreferences>()
         val categoriesPrefs = listOf(
             libraryPreferences.updateCategories(),
             libraryPreferences.updateCategoriesExclude(),


### PR DESCRIPTION
When a category is deleted, preferences which are referencing to that category should also be clear to avoid null/incorrect settings