### PR TITLE
Fix pressing `Enter` while searching also triggering navigation back on physical keyboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix empty layout not appearing in browse source screen in some cases ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2043](https://github.com/mihonapp/mihon/pull/2043))
 - Fix Pill not following the local text style ([@AntsyLich](https://github.com/AntsyLich)) ([`f8cb506`](https://github.com/mihonapp/mihon/commit/f8cb506))
 - Fix downloader stopping after failing to create download directory of a manga ([@AntsyLich](https://github.com/AntsyLich)) ([#2068](https://github.com/mihonapp/mihon/pull/2068))
+- Fix enter key exiting out of search on physical keyboards ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2077](https://github.com/mihonapp/mihon/pull/2077))
 
 ### Removed
 - Remove Okhttp networking from WebView Screen ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2020](https://github.com/mihonapp/mihon/pull/2020))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix empty layout not appearing in browse source screen in some cases ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2043](https://github.com/mihonapp/mihon/pull/2043))
 - Fix Pill not following the local text style ([@AntsyLich](https://github.com/AntsyLich)) ([`f8cb506`](https://github.com/mihonapp/mihon/commit/f8cb506))
 - Fix downloader stopping after failing to create download directory of a manga ([@AntsyLich](https://github.com/AntsyLich)) ([#2068](https://github.com/mihonapp/mihon/pull/2068))
-- Fix enter key exiting out of search on physical keyboards ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2077](https://github.com/mihonapp/mihon/pull/2077))
+- Fix pressing `Enter` while searching also triggering navigation back on physical keyboards ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2077](https://github.com/mihonapp/mihon/pull/2077))
 
 ### Removed
 - Remove Okhttp networking from WebView Screen ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2020](https://github.com/mihonapp/mihon/pull/2020))

--- a/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -291,6 +292,7 @@ fun SearchToolbar(
                 onSearch(searchQuery)
                 focusManager.clearFocus()
                 keyboardController?.hide()
+                focusManager.moveFocus(FocusDirection.Next)
             }
 
             BasicTextField(

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/util/Modifier.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/util/Modifier.kt
@@ -19,8 +19,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import tachiyomi.presentation.core.components.material.SECONDARY_ALPHA
 
@@ -53,8 +55,17 @@ fun Modifier.clickableNoIndication(
 fun Modifier.runOnEnterKeyPressed(action: () -> Unit): Modifier = this.onPreviewKeyEvent {
     when (it.key) {
         Key.Enter, Key.NumPadEnter -> {
-            action()
-            true
+            // Physical keyboards generate two event types:
+            // - KeyDown when the key is pressed
+            // - KeyUp when the key is released
+            // To match the behavior of software keyboards (IME),
+            // trigger [action] only on the KeyUp event.
+            if (it.type == KeyEventType.KeyUp) {
+                action()
+                true
+            } else {
+                false
+            }
         }
 
         else -> false

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/util/Modifier.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/util/Modifier.kt
@@ -58,9 +58,7 @@ fun Modifier.runOnEnterKeyPressed(action: () -> Unit): Modifier = this.onPreview
             // Physical keyboards generate two event types:
             // - KeyDown when the key is pressed
             // - KeyUp when the key is released
-            // To match the behavior of software keyboards (IME),
-            // trigger [action] only on the KeyUp event.
-            if (it.type == KeyEventType.KeyUp) {
+            if (it.type == KeyEventType.KeyDown) {
                 action()
                 true
             } else {


### PR DESCRIPTION
On a physical/hardware keyboard, a keystroke sends two events. One of key press and one on key release, so effectively two events on a single keystroke. ([ref](https://developer.android.com/develop/ui/compose/touch-input/keyboard-input/commands#key_events))
This caused `searchAndClearFocus` in `SearchToolbar` composable to trigger twice, second time tapping the back button and exiting out of search.
To fix this, I have changed it to only trigger on Key release, which is the behavior of software keyboard when tapping the enter/search key.

Also changed it so focus is moved next, and not to the back button

Note: only tested on Waydroid, I don't know if this will have any other side effects on other devices with keyboards

closes #1131