### PR TITLE
Artist and author in track search info for anilist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add option to export minimal library information to a CSV file ([@Animeboynz](https://github.com/Animeboynz), [@AntsyLich](https://github.com/AntsyLich)) ([#1161](https://github.com/mihonapp/mihon/pull/1161))
 - Add back support for drag-and-drop category reordering ([@cuong-tran](https://github.com/cuong-tran)) ([#1427](https://github.com/mihonapp/mihon/pull/1427))
 - Add option to mark new duplicate read chapters as read
-- Display creator information for Anilist tracking search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
+- Display staff information on Anilist tracker search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
 
 ### Changed
 - Apply "Downloaded only" filter to all entries regardless of favourite status ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#1603](https://github.com/mihonapp/mihon/pull/1603))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Migrate to newer Bangumi API ([@MajorTanya](https://github.com/MajorTanya)) ([#1748](https://github.com/mihonapp/mihon/pull/1748))
   - Now showing manga starting dates in search
   - Reduced request load by 2-4x in certain situations
+- Display creator information for Anilist tracking search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
 
 ### Fixed
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add option to export minimal library information to a CSV file ([@Animeboynz](https://github.com/Animeboynz), [@AntsyLich](https://github.com/AntsyLich)) ([#1161](https://github.com/mihonapp/mihon/pull/1161))
 - Add back support for drag-and-drop category reordering ([@cuong-tran](https://github.com/cuong-tran)) ([#1427](https://github.com/mihonapp/mihon/pull/1427))
 - Add option to mark new duplicate read chapters as read
+- Display creator information for Anilist tracking search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
 
 ### Changed
 - Apply "Downloaded only" filter to all entries regardless of favourite status ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#1603](https://github.com/mihonapp/mihon/pull/1603))
@@ -28,7 +29,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Migrate to newer Bangumi API ([@MajorTanya](https://github.com/MajorTanya)) ([#1748](https://github.com/mihonapp/mihon/pull/1748))
   - Now showing manga starting dates in search
   - Reduced request load by 2-4x in certain situations
-- Display creator information for Anilist tracking search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
 
 ### Fixed
 - Fix MAL `main_picture` nullability breaking search if a result doesn't have a cover set ([@MajorTanya](https://github.com/MajorTanya)) ([#1618](https://github.com/mihonapp/mihon/pull/1618))

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
@@ -307,8 +307,7 @@ private fun SearchResultItem(
                     if (trackSearch.authors.isNotEmpty() || trackSearch.artists.isNotEmpty()) {
                         Text(
                             text = (trackSearch.authors + trackSearch.artists).distinct().joinToString(),
-                            modifier = Modifier
-                                .secondaryItemAlpha(),
+                            modifier = Modifier.secondaryItemAlpha(),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
@@ -310,6 +310,18 @@ private fun SearchResultItem(
                             text = type,
                         )
                     }
+                    if (trackSearch.authors.isNotEmpty()) {
+                        SearchResultItemDetails(
+                            title = stringResource(MR.strings.author),
+                            text = trackSearch.authors.joinToString(),
+                        )
+                    }
+                    if (trackSearch.artists.isNotEmpty() && !trackSearch.artists.containsAll(trackSearch.authors)) {
+                        SearchResultItemDetails(
+                            title = stringResource(MR.strings.artist),
+                            text = trackSearch.artists.joinToString(),
+                        )
+                    }
                     if (trackSearch.start_date.isNotBlank()) {
                         SearchResultItemDetails(
                             title = stringResource(MR.strings.label_started),

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearch.kt
@@ -304,22 +304,20 @@ private fun SearchResultItem(
                             }
                         },
                     )
+                    if (trackSearch.authors.isNotEmpty() || trackSearch.artists.isNotEmpty()) {
+                        Text(
+                            text = (trackSearch.authors + trackSearch.artists).distinct().joinToString(),
+                            modifier = Modifier
+                                .secondaryItemAlpha(),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
                     if (type.isNotBlank()) {
                         SearchResultItemDetails(
                             title = stringResource(MR.strings.track_type),
                             text = type,
-                        )
-                    }
-                    if (trackSearch.authors.isNotEmpty()) {
-                        SearchResultItemDetails(
-                            title = stringResource(MR.strings.author),
-                            text = trackSearch.authors.joinToString(),
-                        )
-                    }
-                    if (trackSearch.artists.isNotEmpty() && !trackSearch.artists.containsAll(trackSearch.authors)) {
-                        SearchResultItemDetails(
-                            title = stringResource(MR.strings.artist),
-                            text = trackSearch.artists.joinToString(),
                         )
                     }
                     if (trackSearch.start_date.isNotBlank()) {

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
@@ -97,8 +97,13 @@ internal class TrackerSearchPreviewProvider : PreviewParameterProvider<@Composab
         it.summary = lorem((0..40).random()).joinToString()
         it.publishing_status = if (Random.nextBoolean()) "Finished" else ""
         it.publishing_type = if (Random.nextBoolean()) "Oneshot" else ""
+        it.artists = randomNames()
+        it.authors = randomNames()
         it
     }
+
+    private fun randomNames(): List<String> =
+        (0..(0..3).random()).map { lorem((1..2).random()).joinToString() }
 
     private fun lorem(words: Int): Sequence<String> =
         LoremIpsum(words).values

--- a/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackerSearchPreviewProvider.kt
@@ -102,8 +102,7 @@ internal class TrackerSearchPreviewProvider : PreviewParameterProvider<@Composab
         it
     }
 
-    private fun randomNames(): List<String> =
-        (0..(0..3).random()).map { lorem((1..2).random()).joinToString() }
+    private fun randomNames(): List<String> = (0..(0..3).random()).map { lorem((3..5).random()).joinToString() }
 
     private fun lorem(words: Int): Sequence<String> =
         LoremIpsum(words).values

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -233,6 +233,19 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                                 |month
                                 |day
                             |}
+                            |staff {
+                                |edges {
+                                    |role
+                                    |id
+                                    |node {
+                                        |name {
+                                            |full
+                                            |userPreferred
+                                            |native
+                                        |}
+                                    |}
+                                |}
+                            |}
                         |}
                     |}
                 |}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -140,6 +140,19 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 |Page (perPage: 50) {
                     |media(search: ${'$'}query, type: MANGA, format_not_in: [NOVEL]) {
                         |id
+                        |staff {
+                            |edges {
+                                |role
+                                |id
+                                |node {
+                                    |name {
+                                        |full
+                                        |userPreferred
+                                        |native
+                                    |}
+                                |}
+                            |}
+                        |}
                         |title {
                             |userPreferred
                         |}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -39,16 +39,11 @@ data class ALManga(
                 ""
             }
         }
-        staff.edges.forEach(
-            action = {
-                if ("Story" in it.role) {
-                    if (it.node.name.getName() != null) this.authors += it.node.name.getName()!!
-                }
-                if ("Art" in it.role) {
-                    if (it.node.name.getName() != null) this.artists += it.node.name.getName()!!
-                }
-            },
-        )
+        staff.edges.forEach {
+            val name = it.node.name() ?: return@forEach
+            if ("Story" in it.role) authors += name
+            if ("Art" in it.role) artists += name
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -19,6 +19,7 @@ data class ALManga(
     val startDateFuzzy: Long,
     val totalChapters: Long,
     val averageScore: Int,
+    val staff: ALStaff,
 ) {
     fun toTrack() = TrackSearch.create(TrackerManager.ANILIST).apply {
         remote_id = remoteId
@@ -38,6 +39,16 @@ data class ALManga(
                 ""
             }
         }
+        staff.edges.forEach(
+            action = {
+                if ("Story" in it.role) {
+                    if (it.node.name.getName() != null) this.artists += it.node.name.getName()!!
+                }
+                if ("Art" in it.role) {
+                    if (it.node.name.getName() != null) this.authors += it.node.name.getName()!!
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -42,10 +42,10 @@ data class ALManga(
         staff.edges.forEach(
             action = {
                 if ("Story" in it.role) {
-                    if (it.node.name.getName() != null) this.artists += it.node.name.getName()!!
+                    if (it.node.name.getName() != null) this.authors += it.node.name.getName()!!
                 }
                 if ("Art" in it.role) {
-                    if (it.node.name.getName() != null) this.authors += it.node.name.getName()!!
+                    if (it.node.name.getName() != null) this.artists += it.node.name.getName()!!
                 }
             },
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -47,7 +47,7 @@ data class ALManga(
                 if ("Art" in it.role) {
                     if (it.node.name.getName() != null) this.authors += it.node.name.getName()!!
                 }
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
@@ -13,6 +13,7 @@ data class ALSearchItem(
     val startDate: ALFuzzyDate,
     val chapters: Long?,
     val averageScore: Int?,
+    val staff: ALStaff,
 ) {
     fun toALManga(): ALManga = ALManga(
         remoteId = id,
@@ -24,6 +25,7 @@ data class ALSearchItem(
         startDateFuzzy = startDate.toEpochMilli(),
         totalChapters = chapters ?: 0,
         averageScore = averageScore ?: -1,
+        staff = staff,
     )
 }
 
@@ -36,3 +38,31 @@ data class ALItemTitle(
 data class ItemCover(
     val large: String,
 )
+
+@Serializable
+data class ALStaff(
+    val edges: List<ALEdge>,
+)
+
+@Serializable
+data class ALEdge(
+    val role: String,
+    val id: Int,
+    val node: ALStaffNode,
+)
+
+@Serializable
+data class ALStaffNode(
+    val name: ALStaffName,
+)
+
+@Serializable
+data class ALStaffName(
+    val userPreferred: String?,
+    val native: String?,
+    val full: String?,
+) {
+    fun getName(): String? {
+        return userPreferred ?: full ?: native
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
@@ -62,7 +62,7 @@ data class ALStaffName(
     val native: String?,
     val full: String?,
 ) {
-    fun getName(): String? {
+    operator fun invoke(): String? {
         return userPreferred ?: full ?: native
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/model/TrackSearch.kt
@@ -34,6 +34,10 @@ class TrackSearch : Track {
 
     override lateinit var tracking_url: String
 
+    var authors: List<String> = emptyList()
+
+    var artists: List<String> = emptyList()
+
     var cover_url: String = ""
 
     var summary: String = ""


### PR DESCRIPTION
Include the artist and author information from anilist in the tracker search if available.

If all artists are the same as all authors it doesn't display artists.

Only thing i'm maybe concious of is that if ALL the info is there then it runs quite long and pushed the description quite low. Thought about putting the artist/authors on one row but don't think we have the space really.

But I think it's worth having this info on there.

I've put in a good amount of null protection cus I just don't know if those values are guaranteed from anilist query

![image](https://github.com/user-attachments/assets/04b39196-4c52-4e3c-9c3d-5fa590c495be)
