### PR TITLE
Allow extensions to load native libraries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -272,7 +272,7 @@ internal object ExtensionLoader {
         }
 
         val classLoader = try {
-            ChildFirstPathClassLoader(appInfo.sourceDir, null, context.classLoader)
+            ChildFirstPathClassLoader(appInfo.sourceDir, appInfo.nativeLibraryDir, context.classLoader)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($pkgName)" }
             return LoadResult.Error


### PR DESCRIPTION
Currently the classloader that gets created when an extension is loaded doesn't pass a path for the extension's native libraries, which means `System.loadLibrary` will only be able to search for libraries in system directories and not for libraries packaged in the extension. This change would pass through the extension APK's native libraries directory, allowing extensions that include native libraries to load those native libraries.