### PR TITLE
Fix Bangumi search including novels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Fixes
+- Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))
 
 ## [v0.18.0] - 2025-03-20
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -104,6 +104,7 @@ class BangumiApi(
                     .awaitSuccess()
                     .parseAs<BGMSearchResult>()
                     .data
+                    .filter { it.platform == null || it.platform == "漫画" }
                     .map { it.toTrackSearch(trackId) }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSearch.kt
@@ -25,6 +25,7 @@ data class BGMSubject(
     val volumes: Long = 0,
     val eps: Long = 0,
     val rating: BGMSubjectRating?,
+    val platform: String?,
 ) {
     fun toTrackSearch(trackId: Long): TrackSearch = TrackSearch.create(trackId).apply {
         remote_id = this@BGMSubject.id


### PR DESCRIPTION
Missed including this in the v0 rewrite.

Fixes #1880. The other part of the issue is a community translation issue or would require introducing a new string entirely.