### PR TITLE
Rework website update workflow

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -122,14 +122,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update website
-        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'mihonapp/mihon'
-        run: |
-          curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/mihonapp/website/dispatches \
-          -d '{"event_type":"app_release"}'

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -120,5 +120,4 @@ jobs:
             mihon-x86_64-${{ env.VERSION_TAG }}.apk
           draft: true
           prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MIHON_BOT_TOKEN }}

--- a/.github/workflows/update_website.yml
+++ b/.github/workflows/update_website.yml
@@ -1,0 +1,23 @@
+name: Update website
+
+on:
+  release:
+    types: 
+      - published
+      - deleted
+      - edited
+
+jobs:
+  update_website:
+    runs-on: 'ubuntu-24.04'
+
+    steps:
+      - name: Update website
+        run: |
+          curl --fail-with-body -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.MIHON_BOT_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/mihonapp/website/dispatches \
+          -d '{"event_type":"app_release"}'


### PR DESCRIPTION
Follow up for #1818
See also: https://github.com/mihonapp/mihon-preview/pull/35

Why: the previous implementation didn't work properly because the build CI does only a draft release. This PR separates the website update into a separate workflow that is triggered whenever an actual release is published, deleted, or edited.

Also added --fail-with-body to curl so that the action fails when the event couldn't be sent successfully.