### PR TITLE
Add back explicit update(track) call to Bangumi

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
@@ -58,7 +58,7 @@ class Bangumi(id: Long) : BaseTracker(id, "Bangumi") {
                 track.status = if (hasReadChapters) READING else statusTrack.status
             }
 
-            track
+            update(track)
         } else {
             // Set default fields if it's not found in the list
             track.status = if (hasReadChapters) READING else PLAN_TO_READ


### PR DESCRIPTION
Most if not all other trackers do this too. Technically this causes some request duplication (since things like the BaseTracker's setRemoteLastChapterRead fire anyway due to the tracker sheet being open). But considering the reduced number of requests in other places, I think this is still acceptable.

Forgot to say why:
This makes sure that we update Bangumi with our new local data where applicable (like private tracking state).

This change will allow #1736 to proceed, hopefully.

What have we learned from this? Actually think about code. Also, don't hide request stuff in base classes but that's not actionable here.