### PR TITLE
fix "Multiple substitutions specified in non-positional format of string resource string/restore_duration"

### DIFF
--- a/i18n/src/commonMain/moko-resources/am/strings.xml
+++ b/i18n/src/commonMain/moko-resources/am/strings.xml
@@ -270,7 +270,7 @@
     <string name="creating_backup">ምትኬን መፍጠር</string>
     <string name="backup_choice">ምትኬ ለማስቀመጥ ምን ይፈልጋሉ?</string>
     <string name="backup_in_progress">ምትኬ ቀድሞውኑ በሂደት ላይ ነው</string>
-    <string name="restore_duration">%02d ደቂቃ ፣ %02d ሰከንድ</string>
+    <string name="restore_duration">%1$02d ደቂቃ ፣ %2$02d ሰከንድ</string>
     <string name="restore_completed">እነበረበት መልስ ተጠናቅቋል</string>
     <string name="backup_restore_missing_trackers">መከታተያዎች አልገቡም:</string>
     <string name="backup_restore_missing_sources">የጠፋ ምንጮች:</string>

--- a/i18n/src/commonMain/moko-resources/ar/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ar/strings.xml
@@ -330,7 +330,7 @@
     <string name="restore_in_progress">الاستعادة قيد التقدم بالفعل</string>
     <string name="creating_backup_error">فشل النسخ الاحتياطي</string>
     <string name="backup_in_progress">يُنسخ احتياطيًّا بالفعل</string>
-    <string name="restore_duration">%02d دقيقة و %02d ثانية</string>
+    <string name="restore_duration">%1$02d دقيقة و %2$02d ثانية</string>
     <string name="action_unpin">إلغاء التثبيت</string>
     <string name="action_pin">تثبيت</string>
     <string name="action_select_inverse">عكس التحديد</string>

--- a/i18n/src/commonMain/moko-resources/bg/strings.xml
+++ b/i18n/src/commonMain/moko-resources/bg/strings.xml
@@ -329,7 +329,7 @@
     <string name="restore_in_progress">Възстановяването е в процес</string>
     <string name="creating_backup_error">Съхраняването неуспешно</string>
     <string name="backup_in_progress">Архивирането вече е в ход</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_webtoon_side_padding">Странично разстояние</string>
     <string name="pref_category_reading">Четене</string>
     <string name="pref_always_show_chapter_transition">Винаги показвай прехода между главите</string>

--- a/i18n/src/commonMain/moko-resources/bn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/bn/strings.xml
@@ -346,7 +346,7 @@
     <string name="restore_in_progress">বর্তমানে পুনরুদ্ধার চলছে</string>
     <string name="creating_backup_error">ব্যাকআপ ব্যর্থ হয়েছে</string>
     <string name="backup_in_progress">ব্যাকআপ ইতিমধ্যেই চলছে</string>
-    <string name="restore_duration">%02d মিনিট, %02d সেকেন্ড</string>
+    <string name="restore_duration">%1$02d মিনিট, %2$02d সেকেন্ড</string>
     <string name="backup_restore_missing_sources">উৎস অনুপলব্ধ:</string>
     <string name="invalid_backup_file_missing_manga">ব্যাকআপে কোনো মাংগা নেই।</string>
     <string name="invalid_backup_file">ব্যাকআপ ফাইল গ্রহণযোগ্য নয়</string>

--- a/i18n/src/commonMain/moko-resources/ca/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ca/strings.xml
@@ -358,7 +358,7 @@
     <string name="local_source_help_guide">Guia de fonts locals</string>
     <string name="last_used_source">Utilitzada per darrera vegada</string>
     <string name="check_for_updates">Comprova si hi ha actualitzacions</string>
-    <string name="restore_duration">%02d min i %02d s</string>
+    <string name="restore_duration">%1$02d min i %2$02d s</string>
     <string name="downloaded_only_summary">Filtra tots els elements de la vostra biblioteca</string>
     <string name="gray_background">Gris</string>
     <string name="viewer">Mode de lectura</string>

--- a/i18n/src/commonMain/moko-resources/ceb/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ceb/strings.xml
@@ -357,7 +357,7 @@
     <string name="pref_dns_over_https">DNS sa HTTPS (DoH)</string>
     <string name="requires_app_restart">Nagkinahanglan nga i-restart ang app aron ma-epekto</string>
     <string name="backup_in_progress">Ang pag-backup nagpadayon na</string>
-    <string name="restore_duration">%02d minuto , %02d ikaduha</string>
+    <string name="restore_duration">%1$02d minuto , %2$02d ikaduha</string>
     <string name="backup_choice">Unsa ang gusto nimo i-backup?</string>
     <string name="backup_restore_content_full">Ang datos gikan sa backup file mapasig-uli.
 \n

--- a/i18n/src/commonMain/moko-resources/cs/strings.xml
+++ b/i18n/src/commonMain/moko-resources/cs/strings.xml
@@ -354,7 +354,7 @@
     <string name="restore_in_progress">Obnovení již probíhá</string>
     <string name="creating_backup_error">Zálohování selhalo</string>
     <string name="backup_in_progress">Zálohování již probíhá</string>
-    <string name="restore_duration">%02d minut, %02d sekund</string>
+    <string name="restore_duration">%1$02d minut, %2$02d sekund</string>
     <string name="backup_restore_content_full">Budeš poté muset doinstalovat jakékoliv chybějící rozšíření a přihlásit se do sledovacích služeb pro jejich použití.</string>
     <string name="backup_restore_missing_trackers">Sledovače, ve kterých nejsi přihlášený/á:</string>
     <string name="backup_restore_missing_sources">Chybějící zdroje:</string>

--- a/i18n/src/commonMain/moko-resources/cv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/cv/strings.xml
@@ -5,7 +5,7 @@
     <string name="cookies_cleared">Куккисем катертнӗ</string>
     <string name="pref_clear_cookies">Кукки тасат</string>
     <string name="label_network">Тетел</string>
-    <string name="restore_duration">%02d минут та %02d ҫеккунт</string>
+    <string name="restore_duration">%1$02d минут та %2$02d ҫеккунт</string>
     <string name="services">Сервиссем</string>
     <string name="pref_download_new">Ҫӗнӗ сыпӑксене тийесе илмелле</string>
     <string name="last_read_chapter">Юлашки вуланӑ сыпăк</string>

--- a/i18n/src/commonMain/moko-resources/da/strings.xml
+++ b/i18n/src/commonMain/moko-resources/da/strings.xml
@@ -304,7 +304,7 @@
     <string name="split_tall_images">Opdel høje billeder</string>
     <string name="disabled">Deaktiveret</string>
     <string name="last_read_chapter">Senest læste kapitel</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="pref_high">Høj</string>
     <string name="pref_restore_backup_summ">Gendan biblioteket fra sikkerhedskopi</string>
     <string name="spen_previous_page">Forrige side</string>

--- a/i18n/src/commonMain/moko-resources/eo/strings.xml
+++ b/i18n/src/commonMain/moko-resources/eo/strings.xml
@@ -316,7 +316,7 @@
     <string name="creating_backup_error">Kreado de savkopio fiaskis</string>
     <string name="creating_backup">Kreas savkopion</string>
     <string name="backup_choice">Kion vi volas savkopii?</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="backup_restore_missing_sources">Mankantaj fontoj:</string>
     <string name="pref_category_auto_download">Aŭtomata elŝuto</string>
     <string name="last_read_chapter">Laste legita ĉapitro</string>

--- a/i18n/src/commonMain/moko-resources/eu/strings.xml
+++ b/i18n/src/commonMain/moko-resources/eu/strings.xml
@@ -35,7 +35,7 @@
     <string name="no_more_results">Ez dago emaitza gehiagorik</string>
     <string name="download_queue_size_warning">Abisua: deskarga handiek iturriak motelagoak izatea eta/edo Mihon blokeatzea ekar dezakete</string>
     <string name="creating_backup">Babeskopia sortzen</string>
-    <string name="restore_duration">%02d min, %02d seg</string>
+    <string name="restore_duration">%1$02d min, %2$02d seg</string>
     <string name="add_tracking">Gehitu jarraipena</string>
     <string name="cache_delete_error">Errore bat gertatu da cachea garbitzean</string>
     <string name="backup_created">Babeskopia sortu da</string>

--- a/i18n/src/commonMain/moko-resources/fa/strings.xml
+++ b/i18n/src/commonMain/moko-resources/fa/strings.xml
@@ -344,7 +344,7 @@
     <string name="creating_backup">درحال ایجاد نسخه پشتیبان</string>
     <string name="backup_choice">چه چیزی را می خواهید پشتیبان گیری کنید ؟</string>
     <string name="backup_in_progress">پشتیبان گیری هنوز در حال انجام است</string>
-    <string name="restore_duration">%02d دقیقه, %02d ثانیه</string>
+    <string name="restore_duration">%1$02d دقیقه, %2$02d ثانیه</string>
     <string name="restore_completed">بازیابی کامل شد</string>
     <string name="backup_restore_missing_sources">منابع ناموجود:</string>
     <string name="invalid_backup_file_missing_manga">فایل پشتیبان حاوی هیچ ورودی کتابخانه نیست.</string>

--- a/i18n/src/commonMain/moko-resources/fi/strings.xml
+++ b/i18n/src/commonMain/moko-resources/fi/strings.xml
@@ -358,7 +358,7 @@
     <string name="check_for_updates">Tarkista päivitykset</string>
     <string name="last_used_source">Viimeksi käytetty</string>
     <string name="local_source_help_guide">Paikallinen lähdeopas</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="downloaded_only_summary">Suodattaa kaikki sarjat kirjastossasi</string>
     <string name="gray_background">Harmaa</string>
     <string name="pref_category_for_this_series">Tälle sarjalle</string>

--- a/i18n/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n/src/commonMain/moko-resources/fr/strings.xml
@@ -356,7 +356,7 @@
     <string name="licenses">Licences à code source ouvert</string>
     <string name="last_used_source">Dernière utilisée</string>
     <string name="check_for_updates">Rechercher des mises à jour</string>
-    <string name="restore_duration">%02d min, %02d s</string>
+    <string name="restore_duration">%1$02d min, %2$02d s</string>
     <string name="information_webview_required">WebView est requis pour le fonctionnement l\'application</string>
     <string name="local_source_help_guide">Guide des sources locales</string>
     <string name="downloaded_only_summary">Filtrer toutes les entrées dans la bibliothèque</string>

--- a/i18n/src/commonMain/moko-resources/gl/strings.xml
+++ b/i18n/src/commonMain/moko-resources/gl/strings.xml
@@ -287,7 +287,7 @@
     <string name="auto_download_while_reading">Descargar automaticamente durante a lectura</string>
     <string name="download_ahead_info">Só funciona con elementos da biblioteca e se o capítulo actual e o seguinte xa están descargados.</string>
     <string name="restore_completed">Restauración completada</string>
-    <string name="restore_duration">%02d min y %02d seg</string>
+    <string name="restore_duration">%1$02d min y %2$02d seg</string>
     <string name="backup_choice">De que queres facer unha copia de seguridade?</string>
     <string name="missing_storage_permission">Non se concederon os permisos de almacenamento</string>
     <string name="empty_backup_error">Ningún elemento na biblioteca co que facer a copia de seguridade</string>

--- a/i18n/src/commonMain/moko-resources/he/strings.xml
+++ b/i18n/src/commonMain/moko-resources/he/strings.xml
@@ -476,7 +476,7 @@
     <string name="reading">קריאה</string>
     <string name="login">התחברות</string>
     <string name="pinned_sources">נעוץ</string>
-    <string name="restore_duration">%02d דקות, %02d שניות</string>
+    <string name="restore_duration">%1$02d דקות, %2$02d שניות</string>
     <string name="restoring_backup_canceled">השחזור בוטל</string>
     <string name="backup_info">רצוי לשמור עותקים נוספים של גיבויים במקומות אחרים בנוסף.</string>
     <string name="database_clean">אין מה לנקות</string>

--- a/i18n/src/commonMain/moko-resources/hi/strings.xml
+++ b/i18n/src/commonMain/moko-resources/hi/strings.xml
@@ -360,7 +360,7 @@
     <string name="last_used_source">आखरी इस्त्तमाल किया गया</string>
     <string name="check_for_updates">अद्यतन के लिए जाँच</string>
     <string name="local_source_help_guide">स्थानीय स्रोत गाइड</string>
-    <string name="restore_duration">%02d मिनट,%02d सेकंड</string>
+    <string name="restore_duration">%1$02d मिनट,%2$02d सेकंड</string>
     <string name="downloaded_only_summary">आपकी पुस्तकालय में सभी आइटम को फ़िल्टर करता है</string>
     <string name="viewer">पढ़न मोड</string>
     <string name="pref_category_for_this_series">इस श्रृंखला के लिए</string>

--- a/i18n/src/commonMain/moko-resources/hu/strings.xml
+++ b/i18n/src/commonMain/moko-resources/hu/strings.xml
@@ -452,7 +452,7 @@
     <string name="information_cloudflare_bypass_failure">Nem sikerült megkerülni a Cloudflare-t</string>
     <string name="pref_landscape_zoom">Automatikusan nagyítsa a széles képeket</string>
     <string name="restore_completed">Helyreállítás befejeződött</string>
-    <string name="restore_duration">%02d perc, %02d másodperc</string>
+    <string name="restore_duration">%1$02d perc, %2$02d másodperc</string>
     <string name="backup_restore_content_full">Előfordulhat, hogy telepítenie kell a hiányzó bővítményeket, majd később be kell jelentkeznie a nyilvántartási szolgáltatásokba a használatukhoz.</string>
     <string name="pref_refresh_library_covers">Könyvtár fedők frissítése</string>
     <string name="pref_dump_crash_logs">Hibaüzenetetek törlése</string>

--- a/i18n/src/commonMain/moko-resources/ka-rGE/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ka-rGE/strings.xml
@@ -191,7 +191,7 @@
     <string name="invalid_backup_file_missing_manga">მარქაფი ბიბლიოთეკის ჩანაწერებს არ შეიცავს.</string>
     <string name="backup_restore_missing_sources">დაკარგული წყაროები:</string>
     <string name="restore_completed">აღდგენა შესრულებულია</string>
-    <string name="restore_duration">%02d წუთი, %02d წამი</string>
+    <string name="restore_duration">%1$02d წუთი, %2$02d წამი</string>
     <string name="backup_in_progress">მარქაფი უკვე მიმდინარეობს</string>
     <string name="backup_choice">რას გსურს რომ შეუქმნა რეზერვი?</string>
     <string name="creating_backup">რეზერვის შექმნა</string>

--- a/i18n/src/commonMain/moko-resources/kk/strings.xml
+++ b/i18n/src/commonMain/moko-resources/kk/strings.xml
@@ -306,7 +306,7 @@
     <string name="color_filter_g_value">Ж</string>
     <string name="color_filter_b_value">К</string>
     <string name="white_background">Ақ</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_always_show_chapter_transition">Тараулардың ауысуын әрдайым көрсету</string>
     <string name="rotation_force_portrait">Құлыпталған портрет</string>
     <string name="pref_high">Жоғары</string>

--- a/i18n/src/commonMain/moko-resources/kn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/kn/strings.xml
@@ -111,7 +111,7 @@
     <string name="label_settings">ಸಂಯೋಜನೆಗಳು</string>
     <string name="label_more">ಇನ್ನಷ್ಟು</string>
     <string name="name">ಹೆಸರು</string>
-    <string name="restore_duration">%02d ನಿಮಿಷ, %02d ಸೆಕೆಂಡು</string>
+    <string name="restore_duration">%1$02d ನಿಮಿಷ, %2$02d ಸೆಕೆಂಡು</string>
     <string name="restore_completed">ಮರುಸ್ಥಾಪನೆ ಪೂರ್ಣಗೊಂಡಿದೆ</string>
     <string name="backup_created">ಬ್ಯಾಕಪ್ ರಚಿಸಲಾಗಿದೆ</string>
     <string name="pref_backup_interval">ಬ್ಯಾಕಪ್ ಆವರ್ತನ</string>

--- a/i18n/src/commonMain/moko-resources/ko/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ko/strings.xml
@@ -314,7 +314,7 @@
     <string name="label_network">네트워크</string>
     <string name="restoring_backup_canceled">복원 취소</string>
     <string name="creating_backup_error">백업 실패</string>
-    <string name="restore_duration">%02d분 %02d초</string>
+    <string name="restore_duration">%1$02d분 %2$02d초</string>
     <string name="invalid_backup_file">잘못된 백업 파일:</string>
     <string name="pref_category_auto_download">자동 다운로드</string>
     <string name="pref_remove_bookmarked_chapters">북마크 표시된 회차 삭제 허용</string>

--- a/i18n/src/commonMain/moko-resources/lt/strings.xml
+++ b/i18n/src/commonMain/moko-resources/lt/strings.xml
@@ -482,7 +482,7 @@
     <string name="update_check_fdroid_migration_info">Nauja versija pasiekiama oficialiuose leidiniuose. Bakstelėkite , kad sužinotumėte, kaip pereiti iš neoficialių \"F-Droid\" leidinių.</string>
     <string name="pref_disable_battery_optimization">Išjungti akumuliatoriaus optimizavimą</string>
     <string name="restore_completed">Atkūrimas baigtas</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="database_clean">Nėra ką išvalyti</string>
     <string name="webview_data_deleted">„WebView“ duomenys išvalyti</string>
     <string name="getting_started_guide">Darbo pradžios vadovas</string>

--- a/i18n/src/commonMain/moko-resources/lv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/lv/strings.xml
@@ -79,7 +79,7 @@
     <string name="creating_backup">Izveido dublējumu</string>
     <string name="backup_choice">Ko vēlaties dublēt?</string>
     <string name="backup_in_progress">Dublēšana jau notiek</string>
-    <string name="restore_duration">%02d min, %02d sec</string>
+    <string name="restore_duration">%1$02d min, %2$02d sec</string>
     <string name="restore_completed">Atjaunošana pabeigta</string>
     <string name="backup_restore_missing_sources">Trūkstošie avoti:</string>
     <string name="invalid_backup_file_missing_manga">Dublējumā nav neviena bibliotēkas ieraksta.</string>

--- a/i18n/src/commonMain/moko-resources/ms/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ms/strings.xml
@@ -358,7 +358,7 @@
     <string name="last_used_source">Terakhir digunakan</string>
     <string name="check_for_updates">Semak untuk kemas kini</string>
     <string name="local_source_help_guide">Panduan penggunaan sumber lokal</string>
-    <string name="restore_duration">%02d minit, %02d saat</string>
+    <string name="restore_duration">%1$02d minit, %2$02d saat</string>
     <string name="downloaded_only_summary">Tapis semua entri di dalam pustaka anda</string>
     <string name="gray_background">Kelabu</string>
     <string name="viewer">Mod membaca</string>

--- a/i18n/src/commonMain/moko-resources/nb-rNO/strings.xml
+++ b/i18n/src/commonMain/moko-resources/nb-rNO/strings.xml
@@ -343,7 +343,7 @@
     <string name="sort_by_upload_date">Etter opplastingsdato</string>
     <string name="last_used_source">Sist brukt</string>
     <string name="tabs_header">Faner</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="backup_restore_missing_sources">Manglende kilder:</string>
     <string name="gray_background">Grå</string>
     <string name="action_display_show_tabs">Vis kategorifaner</string>

--- a/i18n/src/commonMain/moko-resources/nl/strings.xml
+++ b/i18n/src/commonMain/moko-resources/nl/strings.xml
@@ -348,7 +348,7 @@
     <string name="pref_disable_battery_optimization">Batterijoptimalisatie uitzetten</string>
     <string name="creating_backup_error">Back-up mislukt</string>
     <string name="backup_in_progress">Er wordt al een back-up gemaakt</string>
-    <string name="restore_duration">%02d min, %02d sec</string>
+    <string name="restore_duration">%1$02d min, %2$02d sec</string>
     <string name="pref_category_reading">Lezen</string>
     <string name="pref_always_show_chapter_transition">Hoofdstukovergangen altijd weergeven</string>
     <string name="vertical_plus_viewer">Doorlopend verticaal</string>

--- a/i18n/src/commonMain/moko-resources/nn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/nn/strings.xml
@@ -192,7 +192,7 @@
     <string name="invalid_backup_file_missing_manga">Reservekopi inneheld ingen manga.</string>
     <string name="pref_restore_backup_summ">Gjenopprett bibliotek frå reservekopifil</string>
     <string name="restore_completed">Gjenoppretting fullført</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="backup_choice">Kva ønskjer du å ta reservekopi av?</string>
     <string name="creating_backup">Lagar reservekopi</string>
     <string name="restoring_backup">Gjenoppretter reservekopi</string>

--- a/i18n/src/commonMain/moko-resources/pl/strings.xml
+++ b/i18n/src/commonMain/moko-resources/pl/strings.xml
@@ -341,7 +341,7 @@
     <string name="restoring_backup_canceled">Anulowano przywracanie</string>
     <string name="restore_in_progress">Kopia zapasowa jest w trakcie przywracania</string>
     <string name="backup_in_progress">Kopia zapasowa jest już w trakcie tworzenia</string>
-    <string name="restore_duration">%02d min, %02d s</string>
+    <string name="restore_duration">%1$02d min, %2$02d s</string>
     <string name="pref_webtoon_side_padding">Marginesy boczne</string>
     <string name="gray_background">Szary</string>
     <string name="ext_updates_pending">Dostępne aktualizacje</string>

--- a/i18n/src/commonMain/moko-resources/pt-rBR/strings.xml
+++ b/i18n/src/commonMain/moko-resources/pt-rBR/strings.xml
@@ -358,7 +358,7 @@
     <string name="last_used_source">Última utilizada</string>
     <string name="check_for_updates">Procurar por atualizações</string>
     <string name="local_source_help_guide">Guia sobre a fonte local</string>
-    <string name="restore_duration">%02d min e %02d seg</string>
+    <string name="restore_duration">%1$02d min e %2$02d seg</string>
     <string name="downloaded_only_summary">Filtra todos os itens em sua biblioteca</string>
     <string name="gray_background">Cinza</string>
     <string name="viewer">Modo de leitura</string>

--- a/i18n/src/commonMain/moko-resources/pt/strings.xml
+++ b/i18n/src/commonMain/moko-resources/pt/strings.xml
@@ -361,7 +361,7 @@
     <string name="check_for_updates">Verificar por atualizações</string>
     <string name="licenses">Licenças de código aberto</string>
     <string name="downloaded_only_summary">Filtra todos os itens nasua biblioteca</string>
-    <string name="restore_duration">%02d min, %02d seg</string>
+    <string name="restore_duration">%1$02d min, %2$02d seg</string>
     <string name="gray_background">Cinza</string>
     <string name="viewer">Modo de leitura</string>
     <string name="pref_category_for_this_series">Para esta série</string>

--- a/i18n/src/commonMain/moko-resources/ro/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ro/strings.xml
@@ -358,7 +358,7 @@
     <string name="local_source_help_guide">Ghid sursă locală</string>
     <string name="last_used_source">Data ultimei utilizări</string>
     <string name="check_for_updates">Verifică pentru actualizări</string>
-    <string name="restore_duration">%02d minute, %02d secunde</string>
+    <string name="restore_duration">%1$02d minute, %2$02d secunde</string>
     <string name="downloaded_only_summary">Filtrează toate intrările din bibliotecă</string>
     <string name="viewer">Mod de citire</string>
     <string name="pref_category_for_this_series">Pentru această serie</string>

--- a/i18n/src/commonMain/moko-resources/sa/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sa/strings.xml
@@ -319,7 +319,7 @@
     <string name="pref_restore_backup">प्रतिलेखनं समाददातु</string>
     <string name="pref_backup_interval">प्रतिलेखनस्य आवर्तनता</string>
     <string name="backup_in_progress">प्रतिलेखनं पूर्वमेव प्रगतौ अस्ति</string>
-    <string name="restore_duration">%02d निमेषाः %02d क्षणाः च</string>
+    <string name="restore_duration">%1$02d निमेषाः %2$02d क्षणाः च</string>
     <string name="restoring_backup_error">प्रतिलेखनस्य समादानम् अनुत्तीर्णम्</string>
     <string name="creating_backup_error">प्रतिलेखनम् अनुत्तीर्णम्</string>
     <string name="restore_in_progress">प्रतिसंस्कारः पूर्वमेव प्रगत्याम् अस्ति</string>

--- a/i18n/src/commonMain/moko-resources/sah/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sah/strings.xml
@@ -225,7 +225,7 @@
     <string name="creating_backup">Хаппаас куопуйа оҥоһуута</string>
     <string name="backup_choice">Тугу куопуйалаары гынннын?</string>
     <string name="backup_in_progress">Хаппаас куопуйа оҥоруута туола турар</string>
-    <string name="restore_duration">%02d мүнүүтэ %02d сөкүүндэ</string>
+    <string name="restore_duration">%1$02d мүнүүтэ %2$02d сөкүүндэ</string>
     <string name="restore_completed">Төнүҥнэри бүттэ</string>
     <string name="backup_restore_missing_trackers">Трэкэрдар киирбэтилэр:</string>
     <string name="backup_restore_missing_sources">Суох төрүттэр:</string>

--- a/i18n/src/commonMain/moko-resources/sk/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sk/strings.xml
@@ -527,7 +527,7 @@
     <string name="backup_restore_missing_trackers">Sledovače, do ktorých nie ste prihlásení:</string>
     <string name="pref_dns_over_https">DNS cez HTTPS (DoH)</string>
     <string name="invalid_backup_file">Neplatný záložný súbor</string>
-    <string name="restore_duration">%02d min., %02d s</string>
+    <string name="restore_duration">%1$02d min., %2$02d s</string>
     <string name="multi_lang">Viacjazyčné</string>
     <string name="no_chapters_error">Nenašli sa žiadne kapitoly</string>
     <string name="ext_app_info">Informácie o aplikácii</string>

--- a/i18n/src/commonMain/moko-resources/sq/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sq/strings.xml
@@ -392,7 +392,7 @@
     <string name="action_track">Pista</string>
     <string name="pref_backup_interval">Frekuenca rezervë</string>
     <string name="backup_restore_missing_trackers">I pa identifikuar ne gjurmuesit:</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="restore_miui_warning">Rezervimi/rivendosja mund të mos funksionojë siç duhet nëse Optimizimi MIUI është i çaktivizuar.</string>
     <string name="pref_reset_user_agent_string">Rivendos vargun e parazgjedhur të agjentit të përdoruesit</string>
     <string name="cache_delete_error">Ndodhi një gabim gjatë pastrimit</string>

--- a/i18n/src/commonMain/moko-resources/sr/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sr/strings.xml
@@ -326,7 +326,7 @@
     <string name="restore_in_progress">Враћање је већ у току</string>
     <string name="creating_backup_error">Прављење резервне копије није успело</string>
     <string name="backup_in_progress">Прављење резервне копије је већ у току</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_webtoon_side_padding">Растојање од ивице</string>
     <string name="pref_category_reading">Читање</string>
     <string name="pref_always_show_chapter_transition">Увек прикажи транзицију поглавља</string>

--- a/i18n/src/commonMain/moko-resources/sv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sv/strings.xml
@@ -357,7 +357,7 @@
     <string name="restore_in_progress">Återställningen pågår redan</string>
     <string name="creating_backup_error">Säkerhetskopiering misslyckades</string>
     <string name="backup_in_progress">Säkerhetskopiering pågår redan</string>
-    <string name="restore_duration">%02d minuter, %02d sekunder</string>
+    <string name="restore_duration">%1$02d minuter, %2$02d sekunder</string>
     <string name="label_downloaded_only">Endast nedladdat</string>
     <string name="downloaded_only_summary">Filtrerar alla poster i ditt bibliotek</string>
     <string name="viewer">Läsläge</string>

--- a/i18n/src/commonMain/moko-resources/th/strings.xml
+++ b/i18n/src/commonMain/moko-resources/th/strings.xml
@@ -453,7 +453,7 @@
     <string name="restore_in_progress">การคืนค่ากําลังดําเนินการอยู่แล้ว</string>
     <string name="creating_backup_error">การสำรองข้อมูลล้มเหลว</string>
     <string name="backup_in_progress">การสำรองข้อมูลกําลังดําเนินการอยู่แล้ว</string>
-    <string name="restore_duration">%02d นาที %02d วินาที</string>
+    <string name="restore_duration">%1$02d นาที %2$02d วินาที</string>
     <string name="backup_restore_content_full">คุณจะต้องติดตั้งส่วนขยายที่ขาดหายไปและลงชื่อเข้าใช้บริการติดตามจึงจะสามารถใช้งานได้</string>
     <string name="backup_restore_missing_trackers">ตัวติดตามไม่ได้เข้าสู่ระบบ:</string>
     <string name="backup_restore_missing_sources">แหล่งที่มาที่หายไป:</string>


### PR DESCRIPTION
string replaced by using following command
```bash
sed -i "s/%02d/%1\$02d/" i18n/src/commonMain/moko-resources/*/strings.xml
sed -i "s/%02d/%2\$02d/" i18n/src/commonMain/moko-resources/*/strings.xml
```

but im not sure is that the same order in every language