### PR TITLE
Spoof or remove `X-Requested-With` header from webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix certain Infinix, Xiaomi devices being unable to use any "Open link in browser" actions, including tracker setup ([@MajorTanya](https://github.com/MajorTanya)) ([#1684](https://github.com/mihonapp/mihon/pull/1684)) ([#1776](https://github.com/mihonapp/mihon/pull/1776))
 - Fix App's preferences referencing deleted categories ([@cuong-tran](https://github.com/cuong-tran)) ([#1734](https://github.com/mihonapp/mihon/pull/1734))
 - Fix backup/restore of category related preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1726](https://github.com/mihonapp/mihon/pull/1726))
+- Fix WebView sending app's package name in `X-Requested-With` header, which led to sources blocking access ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1812](https://github.com/mihonapp/mihon/pull/1812))
 
 ### Removed
 - Remove alphabetical category sort option

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -51,8 +51,6 @@ import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.net.HttpURLConnection
-import java.net.URL
 
 @Composable
 fun WebViewScreenContent(
@@ -71,6 +69,7 @@ fun WebViewScreenContent(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val network = Injekt.get<NetworkHelper>()
+    val spoofedPackageName = WebViewUtil.spoofedPackageName(context)
 
     var currentUrl by remember { mutableStateOf(url) }
     var showCloudflareHelp by remember { mutableStateOf(false) }
@@ -135,7 +134,7 @@ fun WebViewScreenContent(
                         Request.Builder().apply {
                             url(request!!.url.toString())
                             request.requestHeaders.forEach { (key, value) ->
-                                if (key == "X-Requested-With" && value in setOf(context.packageName, WebViewUtil.SPOOF_PACKAGE_NAME)) {
+                                if (key == "X-Requested-With" && value in setOf(context.packageName, spoofedPackageName)) {
                                     return@forEach
                                 }
                                 addHeader(key, value)

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -145,7 +145,6 @@ fun WebViewScreenContent(
                         }.build(),
                     ).execute()
 
-                    // Get content type and encoding
                     val contentType = response.body.contentType()?.let { "${it.type}/${it.subtype}" } ?: "text/html"
                     val contentEncoding = response.body.contentType()?.charset()?.name() ?: "utf-8"
 

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -127,20 +127,22 @@ fun WebViewScreenContent(
 
             override fun shouldInterceptRequest(
                 view: WebView?,
-                request: WebResourceRequest?
+                request: WebResourceRequest?,
             ): WebResourceResponse? {
                 return try {
                     val response = network.noCfClient.newCall(
                         Request.Builder().apply {
                             url(request!!.url.toString())
                             request.requestHeaders.forEach { (key, value) ->
-                                if (key == "X-Requested-With" && value in setOf(context.packageName, spoofedPackageName)) {
+                                if (key == "X-Requested-With" &&
+                                    value in setOf(context.packageName, spoofedPackageName)
+                                ) {
                                     return@forEach
                                 }
                                 addHeader(key, value)
                             }
                             method(request.method, null)
-                        }.build()
+                        }.build(),
                     ).execute()
 
                     // Get content type and encoding
@@ -153,13 +155,12 @@ fun WebViewScreenContent(
                         response.code,
                         response.message,
                         response.headers.associate { it.first to it.second },
-                        response.body.byteStream()
+                        response.body.byteStream(),
                     )
                 } catch (e: Throwable) {
                     super.shouldInterceptRequest(view, request)
                 }
             }
-
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -3,6 +3,7 @@ package eu.kanade.presentation.webview
 import android.content.pm.ApplicationInfo
 import android.graphics.Bitmap
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -26,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import com.kevinnzou.web.AccompanistWebViewClient
@@ -37,13 +39,20 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.WarningBanner
 import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.getHtml
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
+import okhttp3.Request
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.net.HttpURLConnection
+import java.net.URL
 
 @Composable
 fun WebViewScreenContent(
@@ -60,6 +69,8 @@ fun WebViewScreenContent(
     val navigator = rememberWebViewNavigator()
     val uriHandler = LocalUriHandler.current
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val network = Injekt.get<NetworkHelper>()
 
     var currentUrl by remember { mutableStateOf(url) }
     var showCloudflareHelp by remember { mutableStateOf(false) }
@@ -114,6 +125,42 @@ fun WebViewScreenContent(
                 }
                 return super.shouldOverrideUrlLoading(view, request)
             }
+
+            override fun shouldInterceptRequest(
+                view: WebView?,
+                request: WebResourceRequest?
+            ): WebResourceResponse? {
+                return try {
+                    val response = network.noCfClient.newCall(
+                        Request.Builder().apply {
+                            url(request!!.url.toString())
+                            request.requestHeaders.forEach { (key, value) ->
+                                if (key == "X-Requested-With" && value in setOf(context.packageName, WebViewUtil.SPOOF_PACKAGE_NAME)) {
+                                    return@forEach
+                                }
+                                addHeader(key, value)
+                            }
+                            method(request.method, null)
+                        }.build()
+                    ).execute()
+
+                    // Get content type and encoding
+                    val contentType = response.body.contentType()?.let { "${it.type}/${it.subtype}" } ?: "text/html"
+                    val contentEncoding = response.body.contentType()?.charset()?.name() ?: "utf-8"
+
+                    WebResourceResponse(
+                        contentType,
+                        contentEncoding,
+                        response.code,
+                        response.message,
+                        response.headers.associate { it.first to it.second },
+                        response.body.byteStream()
+                    )
+                } catch (e: Throwable) {
+                    super.shouldInterceptRequest(view, request)
+                }
+            }
+
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -10,7 +10,6 @@ import android.content.IntentFilter
 import android.os.Build
 import android.os.Looper
 import android.webkit.WebView
-import androidx.compose.ui.util.fastAny
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -225,7 +224,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
                     it.methodName in setOf("getAll", "getPackageName", "<init>")
             }
 
-            if (isChromiumCall) return WebViewUtil.SPOOF_PACKAGE_NAME
+            if (isChromiumCall) return WebViewUtil.spoofedPackageName(applicationContext)
         } catch (_: Exception) {
         }
 

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -19,7 +19,8 @@ class NetworkHelper(
 
     val cookieJar = AndroidCookieJar()
 
-    val client: OkHttpClient = run {
+
+    private val clientBuilder: OkHttpClient.Builder = run {
         val builder = OkHttpClient.Builder()
             .cookieJar(cookieJar)
             .connectTimeout(30, TimeUnit.SECONDS)
@@ -43,10 +44,6 @@ class NetworkHelper(
             builder.addNetworkInterceptor(httpLoggingInterceptor)
         }
 
-        builder.addInterceptor(
-            CloudflareInterceptor(context, cookieJar, ::defaultUserAgentProvider),
-        )
-
         when (preferences.dohProvider().get()) {
             PREF_DOH_CLOUDFLARE -> builder.dohCloudflare()
             PREF_DOH_GOOGLE -> builder.dohGoogle()
@@ -60,10 +57,17 @@ class NetworkHelper(
             PREF_DOH_CONTROLD -> builder.dohControlD()
             PREF_DOH_NJALLA -> builder.dohNajalla()
             PREF_DOH_SHECAN -> builder.dohShecan()
+            else -> builder
         }
-
-        builder.build()
     }
+
+    val noCfClient = clientBuilder.build()
+
+    val client = clientBuilder
+        .addInterceptor(
+            CloudflareInterceptor(context, cookieJar, ::defaultUserAgentProvider),
+        )
+        .build()
 
     /**
      * @deprecated Since extension-lib 1.5

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -60,7 +60,7 @@ class NetworkHelper(
         }
     }
 
-    val noCfClient = clientBuilder.build()
+    val nonCloudflareClient = clientBuilder.build()
 
     val client = clientBuilder
         .addInterceptor(

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -19,7 +19,6 @@ class NetworkHelper(
 
     val cookieJar = AndroidCookieJar()
 
-
     private val clientBuilder: OkHttpClient.Builder = run {
         val builder = OkHttpClient.Builder()
             .cookieJar(cookieJar)

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
@@ -12,7 +12,7 @@ import tachiyomi.core.common.util.system.logcat
 import kotlin.coroutines.resume
 
 object WebViewUtil {
-    const val SPOOF_PACKAGE_NAME = "org.chromium.chrome"
+    const val SPOOF_PACKAGE_NAME = "com.android.chrome"
 
     const val MINIMUM_WEBVIEW_VERSION = 118
 

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
@@ -12,6 +12,9 @@ import tachiyomi.core.common.util.system.logcat
 import kotlin.coroutines.resume
 
 object WebViewUtil {
+    private const val CHROME_PACKAGE = "com.android.chrome"
+    private const val SYSTEM_SETTINGS_PACKAGE = "com.android.settings"
+
     const val MINIMUM_WEBVIEW_VERSION = 118
 
     /**
@@ -53,14 +56,12 @@ object WebViewUtil {
     }
 
     fun spoofedPackageName(context: Context): String {
-        val chromePkg = "com.android.chrome"
-
         return try {
-            context.packageManager.getPackageInfo(chromePkg, PackageManager.GET_META_DATA)
+            context.packageManager.getPackageInfo(CHROME_PACKAGE, PackageManager.GET_META_DATA)
 
-            chromePkg
+            CHROME_PACKAGE
         } catch (_: PackageManager.NameNotFoundException) {
-            "com.android.settings"
+            SYSTEM_SETTINGS_PACKAGE
         }
     }
 }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/util/system/WebViewUtil.kt
@@ -12,8 +12,6 @@ import tachiyomi.core.common.util.system.logcat
 import kotlin.coroutines.resume
 
 object WebViewUtil {
-    const val SPOOF_PACKAGE_NAME = "com.android.chrome"
-
     const val MINIMUM_WEBVIEW_VERSION = 118
 
     /**
@@ -52,6 +50,18 @@ object WebViewUtil {
         }
 
         return context.packageManager.hasSystemFeature(PackageManager.FEATURE_WEBVIEW)
+    }
+
+    fun spoofedPackageName(context: Context): String {
+        val chromePkg = "com.android.chrome"
+
+        return try {
+            context.packageManager.getPackageInfo(chromePkg, PackageManager.GET_META_DATA)
+
+            chromePkg
+        } catch (_: PackageManager.NameNotFoundException) {
+            "com.android.settings"
+        }
     }
 }
 


### PR DESCRIPTION
- fix the webview detection in `getPackageName` to correctly detect it and return a spoofed package (thanks to @vetleledaal)
- spoofed package will be `com.android.chrome` (google chrome) or in some cases when it isn't installed, `com.android.settings`
  - this needs to be a valid installed package, otherwise the app crashes 
- override `shouldInterceptRequest` of the webview to use okhttp for making the calls and being able to remove the header completely
  - this isn't called for post or xhr/fetch calls in js so spoofed package name is needed 

closes #1659