### PR TITLE
Limit author and artist name lines to 1 with ellipsis (#94)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -453,6 +453,8 @@ private fun ColumnScope.MangaContentInfo(
             text = author?.takeIf { it.isNotBlank() }
                 ?: stringResource(MR.strings.unknown_author),
             style = MaterialTheme.typography.titleSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .clickableNoIndication(
                     onLongClick = {
@@ -483,6 +485,8 @@ private fun ColumnScope.MangaContentInfo(
             Text(
                 text = artist,
                 style = MaterialTheme.typography.titleSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .clickableNoIndication(
                         onLongClick = { context.copyToClipboard(artist, artist) },


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

### Summary

This pull request addresses #94  by limiting the number of lines shown for the author and artist fields in the manga info header. Long author or artist names will now be truncated with an ellipsis (`...`) to avoid overflowing and disrupting the layout.

### What was changed

In `MangaInfoHeader.kt`, I added:

```kotlin
maxLines = 1,
overflow = TextOverflow.Ellipsis,
```
to the Text components for both author and artist.

### Images

| Before | After |
|--------|-------|
| <img width="360" alt="Before" src="https://github.com/user-attachments/assets/43dc305b-e66e-4a9a-b97f-aa29ddcdd83e" /> | <img width="360" alt="After" src="https://github.com/user-attachments/assets/f2780fef-cfaa-4194-bed9-8b75e21ae58b" /> |
