### PR TITLE
fix "AAPT: error: attribute 'package' in <manifest> tag is not a valid Android package name: 'app.mihon.t-foss'"

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,7 @@ android {
         create("foss") {
             initWith(release)
 
-            applicationIdSuffix = ".t-foss"
+            applicationIdSuffix = ".foss"
 
             matchingFallbacks.add(release.name)
         }


### PR DESCRIPTION
is there any reason to add a "t-" prefix to suffix?

before merging this. i think i need some discussion with @linsui .

should we use a separate package name for foss flavor? if we use same package name as github build. with reproducible build. user can override current installed github flavor with foss flavor (vice verse), without need to reinstall (and restore backup).

it is also fine to keep a suffix for foss build. as it perverted accidentally overridden foss flavor with github flavor. which sometimes happens on izzy droid / obtainium / upgradeall user. this is also my preferred method