### PR TITLE
Added edge-to-edge in reader activity (#1614)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -9,8 +9,12 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
@@ -72,7 +76,7 @@ fun ReaderAppBars(
         .copy(alpha = if (isSystemInDarkTheme()) 0.9f else 0.95f)
 
     val modifierWithInsetsPadding = if (fullscreen) {
-        Modifier.systemBarsPadding()
+        Modifier.imePadding()
     } else {
         Modifier
     }
@@ -94,7 +98,8 @@ fun ReaderAppBars(
         ) {
             AppBar(
                 modifier = modifierWithInsetsPadding
-                    .clickable(onClick = onClickTopAppBar),
+                    .clickable(onClick = onClickTopAppBar)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
                 backgroundColor = backgroundColor,
                 title = mangaTitle,
                 subtitle = chapterTitle,
@@ -165,7 +170,8 @@ fun ReaderAppBars(
             ),
         ) {
             Column(
-                modifier = modifierWithInsetsPadding,
+                modifier = modifierWithInsetsPadding
+                    .windowInsetsPadding(WindowInsets.statusBars),
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
             ) {
                 ChapterNavigator(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -19,6 +19,7 @@ import android.view.MotionEvent
 import android.view.View.LAYER_TYPE_HARDWARE
 import android.view.WindowManager
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -31,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
-import androidx.core.graphics.ColorUtils
 import androidx.core.net.toUri
 import androidx.core.transition.doOnEnd
 import androidx.core.view.WindowCompat
@@ -39,7 +39,6 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.lifecycleScope
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
-import com.google.android.material.elevation.SurfaceColors
 import com.google.android.material.transition.platform.MaterialContainerTransform
 import com.hippo.unifile.UniFile
 import dev.chrisbanes.insetter.applyInsetter
@@ -154,6 +153,10 @@ class ReaderActivity : BaseActivity() {
             @Suppress("DEPRECATION")
             overridePendingTransition(R.anim.shared_axis_x_push_enter, R.anim.shared_axis_x_push_exit)
         }
+        enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
 
         super.onCreate(savedInstanceState)
 
@@ -215,21 +218,27 @@ class ReaderActivity : BaseActivity() {
                     ReaderViewModel.Event.ReloadViewerChapters -> {
                         viewModel.state.value.viewerChapters?.let(::setChapters)
                     }
+
                     ReaderViewModel.Event.PageChanged -> {
                         displayRefreshHost.flash()
                     }
+
                     is ReaderViewModel.Event.SetOrientation -> {
                         setOrientation(event.orientation)
                     }
+
                     is ReaderViewModel.Event.SavedImage -> {
                         onSaveImageResult(event.result)
                     }
+
                     is ReaderViewModel.Event.ShareImage -> {
                         onShareImageResult(event.uri, event.page)
                     }
+
                     is ReaderViewModel.Event.CopyImage -> {
                         onCopyImageResult(event.uri)
                     }
+
                     is ReaderViewModel.Event.SetCoverResult -> {
                         onSetAsCoverResult(event.result)
                     }
@@ -446,6 +455,7 @@ class ReaderActivity : BaseActivity() {
                         },
                     )
                 }
+
                 is ReaderViewModel.Dialog.Settings -> {
                     ReaderSettingsDialog(
                         onDismissRequest = onDismissRequest,
@@ -454,6 +464,7 @@ class ReaderActivity : BaseActivity() {
                         screenModel = settingsScreenModel,
                     )
                 }
+
                 is ReaderViewModel.Dialog.ReadingModeSelect -> {
                     ReadingModeSelectDialog(
                         onDismissRequest = onDismissRequest,
@@ -466,6 +477,7 @@ class ReaderActivity : BaseActivity() {
                         },
                     )
                 }
+
                 is ReaderViewModel.Dialog.OrientationModeSelect -> {
                     OrientationSelectDialog(
                         onDismissRequest = onDismissRequest,
@@ -476,6 +488,7 @@ class ReaderActivity : BaseActivity() {
                         },
                     )
                 }
+
                 is ReaderViewModel.Dialog.PageActions -> {
                     ReaderPageActionsDialog(
                         onDismissRequest = onDismissRequest,
@@ -484,19 +497,9 @@ class ReaderActivity : BaseActivity() {
                         onSave = viewModel::saveImage,
                     )
                 }
+
                 null -> {}
             }
-        }
-
-        val toolbarColor = ColorUtils.setAlphaComponent(
-            SurfaceColors.SURFACE_2.getColor(this),
-            if (isNightMode()) 230 else 242, // 90% dark 95% light
-        )
-        @Suppress("DEPRECATION")
-        window.statusBarColor = toolbarColor
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-            @Suppress("DEPRECATION")
-            window.navigationBarColor = toolbarColor
         }
 
         // Set initial visibility
@@ -752,6 +755,7 @@ class ReaderActivity : BaseActivity() {
             is ReaderViewModel.SaveImageResult.Success -> {
                 toast(MR.strings.picture_saved)
             }
+
             is ReaderViewModel.SaveImageResult.Error -> {
                 logcat(LogPriority.ERROR, result.error)
             }
@@ -950,15 +954,18 @@ class ReaderActivity : BaseActivity() {
                 value > 0 -> {
                     value / 100f
                 }
+
                 value < 0 -> {
                     0.01f
                 }
+
                 else -> WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
             }
             window.attributes = window.attributes.apply { screenBrightness = readerBrightness }
 
             viewModel.setBrightnessOverlayValue(value)
         }
+
         private fun setLayerPaint(grayscale: Boolean, invertedColors: Boolean) {
             val paint = if (grayscale || invertedColors) getCombinedPaint(grayscale, invertedColors) else null
             binding.viewerContainer.setLayerType(LAYER_TYPE_HARDWARE, paint)


### PR DESCRIPTION
Fixes #1614

Adds the [edge-to-edge feature](https://developer.android.com/develop/ui/views/layout/edge-to-edge) in the reader activity. 
This fixes the problem of the status and navigation bars not being the same color as the appbar (#1614 ).

### Images
| _Strawberry Daiquiri_ light theme before | _Strawberry Daiquiri_ light theme after|
| ------- | ------- |
| ![sdl_before](https://github.com/user-attachments/assets/f511200c-2c56-4e71-9ebd-e1831a282648)| ![sdl_after](https://github.com/user-attachments/assets/93b4fb4d-54bf-45eb-b661-554e30687517) |


