### PR TITLE
Add back build tools for sign-android-release to be able to work

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -66,6 +66,8 @@ jobs:
           alias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: '35.0.1'
 
       - name: Clean up build artifacts
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'mihonapp/mihon'


### PR DESCRIPTION
Other wise, workflow would fail with this error:
```
Error: Couldnt find the Android build tools @ /usr/local/lib/android/sdk/build-tools/33.0.0
Error: Unable to locate executable file: /usr/local/lib/android/sdk/build-tools/33.0.0/zipalign. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```