### PR TITLE
Display a dialog prompting login when tracker OAuth cannot be refreshed.

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/TrackChapterUiEventBus.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/TrackChapterUiEventBus.kt
@@ -1,0 +1,14 @@
+package eu.kanade.domain.ui
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+object TrackChapterUiEventBus {
+
+    private val _showAuthDialog = MutableSharedFlow<Long>()
+    val showAuthDialog: SharedFlow<Long> = _showAuthDialog
+
+    suspend fun notifyShowAuthDialog(trackerId: Long) {
+        _showAuthDialog.emit(trackerId)
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/track/components/TrackerOAuthExpiredDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/components/TrackerOAuthExpiredDialog.kt
@@ -1,0 +1,57 @@
+package eu.kanade.presentation.track.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import eu.kanade.tachiyomi.data.track.Tracker
+import eu.kanade.tachiyomi.data.track.anilist.Anilist
+import eu.kanade.tachiyomi.data.track.anilist.AnilistApi
+import eu.kanade.tachiyomi.data.track.bangumi.Bangumi
+import eu.kanade.tachiyomi.data.track.bangumi.BangumiApi
+import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeList
+import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeListApi
+import eu.kanade.tachiyomi.util.system.openInBrowser
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun TrackerOAuthExpiredDialog(
+    tracker: Tracker,
+    onDismissRequest: () -> Unit,
+) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    when (tracker) {
+                        is Anilist -> {
+                            context.openInBrowser(AnilistApi.authUrl(), true)
+                        }
+                        is Bangumi -> {
+                            context.openInBrowser(BangumiApi.authUrl(), true)
+                        }
+                        is MyAnimeList -> {
+                            context.openInBrowser(MyAnimeListApi.authUrl(), true)
+                        }
+                    }
+                    onDismissRequest()
+                },
+            ) { Text(stringResource(MR.strings.login)) }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismissRequest,
+            ) { Text(stringResource(MR.strings.action_cancel)) }
+        },
+        title = { Text(stringResource(MR.strings.tracker_oauth_dialog_title, tracker.name)) },
+        text = {
+            Text(
+                stringResource(MR.strings.tracker_oauth_dialog_description, tracker.name),
+            )
+        },
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerOAuthRefreshNotPossibleException.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerOAuthRefreshNotPossibleException.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.data.track
+
+import java.io.IOException
+
+/**
+ * Thrown when the OAuth for a tracker has expired and renewing is not possible either due to expired refresh
+ * token or not being provided a way to do so by service.
+ */
+class TrackerOAuthRefreshNotPossibleException(
+    val tracker: Tracker,
+) : IOException("${tracker.name}: OAuth refresh not possible.")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistInterceptor.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.track.anilist
 
 import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.data.track.TrackerOAuthRefreshNotPossibleException
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.anilist.dto.isExpired
 import okhttp3.Interceptor
@@ -32,7 +33,7 @@ class AnilistInterceptor(val anilist: Anilist, private var token: String?) : Int
         // Refresh access token if null or expired.
         if (oauth!!.isExpired()) {
             anilist.logout()
-            throw IOException("Token expired")
+            throw TrackerOAuthRefreshNotPossibleException(anilist)
         }
 
         // Throw on null auth.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiInterceptor.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.track.bangumi
 
 import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.data.track.TrackerOAuthRefreshNotPossibleException
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMOAuth
 import eu.kanade.tachiyomi.data.track.bangumi.dto.isExpired
 import kotlinx.serialization.json.Json
@@ -29,6 +30,7 @@ class BangumiInterceptor(private val bangumi: Bangumi) : Interceptor {
                 newAuth(currAuth)
             } else {
                 response.close()
+                throw TrackerOAuthRefreshNotPossibleException(bangumi)
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -37,9 +37,12 @@ import eu.kanade.presentation.manga.components.DeleteChaptersDialog
 import eu.kanade.presentation.manga.components.MangaCoverDialog
 import eu.kanade.presentation.manga.components.ScanlatorFilterDialog
 import eu.kanade.presentation.manga.components.SetIntervalDialog
+import eu.kanade.presentation.track.components.TrackerOAuthExpiredDialog
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.presentation.util.isTabletUi
+import eu.kanade.tachiyomi.data.track.Tracker
+import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isLocalOrStub
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -67,6 +70,8 @@ import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.screens.LoadingScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class MangaScreen(
     private val mangaId: Long,
@@ -112,6 +117,13 @@ class MangaScreen(
                 } catch (e: Exception) {
                     logcat(LogPriority.ERROR, e) { "Failed to get manga URL" }
                 }
+            }
+        }
+
+        val authFailedTrackerId by screenModel.authFailedTrackerId.collectAsState()
+        LaunchedEffect(authFailedTrackerId) {
+            if (authFailedTrackerId != null) {
+                screenModel.showTrackerOAuthExpiredDialog(authFailedTrackerId!!)
             }
         }
 
@@ -278,6 +290,15 @@ class MangaScreen(
                     onDismissRequest = onDismissRequest,
                     onValueChanged = { interval: Int -> screenModel.setFetchInterval(dialog.manga, interval) }
                         .takeIf { screenModel.isUpdateIntervalEnabled },
+                )
+            }
+            is MangaScreenModel.Dialog.TrackerOAuthExpiredDialog -> {
+                val tracker = Injekt.get<TrackerManager>().get(
+                    (successState.dialog as MangaScreenModel.Dialog.TrackerOAuthExpiredDialog).trackerID,
+                )
+                TrackerOAuthExpiredDialog(
+                    tracker as Tracker,
+                    onDismissRequest = onDismissRequest,
                 )
             }
         }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1004,4 +1004,8 @@
     <string name="migrationConfigScreen.selectEnabledLabel">Select enabled sources</string>
     <string name="migrationConfigScreen.selectPinnedLabel">Select pinned sources</string>
     <string name="migrationConfigScreen.continueButtonText">Continue</string>
+
+    <!--  Tracker OAuth failed dialog  -->
+    <string name="tracker_oauth_dialog_title">Log in to continue using %s tracker.</string>
+    <string name="tracker_oauth_dialog_description">Your login to %s has expired and cannot be renewed. Please log in again to continue using it.</string>
 </resources>


### PR DESCRIPTION
The dialog is shown in the reader and manga screen when updating track for a manga fails with a custom exception.

Tested in SY but untested in Mihon. No screenshots because I am capable of neither running Mihon, nor running an android emulator.

Closes #1700