### PR TITLE
Track entries privately if supported by the tracker

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/model/Track.kt
+++ b/app/src/main/java/eu/kanade/domain/track/model/Track.kt
@@ -10,6 +10,7 @@ fun Track.copyPersonalFrom(other: Track): Track {
         status = other.status,
         startDate = other.startDate,
         finishDate = other.finishDate,
+        private = other.private,
     )
 }
 
@@ -26,6 +27,7 @@ fun Track.toDbTrack(): DbTrack = DbTrack.create(trackerId).also {
     it.tracking_url = remoteUrl
     it.started_reading_date = startDate
     it.finished_reading_date = finishDate
+    it.private = private
 }
 
 fun DbTrack.toDomainTrack(idRequired: Boolean = true): Track? {
@@ -44,5 +46,6 @@ fun DbTrack.toDomainTrack(idRequired: Boolean = true): Track? {
         remoteUrl = tracking_url,
         startDate = started_reading_date,
         finishDate = finished_reading_date,
+        private = private,
     )
 }

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -36,6 +36,8 @@ class TrackPreferences(
 
     fun anilistScoreType() = preferenceStore.getString("anilist_score_type", Anilist.POINT_10)
 
+    fun privateTracking() = preferenceStore.getBoolean("pref_private_tracking", false)
+
     fun autoUpdateTrack() = preferenceStore.getBoolean("pref_auto_update_manga_sync_key", true)
 
     fun autoUpdateTrackOnMarkRead() = preferenceStore.getEnum(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -135,6 +135,10 @@ object SettingsTrackingScreen : SearchableSettings {
                     .associateWith { stringResource(it.titleRes) }
                     .toPersistentMap(),
             ),
+            Preference.PreferenceItem.SwitchPreference(
+                pref = trackPreferences.privateTracking(),
+                title = stringResource(MR.strings.pref_private_tracking),
+            ),
             Preference.PreferenceGroup(
                 title = stringResource(MR.strings.services),
                 preferenceItems = persistentListOf(

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHomePreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHomePreviewProvider.kt
@@ -25,7 +25,9 @@ internal class TrackInfoDialogHomePreviewProvider :
         remoteUrl = "https://example.com",
         startDate = 0L,
         finishDate = 0L,
+        private = false
     )
+    private val privateTrack = aTrack.copy(private = false)
     private val trackItemWithoutTrack = TrackItem(
         track = null,
         tracker = DummyTracker(
@@ -40,6 +42,14 @@ internal class TrackInfoDialogHomePreviewProvider :
             name = "Example Tracker 2",
         ),
     )
+    private val trackItemWithPrivateTrack = TrackItem(
+        track = privateTrack,
+        tracker = DummyTracker(
+            id = 2L,
+            name = "Example Tracker 2",
+        ),
+    )
+
 
     private val trackersWithAndWithoutTrack = @Composable {
         TrackInfoDialogHome(
@@ -57,6 +67,7 @@ internal class TrackInfoDialogHomePreviewProvider :
             onOpenInBrowser = {},
             onRemoved = {},
             onCopyLink = {},
+            onPrivateClick = {},
         )
     }
 
@@ -73,6 +84,24 @@ internal class TrackInfoDialogHomePreviewProvider :
             onOpenInBrowser = {},
             onRemoved = {},
             onCopyLink = {},
+            onPrivateClick = {},
+        )
+    }
+
+    private val trackerWithPrivateTracking = @Composable {
+        TrackInfoDialogHome(
+            trackItems = listOf(trackItemWithPrivateTrack),
+            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            onStatusClick = {},
+            onChapterClick = {},
+            onScoreClick = {},
+            onStartDateEdit = {},
+            onEndDateEdit = {},
+            onNewSearch = {},
+            onOpenInBrowser = {},
+            onRemoved = {},
+            onCopyLink = {},
+            onPrivateClick = {},
         )
     }
 
@@ -80,5 +109,6 @@ internal class TrackInfoDialogHomePreviewProvider :
         get() = sequenceOf(
             trackersWithAndWithoutTrack,
             noTrackers,
+            trackerWithPrivateTracking,
         )
 }

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
@@ -188,6 +188,29 @@ fun TrackDateSelector(
 }
 
 @Composable
+fun TrackPrivateSelector(
+    selection: Boolean?,
+    onSelectionChange: (Boolean) -> Unit,
+    selections: ImmutableList<String>,
+    onConfirm: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    BaseSelector(
+        title = stringResource(MR.strings.track_private),
+        content = {
+            WheelTextPicker(
+                items = selections,
+                modifier = Modifier.align(Alignment.Center),
+                startIndex = selection?.compareTo(false) ?: 0,
+                onSelectionChanged = { onSelectionChange(it == 1) },
+            )
+        },
+        onConfirm = onConfirm,
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+@Composable
 private fun BaseSelector(
     title: String,
     content: @Composable BoxScope.() -> Unit,

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -90,8 +91,9 @@ fun TrackerSearch(
     queryResult: Result<List<TrackSearch>>?,
     selected: TrackSearch?,
     onSelectedChange: (TrackSearch) -> Unit,
-    onConfirmSelection: () -> Unit,
+    onConfirmSelection: (private: Boolean) -> Unit,
     onDismissRequest: () -> Unit,
+    privateTracking: Boolean,
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
@@ -164,15 +166,42 @@ fun TrackerSearch(
                 enter = fadeIn() + slideInVertically { it / 2 },
                 exit = slideOutVertically { it / 2 } + fadeOut(),
             ) {
-                Button(
-                    onClick = { onConfirmSelection() },
-                    modifier = Modifier
-                        .padding(12.dp)
-                        .windowInsetsPadding(WindowInsets.navigationBars)
-                        .fillMaxWidth(),
-                    elevation = ButtonDefaults.elevatedButtonElevation(),
-                ) {
-                    Text(text = stringResource(MR.strings.action_track))
+                if (privateTracking) {
+                    FlowRow (
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Button(
+                            onClick = { onConfirmSelection(false) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(12.dp)
+                                .windowInsetsPadding(WindowInsets.navigationBars),
+                            elevation = ButtonDefaults.elevatedButtonElevation(),
+                        ) {
+                            Text(text = stringResource(MR.strings.action_track))
+                        }
+                        Button(
+                            onClick = { onConfirmSelection(true) },
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(12.dp)
+                                .windowInsetsPadding(WindowInsets.navigationBars),
+                            elevation = ButtonDefaults.elevatedButtonElevation(),
+                        ) {
+                            Text(text = stringResource(MR.strings.action_private_track))
+                        }
+                    }
+                } else {
+                    Button(
+                        onClick = { onConfirmSelection(false) },
+                        modifier = Modifier
+                            .padding(12.dp)
+                            .windowInsetsPadding(WindowInsets.navigationBars)
+                            .fillMaxWidth(),
+                        elevation = ButtonDefaults.elevatedButtonElevation(),
+                    ) {
+                        Text(text = stringResource(MR.strings.action_track))
+                    }
                 }
             }
         },

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
@@ -20,6 +20,7 @@ internal class TrackerSearchPreviewProvider : PreviewParameterProvider<@Composab
             onSelectedChange = {},
             onConfirmSelection = {},
             onDismissRequest = {},
+            privateTracking = false
         )
     }
     private val fullPageWithoutSelected = @Composable {
@@ -31,6 +32,7 @@ internal class TrackerSearchPreviewProvider : PreviewParameterProvider<@Composab
             onSelectedChange = {},
             onConfirmSelection = {},
             onDismissRequest = {},
+            privateTracking = false
         )
     }
     private val loading = @Composable {
@@ -42,12 +44,27 @@ internal class TrackerSearchPreviewProvider : PreviewParameterProvider<@Composab
             onSelectedChange = {},
             onConfirmSelection = {},
             onDismissRequest = {},
+            privateTracking = false
+        )
+    }
+    private val fullPageWithPrivateTracking = @Composable {
+        val items = someTrackSearches().take(30).toList()
+        TrackerSearch(
+            state = TextFieldState(initialText = "search text"),
+            onDispatchQuery = {},
+            queryResult = Result.success(items),
+            selected = items[1],
+            onSelectedChange = {},
+            onConfirmSelection = {},
+            onDismissRequest = {},
+            privateTracking = true
         )
     }
     override val values: Sequence<@Composable () -> Unit> = sequenceOf(
         fullPageWithSecondSelected,
         fullPageWithoutSelected,
         loading,
+        fullPageWithPrivateTracking,
     )
 
     private fun someTrackSearches(): Sequence<TrackSearch> = sequence {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupTracking.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupTracking.kt
@@ -25,6 +25,7 @@ data class BackupTracking(
     @ProtoNumber(10) var startedReadingDate: Long = 0,
     // finishedReadingDate is called endReadTime in 1.x
     @ProtoNumber(11) var finishedReadingDate: Long = 0,
+    @ProtoNumber(12) var private: Boolean = false,
     @ProtoNumber(100) var mediaId: Long = 0,
 ) {
 
@@ -48,6 +49,7 @@ data class BackupTracking(
             startDate = this@BackupTracking.startedReadingDate,
             finishDate = this@BackupTracking.finishedReadingDate,
             remoteUrl = this@BackupTracking.trackingUrl,
+            private = this@BackupTracking.private,
         )
     }
 }
@@ -66,6 +68,7 @@ val backupTrackMapper = {
         remoteUrl: String,
         startDate: Long,
         finishDate: Long,
+        private: Boolean,
     ->
     BackupTracking(
         syncId = syncId.toInt(),
@@ -80,5 +83,6 @@ val backupTrackMapper = {
         startedReadingDate = startDate,
         finishedReadingDate = finishDate,
         trackingUrl = remoteUrl,
+        private = private,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -404,6 +404,7 @@ class MangaRestorer(
                         track.remoteUrl,
                         track.startDate,
                         track.finishDate,
+                        track.private,
                         track.id,
                     )
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Track.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Track.kt
@@ -32,12 +32,15 @@ interface Track : Serializable {
 
     var tracking_url: String
 
+    var private: Boolean
+
     fun copyPersonalFrom(other: Track) {
         last_chapter_read = other.last_chapter_read
         score = other.score
         status = other.status
         started_reading_date = other.started_reading_date
         finished_reading_date = other.finished_reading_date
+        private = other.private
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/TrackImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/TrackImpl.kt
@@ -29,4 +29,6 @@ class TrackImpl : Track {
     override var finished_reading_date: Long = 0
 
     override var tracking_url: String = ""
+
+    override var private: Boolean = false
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -37,6 +37,8 @@ abstract class BaseTracker(
     // Application and remote support for reading dates
     override val supportsReadingDates: Boolean = false
 
+    override val supportsPrivateTracking: Boolean = false
+
     // TODO: Store all scores as 10 point in the future maybe?
     override fun get10PointScore(track: DomainTrack): Double {
         return track.score
@@ -117,6 +119,11 @@ abstract class BaseTracker(
 
     override suspend fun setRemoteFinishDate(track: Track, epochMillis: Long) {
         track.finished_reading_date = epochMillis
+        updateRemote(track)
+    }
+
+    override suspend fun setRemotePrivate(track: Track, private: Boolean) {
+        track.private = private
         updateRemote(track)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -22,6 +22,8 @@ interface Tracker {
     // Application and remote support for reading dates
     val supportsReadingDates: Boolean
 
+    val supportsPrivateTracking: Boolean
+
     @ColorInt
     fun getLogoColor(): Int
 
@@ -82,4 +84,6 @@ interface Tracker {
     suspend fun setRemoteStartDate(track: Track, epochMillis: Long)
 
     suspend fun setRemoteFinishDate(track: Track, epochMillis: Long)
+
+    suspend fun setRemotePrivate(track: Track, private: Boolean)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -43,6 +43,8 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
 
     override val supportsReadingDates: Boolean = true
 
+    override val supportsPrivateTracking: Boolean = true
+
     private val scorePreference = trackPreferences.anilistScoreType()
 
     init {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -49,6 +49,7 @@ data class ALUserManga(
     val startDateFuzzy: Long,
     val completedDateFuzzy: Long,
     val manga: ALManga,
+    val private: Boolean,
 ) {
     fun toTrack() = Track.create(TrackerManager.ANILIST).apply {
         remote_id = manga.remoteId
@@ -60,6 +61,7 @@ data class ALUserManga(
         last_chapter_read = chaptersRead.toDouble()
         library_id = libraryId
         total_chapters = manga.totalChapters
+        private = private
     }
 
     private fun toTrackStatus() = when (listStatus) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserList.kt
@@ -28,6 +28,7 @@ data class ALUserListItem(
     val startedAt: ALFuzzyDate,
     val completedAt: ALFuzzyDate,
     val media: ALSearchItem,
+    val private: Boolean,
 ) {
     fun toALUserManga(): ALUserManga {
         return ALUserManga(
@@ -38,6 +39,7 @@ data class ALUserListItem(
             startDateFuzzy = startedAt.toEpochMilli(),
             completedDateFuzzy = completedAt.toEpochMilli(),
             manga = media.toALManga(),
+            private = private,
         )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
@@ -30,6 +30,8 @@ class TrackSearch : Track {
 
     override var finished_reading_date: Long = 0
 
+    override var private: Boolean = false
+
     override lateinit var tracking_url: String
 
     var cover_url: String = ""

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -17,6 +17,7 @@ data class DummyTracker(
     override val id: Long,
     override val name: String,
     override val supportsReadingDates: Boolean = false,
+    override val supportsPrivateTracking: Boolean = false,
     override val isLoggedIn: Boolean = false,
     override val isLoggedInFlow: Flow<Boolean> = flowOf(false),
     val valLogoColor: Int = Color.rgb(18, 25, 35),
@@ -118,5 +119,10 @@ data class DummyTracker(
     override suspend fun setRemoteFinishDate(
         track: eu.kanade.tachiyomi.data.database.models.Track,
         epochMillis: Long,
+    ) = Unit
+
+    override suspend fun setRemotePrivate(
+        track: eu.kanade.tachiyomi.data.database.models.Track,
+        private: Boolean,
     ) = Unit
 }

--- a/data/src/main/java/tachiyomi/data/track/TrackMapper.kt
+++ b/data/src/main/java/tachiyomi/data/track/TrackMapper.kt
@@ -17,6 +17,7 @@ object TrackMapper {
         remoteUrl: String,
         startDate: Long,
         finishDate: Long,
+        private: Boolean,
     ): Track = Track(
         id = id,
         mangaId = mangaId,
@@ -31,5 +32,6 @@ object TrackMapper {
         remoteUrl = remoteUrl,
         startDate = startDate,
         finishDate = finishDate,
+        private = private,
     )
 }

--- a/data/src/main/java/tachiyomi/data/track/TrackRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/track/TrackRepositoryImpl.kt
@@ -64,6 +64,7 @@ class TrackRepositoryImpl(
                     remoteUrl = mangaTrack.remoteUrl,
                     startDate = mangaTrack.startDate,
                     finishDate = mangaTrack.finishDate,
+                    private = mangaTrack.private,
                 )
             }
         }

--- a/data/src/main/sqldelight/tachiyomi/data/manga_sync.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/manga_sync.sq
@@ -1,3 +1,5 @@
+import kotlin.Boolean;
+
 CREATE TABLE manga_sync(
     _id INTEGER NOT NULL PRIMARY KEY,
     manga_id INTEGER NOT NULL,
@@ -12,6 +14,7 @@ CREATE TABLE manga_sync(
     remote_url TEXT NOT NULL,
     start_date INTEGER NOT NULL,
     finish_date INTEGER NOT NULL,
+    private INTEGER AS Boolean DEFAULT 0 NOT NULL,
     UNIQUE (manga_id, sync_id) ON CONFLICT REPLACE,
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE
@@ -36,8 +39,8 @@ FROM manga_sync
 WHERE manga_id = :mangaId;
 
 insert:
-INSERT INTO manga_sync(manga_id,sync_id,remote_id,library_id,title,last_chapter_read,total_chapters,status,score,remote_url,start_date,finish_date)
-VALUES (:mangaId,:syncId,:remoteId,:libraryId,:title,:lastChapterRead,:totalChapters,:status,:score,:remoteUrl,:startDate,:finishDate);
+INSERT INTO manga_sync(manga_id,sync_id,remote_id,library_id,title,last_chapter_read,total_chapters,status,score,remote_url,start_date,finish_date,private)
+VALUES (:mangaId,:syncId,:remoteId,:libraryId,:title,:lastChapterRead,:totalChapters,:status,:score,:remoteUrl,:startDate,:finishDate,:private);
 
 update:
 UPDATE manga_sync
@@ -53,5 +56,6 @@ SET
     score = coalesce(:score, score),
     remote_url = coalesce(:trackingUrl, remote_url),
     start_date = coalesce(:startDate, start_date),
-    finish_date = coalesce(:finishDate, finish_date)
+    finish_date = coalesce(:finishDate, finish_date),
+    private = coalesce(:private, private)
 WHERE _id = :id;

--- a/domain/src/main/java/tachiyomi/domain/track/model/Track.kt
+++ b/domain/src/main/java/tachiyomi/domain/track/model/Track.kt
@@ -16,4 +16,5 @@ data class Track(
     val remoteUrl: String,
     val startDate: Long,
     val finishDate: Long,
+    val private: Boolean,
 ) : Serializable

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -515,12 +515,14 @@
     <string name="tracking_guide">Tracking guide</string>
     <string name="pref_auto_update_manga_sync">Update progress after reading</string>
     <string name="pref_auto_update_manga_on_mark_read">Update progress when marked as read</string>
+    <string name="pref_private_tracking">Enable tracking entries privately if supported</string>
     <string name="services">Trackers</string>
     <string name="tracking_info">One-way sync to update the chapter progress in external tracker services. Set up tracking for individual entries from their tracking button.</string>
     <string name="enhanced_services">Enhanced trackers</string>
     <string name="enhanced_services_not_installed">Available but source not installed: %s</string>
     <string name="enhanced_tracking_info">Provides enhanced features for specific sources. Entries are automatically tracked when added to your library.</string>
     <string name="action_track">Track</string>
+    <string name="action_private_track">Track privately</string>
     <string name="track_activity_name">Tracker login</string>
 
       <!-- Browse section -->
@@ -770,6 +772,8 @@
     <string name="track_status">Status</string>
     <string name="track_started_reading_date">Start date</string>
     <string name="track_finished_reading_date">Finish date</string>
+    <string name="track_private">Private</string>
+    <string name="track_public">Public</string>
     <string name="track_type">Type</string>
     <string name="myanimelist_relogin">Please login to MAL again</string>
     <string name="source_unsupported">Source is not supported</string>


### PR DESCRIPTION
Features in #1735

- Add a private tracking setting toggle to allow private tracking.
- Add `supportsPrivateTracking` to Trackers
- if tracking is enabled and supported, can choose between private or public tracking when adding a track on the search screen.
- Add a toggle to the track info screen to toggle between private and public tracking on entries

Current issues:
- `findLibManga` query in anilistApi doesn't seem to return private entries causing further issues down the line