### PR TITLE
Add option to download all chapters not yet downloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add advanced option to always update manga title from source ([@FlaminSarge](https://github.com/FlaminSarge)) ([#1182](https://github.com/mihonapp/mihon/pull/1182))
 - Full predictive back support ([@AntsyLich](https://github.com/AntsyLich)) ([#2085](https://github.com/mihonapp/mihon/pull/2085))
 - Add Catppuccin theme (mocha for dark and latte for light, mauve accent) ([@claymorwan](https://github.com/claymorwan/)) ([#2117](https://github.com/mihonapp/mihon/pull/2117))
+- Add "Not Downloaded" download action to queue all non-downloaded chapters, regardless of read status ([@mawmao](https://github.com/mawmao))
 
 ### Improved
 - Significantly improve browsing speed (near instantaneous) ([@AntsyLich](https://github.com/AntsyLich)) ([#1946](https://github.com/mihonapp/mihon/pull/1946))

--- a/app/src/main/java/eu/kanade/presentation/components/DownloadDropdownMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/DownloadDropdownMenu.kt
@@ -23,6 +23,7 @@ fun DownloadDropdownMenu(
         DownloadAction.NEXT_10_CHAPTERS to pluralStringResource(MR.plurals.download_amount, 10, 10),
         DownloadAction.NEXT_25_CHAPTERS to pluralStringResource(MR.plurals.download_amount, 25, 25),
         DownloadAction.UNREAD_CHAPTERS to stringResource(MR.strings.download_unread),
+        DownloadAction.NOT_DOWNLOADED to stringResource(MR.strings.download_not_downloaded)
     )
 
     DropdownMenu(

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
@@ -6,6 +6,7 @@ enum class DownloadAction {
     NEXT_10_CHAPTERS,
     NEXT_25_CHAPTERS,
     UNREAD_CHAPTERS,
+    NOT_DOWNLOADED
 }
 
 enum class EditCoverAction {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -638,6 +638,14 @@ class MangaScreenModel(
             .map { it.chapter }
     }
 
+    private fun getNotDownloadedChapters(): List<Chapter> {
+        val chapterItems = if (skipFiltered) filteredChapters.orEmpty() else allChapters.orEmpty()
+        return chapterItems
+            .filter { (_, dlStatus) -> dlStatus == Download.State.NOT_DOWNLOADED }
+            .map { it.chapter }
+    }
+
+
     private fun getUnreadChaptersSorted(): List<Chapter> {
         val manga = successState?.manga ?: return emptyList()
         val chaptersSorted = getUnreadChapters().sortedWith(getChapterSort(manga))
@@ -706,6 +714,7 @@ class MangaScreenModel(
             DownloadAction.NEXT_10_CHAPTERS -> getUnreadChaptersSorted().take(10)
             DownloadAction.NEXT_25_CHAPTERS -> getUnreadChaptersSorted().take(25)
             DownloadAction.UNREAD_CHAPTERS -> getUnreadChapters()
+            DownloadAction.NOT_DOWNLOADED -> getNotDownloadedChapters()
         }
         if (chaptersToDownload.isNotEmpty()) {
             startDownload(chaptersToDownload, false)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -750,6 +750,7 @@
     <string name="sort_by_upload_date">By upload date</string>
     <string name="manga_download">Download</string>
     <string name="download_unread">Unread</string>
+    <string name="download_not_downloaded">Not Downloaded</string>
     <string name="custom_cover">Custom cover</string>
     <string name="manga_cover">Cover</string>
     <string name="cover_saved">Cover saved</string>


### PR DESCRIPTION
This adds a new **"Not Downloaded"** option to the download menu on the manga screens. Basically, it lets you queue up all the chapters that aren’t downloaded yet  (regardless of read status). If they’re already downloaded or already in the queue, it just skips them. 

Honestly, I made this mostly for myself because I wanted to download all  the chapters, even the ones I’d already read. 

It’s based off the existing `downloadUnreadChapters()` function, but I tweaked it to include all chapters instead of just the unread ones. 
