### PR TITLE
Update website when a new version is released

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -122,3 +122,13 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update website
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/mihon/website/dispatches \
+          -d '{"event_type":"app_release"}'


### PR DESCRIPTION
This will send a "app_release" event to the website repo to update it with the freshly published app version.

See also: https://github.com/mihonapp/mihon-preview/pull/34, https://github.com/mihonapp/website/pull/141