### PR TITLE
Add app ID to debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Add zoned "Current time" to debug info and include year & timezone in logcat output ([@MajorTanya](https://github.com/MajorTanya)) ([#1672](https://github.com/mihonapp/mihon/pull/1672))
+- Add application package ID to debug info ([@MajorTanya](https://github.com/MajorTanya)) ([#1847](https://github.com/mihonapp/mihon/pull/1847))
 
 ## [v0.17.1] - 2024-12-06
 ### Changed

--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -40,6 +40,7 @@ class CrashLogUtil(
 
     fun getDebugInfo(): String {
         return """
+            App ID: ${BuildConfig.APPLICATION_ID}
             App version: ${BuildConfig.VERSION_NAME} (${BuildConfig.COMMIT_SHA}, ${BuildConfig.VERSION_CODE}, ${BuildConfig.BUILD_TIME})
             Android version: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT}; build ${Build.DISPLAY})
             Device brand: ${Build.BRAND}


### PR DESCRIPTION
This will avoid the need to know which forks has which version numbers and avoid confusion in support.

Example output from the emulator:
```txt
App ID: app.mihon.dev
App version: 0.17.1-7136 (2ba2d86bf, 10, 2025-03-10T02:33:35Z)
Android version: 15 (SDK 35; build BP22.250124.008)
Device brand: google
Device manufacturer: Google
Device name: emu64xa (sdk_gphone64_x86_64)
Device model: sdk_gphone64_x86_64
WebView: Android System WebView 133.0.6943.138
Current time: 2025-03-10T02:34:20.257250Z
```