### PR TITLE
fix: Show proper hint when editing cover of unfavorited entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Switch default user agent to Android Chrome ([@AntsyLich](https://github.com/AntsyLich)) ([#2048](https://github.com/mihonapp/mihon/pull/2048))
 - Changed log in button text when processing tracker login ([@AntsyLich](https://github.com/AntsyLich)) ([#2069](https://github.com/mihonapp/mihon/pull/2069))
 - Disable reader's 'Keep screen on' setting by default ([@AntsyLich](https://github.com/AntsyLich)) ([#2095](https://github.com/mihonapp/mihon/pull/2095))
-- Update manga without chapters even if restricted by source ([@AntsyLich](https://github.com/AntsyLich)) ([#2224](https://github.com/mihonapp/mihon/pull/224))
+- Update manga without chapters even if restricted by source ([@AntsyLich](https://github.com/AntsyLich)) ([#2224](https://github.com/mihonapp/mihon/pull/2224))
+- Changed the hint shown when editing cover of unfavorited entry ([@Quickdesh](https://github.com/quickdesh)) ([#2265](https://github.com/mihonapp/mihon/pull/2265))
 
 ### Fixes
 - Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
@@ -11,6 +11,7 @@ enum class DownloadAction {
 enum class EditCoverAction {
     EDIT,
     DELETE,
+    ADD_TO_LIBRARY,
 }
 
 enum class MangaScreenItem {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
@@ -115,15 +115,15 @@ fun MangaCoverDialog(
                                 ),
                             ),
                         )
-                        if (onEditClick != null && manga.favorite) {
+                        if (onEditClick != null) {
                             Box {
                                 var expanded by remember { mutableStateOf(false) }
                                 IconButton(
                                     onClick = {
-                                        if (isCustomCover) {
-                                            expanded = true
-                                        } else {
-                                            onEditClick(EditCoverAction.EDIT)
+                                        when {
+                                            !manga.favorite -> onEditClick(EditCoverAction.ADD_TO_LIBRARY)
+                                            isCustomCover -> expanded = true
+                                            else -> onEditClick(EditCoverAction.EDIT)
                                         }
                                     },
                                 ) {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
@@ -115,7 +115,7 @@ fun MangaCoverDialog(
                                 ),
                             ),
                         )
-                        if (onEditClick != null) {
+                        if (onEditClick != null && manga.favorite) {
                             Box {
                                 var expanded by remember { mutableStateOf(false) }
                                 IconButton(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaCoverScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaCoverScreenModel.kt
@@ -162,4 +162,13 @@ class MangaCoverScreenModel(
             logcat(LogPriority.ERROR, e)
         }
     }
+
+    fun addToLibraryWarning(context: Context) {
+        screenModelScope.launch {
+            snackbarHostState.showSnackbar(
+                context.stringResource(MR.strings.add_to_library_hint),
+                withDismissAction = true,
+            )
+        }
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -261,6 +261,7 @@ class MangaScreen(
                             when (it) {
                                 EditCoverAction.EDIT -> getContent.launch("image/*")
                                 EditCoverAction.DELETE -> sm.deleteCustomCover(context)
+                                EditCoverAction.ADD_TO_LIBRARY -> sm.addToLibraryWarning(context)
                             }
                         },
                         onDismissRequest = onDismissRequest,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -755,6 +755,7 @@
     <string name="cover_saved">Cover saved</string>
     <string name="error_saving_cover">Error saving cover</string>
     <string name="error_sharing_cover">Error sharing cover</string>
+    <string name="add_to_library_hint">Add entry to the library</string>
     <string name="confirm_delete_chapters">Are you sure you want to delete the selected chapters?</string>
     <string name="chapter_settings">Chapter settings</string>
     <string name="confirm_set_chapter_settings">Are you sure you want to save these settings as default?</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Changes
---
- Trying to edit the cover when the entry is not in the library will now show a updated snackbar telling the user to "Add entry to the Library"

Made this change because currently:
- Editing Cover option shows up on an unfavourited entry
- When editing the cover it shows the "Cover Updated" snackbar
- Doesn't actually do anything and would confuse the user
