### PR TITLE
fix backup share not working from background notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixes
 - Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))
 - Fix next chapter button occasionally jumping to the last page of the current chapter ([@perokhe](https://github.com/perokhe)) ([#1920](https://github.com/mihonapp/mihon/pull/1920))
-- Fix backup share in notification not working when app is in background ([@JaymanR](https://github.com/JaymanR))([#1929](https://github.com/mihonapp/mihon/pull/1929))
+- Fix backup sharing from notifications not working when app is in background ([@JaymanR](https://github.com/JaymanR))([#1929](https://github.com/mihonapp/mihon/pull/1929))
 
 ## [v0.18.0] - 2025-03-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixes
 - Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))
 - Fix next chapter button occasionally jumping to the last page of the current chapter ([@perokhe](https://github.com/perokhe)) ([#1920](https://github.com/mihonapp/mihon/pull/1920))
+- Fix backup share in notification not working when app is in background ([@JaymanR](https://github.com/JaymanR))([#1929](https://github.com/mihonapp/mihon/pull/1929))
 
 ## [v0.18.0] - 2025-03-20
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -80,7 +80,7 @@ class BackupNotifier(private val context: Context) {
             addAction(
                 R.drawable.ic_share_24dp,
                 context.stringResource(MR.strings.action_share),
-                NotificationReceiver.shareBackupPendingBroadcast(context, file.uri),
+                NotificationReceiver.shareBackupPendingActivity(context, file.uri),
             )
 
             show(Notifications.ID_BACKUP_COMPLETE)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -583,18 +583,17 @@ class NotificationReceiver : BroadcastReceiver() {
         }
 
         /**
-         * Returns [PendingIntent] that starts a share activity for a backup file.
+         * Returns [PendingIntent] that directly launches a share activity for a backup file.
          *
          * @param context context of application
          * @param uri uri of backup file
          * @return [PendingIntent]
          */
-        internal fun shareBackupPendingBroadcast(context: Context, uri: Uri): PendingIntent {
-            val intent = Intent(context, NotificationReceiver::class.java).apply {
-                action = ACTION_SHARE_BACKUP
-                putExtra(EXTRA_URI, uri)
+        internal fun shareBackupPendingActivity(context: Context, uri: Uri): PendingIntent {
+            val intent = uri.toShareIntent(context, "application/x-protobuf+gzip").apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
-            return PendingIntent.getBroadcast(
+            return PendingIntent.getActivity(
                 context,
                 0,
                 intent,


### PR DESCRIPTION
## Summary
Closes https://github.com/mihonapp/mihon/issues/1923

This pull request fixes an issue where tapping the "share" button in the backup complete notification does nothing when the app is in background.

Replaces `PendingIntent.getBroadcast()` with `PendingIntent.getActivity()` for the backup share notification action.

The previous implementation triggered a `BroadcastReceiver`, which attempted to launch the share activity via `getBroadcast()`. This fails when the app is backgrounded due to Android's restrictions on launching activities from background components.

Reference: [Android 10 – Background activity start restrictions](https://developer.android.com/about/versions/10/privacy/changes#background-activity-starts)

The updated implementation uses `getActivity()` to directly launch the share activity, which is allowed as a user-initiated action from a notification.

Additional changes:
- Renamed method to `shareBackupPendingActivity`
