### PR TITLE
Add prefix search to search by internal DB ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add back support for drag-and-drop category reordering ([@cuong-tran](https://github.com/cuong-tran)) ([#1427](https://github.com/mihonapp/mihon/pull/1427))
 - Add option to mark duplicate read chapters as read
 - Display staff information on Anilist tracker search results ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#1810](https://github.com/mihonapp/mihon/pull/1810))
+- Add `id:` prefix search to library to search by internal DB ID ([@MajorTanya](https://github.com/MajorTanya)) ([#1856](https://github.com/mihonapp/mihon/pull/1856))
 
 ### Changed
 - Sliders UI

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -22,6 +22,10 @@ data class LibraryItem(
      */
     fun matches(constraint: String): Boolean {
         val sourceName by lazy { sourceManager.getOrStub(libraryManga.manga.source).getNameForMangaInfo() }
+        if (constraint.startsWith("id:", true)) {
+            val id = constraint.substringAfter("id:").toLongOrNull()
+            return libraryManga.id == id
+        }
         return libraryManga.manga.title.contains(constraint, true) ||
             (libraryManga.manga.author?.contains(constraint, true) ?: false) ||
             (libraryManga.manga.artist?.contains(constraint, true) ?: false) ||


### PR DESCRIPTION
This prefix searches entries in the library based on the ID in the database. It is a niche feature but could be very helpful in certain situations, such as a corrupted cover causing a crash in Coil that just shows `🚨 Failed - MangaCover(mangaId=2245, sourceId=1, isMangaFavorite=true, url=, lastModified=0)`. With this prefix search it is possible to find the entry in question without much hassle.

Notably, the database includes literally anything Mihon has ever seen from extension and such, even if they weren't added to the collection. This means that IDs actually present in the collection are not expected to be purely sequential.
For example, in my emulator, I had two entries in the collection but the assigned IDs were 5 and 56.