### PR TITLE
Mitigate the libraryView NPE crash that occurs for large libraries when removing entries shortly after any other DB write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix backup/restore of category related preferences ([@cuong-tran](https://github.com/cuong-tran)) ([#1726](https://github.com/mihonapp/mihon/pull/1726))
 - Fix WebView sending app's package name in `X-Requested-With` header, which led to sources blocking access ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1812](https://github.com/mihonapp/mihon/pull/1812))
 - Fix an issue where tracker reading progress is changed to a lower value ([@Animeboynz](https://github.com/Animeboynz)) ([#1795](https://github.com/mihonapp/mihon/pull/1795))
+- Attempt to fix crash when migrating or removing entries from library ([@FlaminSarge](https://github.com/FlaminSarge)) ([#1828](https://github.com/mihonapp/mihon/pull/1828))
 
 ### Removed
 - Remove alphabetical category sort option

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -284,7 +284,7 @@ internal class MigrateDialogScreenModel(
         }
 
         if (replace) {
-            updateManga.await(MangaUpdate(oldManga.id, favorite = false, dateAdded = 0))
+            updateManga.awaitUpdateFavorite(oldManga.id, favorite = false)
         }
 
         // Update custom cover (recheck if custom cover exists)

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -1,6 +1,11 @@
 package tachiyomi.domain.manga.interactor
 
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.retry
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.repository.MangaRepository
 
@@ -12,7 +17,20 @@ class GetLibraryManga(
         return mangaRepository.getLibraryManga()
     }
 
+    @OptIn(FlowPreview::class)
     fun subscribe(): Flow<List<LibraryManga>> {
         return mangaRepository.getLibraryMangaAsFlow()
+            .retry(3) { cause ->
+                // if we hit the NPE due to library being updated during write
+                // retry up to 3x, waiting 500ms between retries
+                (cause is NullPointerException).also {
+                    if (it) delay(500)
+                }
+            }
+            .debounce(1500) // if another update comes in during retries, ditch the retries
+            .catch {
+                // emit nothing during failure
+                // retries didn't work and we don't want to crash
+            }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -20,17 +20,13 @@ class GetLibraryManga(
     @OptIn(FlowPreview::class)
     fun subscribe(): Flow<List<LibraryManga>> {
         return mangaRepository.getLibraryMangaAsFlow()
-            .retry(3) { cause ->
-                // if we hit the NPE due to library being updated during write
-                // retry up to 3x, waiting 500ms between retries
-                (cause is NullPointerException).also {
-                    if (it) delay(500)
+            .retry {
+                if (it is NullPointerException) {
+                    delay(0.5.seconds)
+                    true
+                } else {
+                    false
                 }
-            }
-            .debounce(1500) // if another update comes in during retries, ditch the retries
-            .catch {
-                // emit nothing during failure
-                // retries didn't work and we don't want to crash
             }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -1,13 +1,14 @@
 package tachiyomi.domain.manga.interactor
 
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.retry
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.repository.MangaRepository
+import kotlin.time.Duration.Companion.seconds
 
 class GetLibraryManga(
     private val mangaRepository: MangaRepository,
@@ -17,7 +18,6 @@ class GetLibraryManga(
         return mangaRepository.getLibraryManga()
     }
 
-    @OptIn(FlowPreview::class)
     fun subscribe(): Flow<List<LibraryManga>> {
         return mangaRepository.getLibraryMangaAsFlow()
             .retry {
@@ -27,6 +27,8 @@ class GetLibraryManga(
                 } else {
                     false
                 }
+            }.catch {
+                logcat(LogPriority.ERROR, it)
             }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetLibraryManga.kt
@@ -28,7 +28,7 @@ class GetLibraryManga(
                     false
                 }
             }.catch {
-                logcat(LogPriority.ERROR, it)
+                this@GetLibraryManga.logcat(LogPriority.ERROR, it)
             }
     }
 }


### PR DESCRIPTION
Reopening #1794 due to #1799 having the possibility of OOM if the user's DB is astronomically large.
Fixes #93 
Cause is https://github.com/sqldelight/sqldelight/issues/1584 (and https://github.com/sqldelight/sqldelight/issues/4194 )

Similar to the implementation at https://github.com/jobobby04/TachiyomiSY/commit/3a5e23550ff0a1f5be7e03138f63ab4960716f82 and https://github.com/null2264/yokai/commit/50fecd5350c9e4aec04ff76c6849c331ca0d29ed but using 3x retries at 500ms each, 1500ms debounce, and a catch at the end as a "nothing worked but we don't want to crash" state.

Delay values/etc can be tweaked if needed.