### PR TITLE
Empty browse source screen when hiding already added entried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix duplicate requests in WebView due to empty reasonPhrase ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2003](https://github.com/mihonapp/mihon/pull/2003))
 - Fix content under source browse screen top appbar is interactable ([@AntsyLich](https://github.com/AntsyLich)) ([#2026](https://github.com/mihonapp/mihon/pull/2026))
 - Fix crash when trying use source sort filter without a pre-selection ([@AntsyLich](https://github.com/AntsyLich)) ([#2036](https://github.com/mihonapp/mihon/pull/2036))
+- Fix browse source screen not showing empty screen when all results are hidden from being already in library ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2043](https://github.com/mihonapp/mihon/pull/2043))
 
 ### Removed
 - Remove Okhttp networking from WebView Screen ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2020](https://github.com/mihonapp/mihon/pull/2020))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix duplicate requests in WebView due to empty reasonPhrase ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2003](https://github.com/mihonapp/mihon/pull/2003))
 - Fix content under source browse screen top appbar is interactable ([@AntsyLich](https://github.com/AntsyLich)) ([#2026](https://github.com/mihonapp/mihon/pull/2026))
 - Fix crash when trying use source sort filter without a pre-selection ([@AntsyLich](https://github.com/AntsyLich)) ([#2036](https://github.com/mihonapp/mihon/pull/2036))
-- Fix browse source screen not showing empty screen when all results are hidden from being already in library ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2043](https://github.com/mihonapp/mihon/pull/2043))
+- Fix empty layout not appearing in browse source screen in some cases ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2043](https://github.com/mihonapp/mihon/pull/2043))
 
 ### Removed
 - Remove Okhttp networking from WebView Screen ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2020](https://github.com/mihonapp/mihon/pull/2020))

--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
@@ -73,10 +73,20 @@ fun BrowseSourceContent(
         }
     }
 
-    if (mangaList.itemCount <= 0 && errorState != null && errorState is LoadState.Error) {
+    if (mangaList.itemCount == 0 && mangaList.loadState.refresh is LoadState.Loading) {
+        LoadingScreen(
+            modifier = Modifier.padding(contentPadding),
+        )
+        return
+    }
+
+    if (mangaList.itemCount <= 0) {
         EmptyScreen(
             modifier = Modifier.padding(contentPadding),
-            message = getErrorMessage(errorState),
+            message = when (errorState) {
+                is LoadState.Error -> getErrorMessage(errorState)
+                else -> stringResource(MR.strings.no_results_found)
+            },
             actions = if (source is LocalSource) {
                 persistentListOf(
                     EmptyScreenAction(
@@ -106,13 +116,6 @@ fun BrowseSourceContent(
             },
         )
 
-        return
-    }
-
-    if (mangaList.itemCount == 0 && mangaList.loadState.refresh is LoadState.Loading) {
-        LoadingScreen(
-            modifier = Modifier.padding(contentPadding),
-        )
         return
     }
 

--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
@@ -74,13 +74,11 @@ fun BrowseSourceContent(
     }
 
     if (mangaList.itemCount == 0 && mangaList.loadState.refresh is LoadState.Loading) {
-        LoadingScreen(
-            modifier = Modifier.padding(contentPadding),
-        )
+        LoadingScreen(Modifier.padding(contentPadding))
         return
     }
 
-    if (mangaList.itemCount <= 0) {
+    if (mangaList.itemCount == 0) {
         EmptyScreen(
             modifier = Modifier.padding(contentPadding),
             message = when (errorState) {


### PR DESCRIPTION
currently if using the "hide entries already in library" setting, it does not show an empty screen message or anything as it relies on the paging state error being no results error which doesn't happen if we filter them out afterwards due to the setting.