### PR TITLE
Use median instead of mean interval to estimate smart update interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Include source headers when opening failed images from reader ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2004](https://github.com/mihonapp/mihon/pull/2004))
 - Added autofill support to tracker login dialog ([@AntsyLich](https://github.com/AntsyLich)) ([#2069](https://github.com/mihonapp/mihon/pull/2069))
 - Added option to hide missing chapter count ([@User826](https://github.com/User826), [@AntsyLich](https://github.com/AntsyLich)) ([#2108](https://github.com/mihonapp/mihon/pull/2108))
+- Use median instead of mean when estimating smart update interval, making it more resiliant to long hiatuses ([@Kladki](https://github.com/Kladki)) ([#2251](https://github.com/mihonapp/mihon/pull/2251))
 
 ### Changed
 - Display all similarly named duplicates in duplicate manga dialogue ([@NarwhalHorns](https://github.com/NarwhalHorns), [@AntsyLich](https://github.com/AntsyLich)) ([#1861](https://github.com/mihonapp/mihon/pull/1861))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Include source headers when opening failed images from reader ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2004](https://github.com/mihonapp/mihon/pull/2004))
 - Added autofill support to tracker login dialog ([@AntsyLich](https://github.com/AntsyLich)) ([#2069](https://github.com/mihonapp/mihon/pull/2069))
 - Added option to hide missing chapter count ([@User826](https://github.com/User826), [@AntsyLich](https://github.com/AntsyLich)) ([#2108](https://github.com/mihonapp/mihon/pull/2108))
-- Use median instead of mean when estimating smart update interval, making it more resiliant to long hiatuses ([@Kladki](https://github.com/Kladki)) ([#2251](https://github.com/mihonapp/mihon/pull/2251))
+- Use median to determine smart update interval, making it more resilient to long hiatuses ([@Kladki](https://github.com/Kladki)) ([#2251](https://github.com/mihonapp/mihon/pull/2251))
 
 ### Changed
 - Display all similarly named duplicates in duplicate manga dialogue ([@NarwhalHorns](https://github.com/NarwhalHorns), [@AntsyLich](https://github.com/AntsyLich)) ([#1861](https://github.com/mihonapp/mihon/pull/1861))

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -70,14 +70,12 @@ class FetchInterval(
             // Enough upload date from source
             uploadDates.size >= 3 -> {
                 val ranges = uploadDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
-                val median = ranges[(ranges.size - 1) / 2]
-                median.toInt()
+                ranges[(ranges.size - 1) / 2].toInt()
             }
             // Enough fetch date from client
             fetchDates.size >= 3 -> {
                 val ranges = fetchDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
-                val median = ranges[(ranges.size - 1) / 2]
-                median.toInt()
+                ranges[(ranges.size - 1) / 2].toInt()
             }
             // Default to 7 days
             else -> 7

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -69,15 +69,15 @@ class FetchInterval(
         val interval = when {
             // Enough upload date from source
             uploadDates.size >= 3 -> {
-                val uploadDelta = uploadDates.last().until(uploadDates.first(), ChronoUnit.DAYS)
-                val uploadPeriod = uploadDates.indexOf(uploadDates.last())
-                uploadDelta.floorDiv(uploadPeriod).toInt()
+                val ranges = uploadDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
+                val median = ranges[(ranges.size - 1) / 2]
+                median.toInt()
             }
             // Enough fetch date from client
             fetchDates.size >= 3 -> {
-                val fetchDelta = fetchDates.last().until(fetchDates.first(), ChronoUnit.DAYS)
-                val uploadPeriod = fetchDates.indexOf(fetchDates.last())
-                fetchDelta.floorDiv(uploadPeriod).toInt()
+                val ranges = fetchDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
+                val median = ranges[(ranges.size - 1) / 2]
+                median.toInt()
             }
             // Default to 7 days
             else -> 7

--- a/domain/src/test/java/tachiyomi/domain/manga/interactor/FetchIntervalTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/interactor/FetchIntervalTest.kt
@@ -125,11 +125,11 @@ class FetchIntervalTest {
     }
 
     @Test
-    fun `returns interval of 1 day when chapters are released just below every 2 days`() {
+    fun `returns interval of 2 days when chapters are released just below every 2 days`() {
         val chapters = (1..20).map {
             chapterWithTime(chapter, (43 * it).hours)
         }
-        fetchInterval.calculateInterval(chapters, testZoneId) shouldBe 1
+        fetchInterval.calculateInterval(chapters, testZoneId) shouldBe 2
     }
 
     private fun chapterWithTime(chapter: Chapter, duration: Duration): Chapter {


### PR DESCRIPTION
this should make the smart updater less likely to be thrown off my long hiatuses

Relevant issues: #144

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
