### PR TITLE
Fix: navigation issue after migrate a duplicated entry from History tab

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -104,7 +104,7 @@ data object HistoryTab : Tab {
                         screenModel.addFavorite(dialog.manga)
                     },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
-                    onMigrate = { screenModel.showMigrateDialog(dialog.manga, it) },
+                    onMigrate = { },
                 )
             }
             is HistoryScreenModel.Dialog.ChangeCategory -> {


### PR DESCRIPTION
after migrating a duplicate entry in History tab, the new Manga screen will replace the current App screen which prevent any going back.

Pushing to the new Manga screen here also doesn't seem reasonable since user might trying to favorite several entries in the list and doesn't expect to go to the Manga screen.