### PR TITLE
Mitigate the libraryView NPE crash that occurs for large libraries when removing entries shortly after any other DB write

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -284,7 +284,7 @@ internal class MigrateDialogScreenModel(
         }
 
         if (replace) {
-            updateManga.await(MangaUpdate(oldManga.id, favorite = false, dateAdded = 0))
+            updateManga.awaitUpdateFavorite(oldManga.id, false)
         }
 
         // Update custom cover (recheck if custom cover exists)

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -1,6 +1,11 @@
 package tachiyomi.domain.manga.interactor
 
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.retry
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.repository.MangaRepository
 
@@ -12,7 +17,20 @@ class GetLibraryManga(
         return mangaRepository.getLibraryManga()
     }
 
+    @OptIn(FlowPreview::class)
     fun subscribe(): Flow<List<LibraryManga>> {
         return mangaRepository.getLibraryMangaAsFlow()
+            .retry(3) { cause ->
+                // if we hit the NPE due to library being updated during write
+                // retry up to 3x, waiting 500ms between retries
+                (cause is NullPointerException).also {
+                    if (it) delay(500)
+                }
+            }
+            .debounce(1500) // if another update comes in during retries, ditch the retries
+            .catch {
+                // emit nothing during failure
+                // retries didn't work and we don't want to crash
+            }
     }
 }


### PR DESCRIPTION
Currently, users with huge libraries hit a NullPointerException when reading libraryView due to the LibraryScreenModal subscribing to the library view Flow, as unfavoriting a manga removes a row from that library view while it is still being read.

This papers over the NPE that gets throw and allows the app to recover if a user removes an entry while that view is still being read by the flow collector.