### PR TITLE
Fix Bangumi linking regression

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
@@ -105,11 +105,11 @@ class Bangumi(id: Long) : BaseTracker(id, "Bangumi") {
     suspend fun login(code: String) {
         try {
             val oauth = api.accessToken(code)
+            interceptor.newAuth(oauth)
             // Users can set a 'username' (not nickname) once which effectively
             // replaces the stringified ID in certain queries.
             // If no username is set, the API returns the user ID as a strings
             var username = api.getUsername()
-            interceptor.newAuth(oauth)
             saveCredentials(username, oauth.accessToken)
         } catch (_: Throwable) {
             logout()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -153,7 +153,7 @@ class BangumiApi(
     suspend fun getUsername(): String {
         return withIOContext {
             with(json) {
-                authClient.newCall(GET("$API_URL/v0/me$"))
+                authClient.newCall(GET("$API_URL/v0/me"))
                     .awaitSuccess()
                     .parseAs<BGMUser>()
                     .username


### PR DESCRIPTION
Caused by #1748.

Two different issues actually.

Firstly, the getUsername API call uses the authClient, which uses the BangumiInterceptor to get the current OAuth data and attach the Authorization header. However, on login, #1748 did not try to set the new auth details until after attempting to call getUsername. This would cause Mihon to think the user was not authenticated with Bangumi and cancel the process.

This is fixed by having Mihon store the OAuth credentials in the interceptor first before attempting to call getUsername.

The second issue is a simple trailing dollar sign in the API URL for the getUsername method. This was removed.

This wasn't caught because I added the username fetching later after having already linked Bangumi in the emulator. I didn't think to relink it from scratch after.

And yes, I did check this time. Linking this way works.