### PR TITLE
Fix ReaderViewModel::updateChapterProgress

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -537,7 +537,7 @@ class ReaderViewModel @JvmOverloads constructor(
         readerChapter.requestedPage = pageIndex
         chapterPageIndex = pageIndex
 
-        if (!incognitoMode && page.status is Page.State.Error) {
+        if (!incognitoMode && page.status !is Page.State.Error) {
             readerChapter.chapter.last_page_read = pageIndex
 
             if (readerChapter.pages?.lastIndex == pageIndex) {


### PR DESCRIPTION
The condition for updating progress is wrong (`!=` to `is` instead of `!is`) since fefa8f84982b537ca930438f7976087844d5bb9c

This prevented progress to be actually updated, even when finishing chapters