### PR TITLE
Workaround SQLDelight Flow handling crash when row is removed while DB is being read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix App's preferences referencing deleted categories ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 - Fix backup/restore of category related preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1726](https://github.com/mihonapp/mihon/pull/1726))
 - Fix WebView sending app's package name in `X-Requested-With` header, which led to sources blocking access ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1812](https://github.com/mihonapp/mihon/pull/1812))
+- Workaround crash when removing/migrating entries from library
+  - Removes libraryView from DB in favor of dbView
 
 ### Removed
 - Remove alphabetical category sort option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix App's preferences referencing deleted categories ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 - Fix backup/restore of category related preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1726](https://github.com/mihonapp/mihon/pull/1726))
 - Fix WebView sending app's package name in `X-Requested-With` header, which led to sources blocking access ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1812](https://github.com/mihonapp/mihon/pull/1812))
-- Workaround crash when removing/migrating entries from library
+- Workaround crash when removing/migrating entries from library ([@FlaminSarge](https://github.com/FlaminSarge)) ([#1799](https://github.com/mihonapp/mihon/pull/1799))
   - Removes libraryView from DB in favor of dbView
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix App's preferences referencing deleted categories ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 - Fix backup/restore of category related preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1726](https://github.com/mihonapp/mihon/pull/1726))
 - Fix WebView sending app's package name in `X-Requested-With` header, which led to sources blocking access ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1812](https://github.com/mihonapp/mihon/pull/1812))
-- Workaround crash when removing/migrating entries from library ([@FlaminSarge](https://github.com/FlaminSarge)) ([#1799](https://github.com/mihonapp/mihon/pull/1799))
-  - Removes libraryView from DB in favor of dbView
+- Attempt to fix crash when migrating or removing entries from library ([@FlaminSarge](https://github.com/FlaminSarge)) ([#1799](https://github.com/mihonapp/mihon/pull/1799))
 
 ### Removed
 - Remove alphabetical category sort option

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -284,7 +284,7 @@ internal class MigrateDialogScreenModel(
         }
 
         if (replace) {
-            updateManga.awaitUpdateFavorite(oldManga.id, false)
+            updateManga.awaitUpdateFavorite(oldManga.id, favorite = false)
         }
 
         // Update custom cover (recheck if custom cover exists)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -284,7 +284,7 @@ internal class MigrateDialogScreenModel(
         }
 
         if (replace) {
-            updateManga.await(MangaUpdate(oldManga.id, favorite = false, dateAdded = 0))
+            updateManga.awaitUpdateFavorite(oldManga.id, false)
         }
 
         // Update custom cover (recheck if custom cover exists)

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -57,14 +57,14 @@ class MangaRepositoryImpl(
 
     override suspend fun getLibraryManga(): List<LibraryManga> {
         // https://github.com/mihonapp/mihon/pull/1799
-        return handler.awaitList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }
+        return handler.awaitList { libraryViewQueries.library(MangaMapper::mapLibraryManga) }
             .filter { it.manga.favorite }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>> {
         // https://github.com/mihonapp/mihon/pull/1799
-        return handler.subscribeToList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }
+        return handler.subscribeToList { libraryViewQueries.library(MangaMapper::mapLibraryManga) }
             .mapLatest { manga ->
                 manga.filter { it.manga.favorite }
             }

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -56,21 +56,17 @@ class MangaRepositoryImpl(
     }
 
     override suspend fun getLibraryManga(): List<LibraryManga> {
-        // filtering favorites here to workaround sqldelight read-after-delete cursor NPE
+        // https://github.com/mihonapp/mihon/pull/1799
         return handler.awaitList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }
-            .filter {
-                it.manga.favorite
-            }
+            .filter { it.manga.favorite }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>> {
-        // filtering favorites here to workaround sqldelight read-after-delete cursor NPE
+        // https://github.com/mihonapp/mihon/pull/1799
         return handler.subscribeToList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }
-            .mapLatest { mangas ->
-                mangas.filter {
-                    it.manga.favorite
-                }
+            .mapLatest { manga ->
+                manga.filter { it.manga.favorite }
             }
     }
 

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -57,9 +57,10 @@ class MangaRepositoryImpl(
 
     override suspend fun getLibraryManga(): List<LibraryManga> {
         // filtering favorites here to workaround sqldelight read-after-delete cursor NPE
-        return handler.awaitList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }.filter {
-            it.manga.favorite
-        }
+        return handler.awaitList { libraryViewQueries.dbManga(MangaMapper::mapLibraryManga) }
+            .filter {
+                it.manga.favorite
+            }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/data/src/main/sqldelight/tachiyomi/migrations/5.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/5.sqm
@@ -30,7 +30,3 @@ LEFT JOIN(
 ON M._id = C.manga_id
 LEFT JOIN mangas_categories AS MC
 ON MC.manga_id = M._id;
-
-dbManga:
-SELECT *
-FROM dbView;

--- a/data/src/main/sqldelight/tachiyomi/migrations/5.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/5.sqm
@@ -1,4 +1,5 @@
-CREATE VIEW dbView AS
+DROP VIEW libraryView;
+CREATE VIEW libraryView AS
 SELECT
     M.*,
     coalesce(C.total, 0) AS totalCount,

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -1,4 +1,6 @@
-CREATE VIEW dbView AS
+-- contains entire DB, filtered to favorites in kotlin
+-- https://github.com/mihonapp/mihon/pull/1799
+CREATE VIEW libraryView AS
 SELECT
     M.*,
     coalesce(C.total, 0) AS totalCount,
@@ -31,6 +33,6 @@ ON M._id = C.manga_id
 LEFT JOIN mangas_categories AS MC
 ON MC.manga_id = M._id;
 
-dbManga:
+library:
 SELECT *
-FROM dbView;
+FROM libraryView;


### PR DESCRIPTION
Alternative to #1794 
Fixes #93 
(maybe)

Instead of allowing rows to be removed from getLibraryMangaAsFlow()'s result while it's still being read (due to favorite toggling), fetch all the DB manga and filter in code instead.

Works around https://github.com/sqldelight/sqldelight/issues/1584 where large DBs run into the issue of cursor reaching a row that's already been removed and NPEing.

This _may_ also make libraryView faster, somehow.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
