### PR TITLE
Combine pages for side-by-side view

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
@@ -18,10 +18,15 @@ import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 fun PageIndicatorText(
     currentPage: Int,
     totalPages: Int,
+    combinedPageNumber: Int? = null,
 ) {
     if (currentPage <= 0 || totalPages <= 0) return
 
-    val text = "$currentPage / $totalPages"
+    val text = if (combinedPageNumber != null && combinedPageNumber != currentPage) {
+        "$currentPage-$combinedPageNumber / $totalPages"
+    } else {
+        "$currentPage / $totalPages"
+    }
 
     val style = TextStyle(
         color = Color(235, 235, 235),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -109,6 +109,19 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         pref = screenModel.preferences.navigateToPan(),
     )
 
+    val combinedPagesPaged by screenModel.preferences.combinedPagesPaged().collectAsState()
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_combined_pages),
+        pref = screenModel.preferences.combinedPagesPaged(),
+    )
+
+    if (combinedPagesPaged) {
+        CheckboxItem(
+            label = stringResource(MR.strings.pref_combined_pages_show_cover),
+            pref = screenModel.preferences.combinedPagesShowCoverPage(),
+        )
+    }
+
     val dualPageSplitPaged by screenModel.preferences.dualPageSplitPaged().collectAsState()
     CheckboxItem(
         label = stringResource(MR.strings.pref_dual_page_split),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -339,6 +339,7 @@ class ReaderActivity : BaseActivity() {
                 PageIndicatorText(
                     currentPage = state.currentPage,
                     totalPages = state.totalPages,
+                    combinedPageNumber = state.combinedPageNumber,
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -530,9 +530,10 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     private suspend fun updateChapterProgress(readerChapter: ReaderChapter, page: Page) {
         val pageIndex = page.index
+        val combinedPageNumber = getCombinedPageNumber(page as ReaderPage)
 
         mutableState.update {
-            it.copy(currentPage = pageIndex + 1)
+            it.copy(currentPage = pageIndex + 1, combinedPageNumber = combinedPageNumber)
         }
         readerChapter.requestedPage = pageIndex
         chapterPageIndex = pageIndex
@@ -552,6 +553,26 @@ class ReaderViewModel @JvmOverloads constructor(
                 ),
             )
         }
+    }
+
+    /**
+     * Gets the ending page number when pages are combined (e.g., 3 for pages 2-3).
+     */
+    private fun getCombinedPageNumber(page: ReaderPage): Int? {
+        val viewer = state.value.viewer as? eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerViewer ?: return null
+
+        val pages = page.chapter.pages ?: return null
+        val nextPageIndex = page.index + 1
+        if (nextPageIndex >= pages.size) {
+            return null
+        }
+
+        val nextPage = pages[nextPageIndex]
+        if (viewer.isPageHidden(nextPage)) {
+            return nextPage.index + 1
+        }
+
+        return null
     }
 
     private suspend fun updateChapterProgressOnComplete(readerChapter: ReaderChapter) {
@@ -953,6 +974,7 @@ class ReaderViewModel @JvmOverloads constructor(
         val bookmarked: Boolean = false,
         val isLoadingAdjacentChapter: Boolean = false,
         val currentPage: Int = -1,
+        val combinedPageNumber: Int? = null,
 
         /**
          * Viewer used to display the pages (pager, webtoon, ...).

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -97,6 +97,10 @@ class ReaderPreferences(
 
     fun dualPageRotateToFitInvertWebtoon() = preferenceStore.getBoolean("pref_dual_page_rotate_invert_webtoon", false)
 
+    fun combinedPagesPaged() = preferenceStore.getBoolean("pref_combined_pages", false)
+
+    fun combinedPagesShowCoverPage() = preferenceStore.getBoolean("pref_combined_pages_show_cover", true)
+
     // endregion
 
     // region Color filter

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerConfig.kt
@@ -42,6 +42,12 @@ abstract class ViewerConfig(readerPreferences: ReaderPreferences, private val sc
     var dualPageRotateToFitInvert = false
         protected set
 
+    var combinedPages = false
+        protected set
+
+    var combinedPagesShowCover = true
+        protected set
+
     abstract var navigator: ViewerNavigation
         protected set
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -33,6 +33,8 @@ class PagerConfig(
 
     var dualPageSplitChangedListener: ((Boolean) -> Unit)? = null
 
+    var combinedPagesChangedListener: ((Boolean) -> Unit)? = null
+
     var imageScaleType = 1
         private set
 
@@ -105,6 +107,24 @@ class PagerConfig(
             .register(
                 { dualPageRotateToFitInvert = it },
                 { imagePropertyChangedListener?.invoke() },
+            )
+
+        readerPreferences.combinedPagesPaged()
+            .register(
+                { combinedPages = it },
+                {
+                    imagePropertyChangedListener?.invoke()
+                    combinedPagesChangedListener?.invoke(it)
+                },
+            )
+
+        readerPreferences.combinedPagesShowCoverPage()
+            .register(
+                { combinedPagesShowCover = it },
+                {
+                    imagePropertyChangedListener?.invoke()
+                    combinedPagesChangedListener?.invoke(combinedPages)
+                },
             )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -118,6 +118,11 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
         }
 
         preprocessed = mutableMapOf()
+
+        if (currentChapter?.chapter?.id != chapters.currChapter.chapter.id) {
+            viewer.clearPageState()
+        }
+
         items = newItems
         notifyDataSetChanged()
 
@@ -128,17 +133,18 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
     }
 
     /**
-     * Returns the amount of items of the adapter.
+     * Returns the amount of items of the adapter, excluding hidden pages.
      */
     override fun getCount(): Int {
-        return items.size
+        return getFilteredItems().size
     }
 
     /**
      * Creates a new view for the item at the given [position].
      */
     override fun createView(container: ViewGroup, position: Int): View {
-        return when (val item = items[position]) {
+        val filteredItems = getFilteredItems()
+        return when (val item = filteredItems[position]) {
             is ReaderPage -> PagerPageHolder(readerThemedContext, viewer, item)
             is ChapterTransition -> PagerTransitionHolder(readerThemedContext, viewer, item)
             else -> throw NotImplementedError("Holder for ${item.javaClass} not implemented")
@@ -150,7 +156,7 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
      */
     override fun getItemPosition(view: Any): Int {
         if (view is PositionableView) {
-            val position = items.indexOf(view.item)
+            val position = getFilteredPosition(view.item)
             if (position != -1) {
                 return position
             } else {
@@ -197,6 +203,20 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
         val insertPages = items.filterIsInstance(InsertPage::class.java)
         items.removeAll(insertPages)
         notifyDataSetChanged()
+    }
+
+    /**
+     * Returns a filtered list of items, excluding hidden pages.
+     */
+    fun getFilteredItems(): List<Any> {
+        return items.filterNot { it is ReaderPage && viewer.isPageHidden(it) }
+    }
+
+    /**
+     * Returns the position of the given item in the filtered list.
+     */
+    fun getFilteredPosition(item: Any): Int {
+        return getFilteredItems().indexOf(item)
     }
 
     fun refresh() {

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -209,6 +209,35 @@ object ImageUtil {
     }
 
     /**
+     * Combines two pages for side-by-side view.
+     */
+    fun combinePages(leftPageSource: BufferedSource, rightPageSource: BufferedSource): BufferedSource {
+        val leftBitmap = BitmapFactory.decodeStream(leftPageSource.inputStream())
+        val rightBitmap = BitmapFactory.decodeStream(rightPageSource.inputStream())
+
+        val maxHeight = max(leftBitmap.height, rightBitmap.height)
+        val combinedWidth = leftBitmap.width + rightBitmap.width
+
+        val combinedBitmap = createBitmap(combinedWidth, maxHeight, Bitmap.Config.RGB_565)
+
+        combinedBitmap.applyCanvas {
+            drawBitmap(leftBitmap, 0f, (maxHeight - leftBitmap.height) / 2f, null)
+            drawBitmap(rightBitmap, leftBitmap.width.toFloat(), (maxHeight - rightBitmap.height) / 2f, null)
+        }
+
+        leftBitmap.recycle()
+        rightBitmap.recycle()
+
+        val buffer = Buffer()
+        buffer.outputStream().use { outputStream ->
+            combinedBitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+        }
+        combinedBitmap.recycle()
+
+        return buffer
+    }
+
+    /**
      * Splits tall images to improve performance of reader
      */
     fun splitTallImage(tmpDir: UniFile, imageFile: UniFile, filenamePrefix: String): Boolean {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -380,6 +380,8 @@
     <string name="pref_dual_page_split">Split wide pages</string>
     <string name="pref_dual_page_invert">Invert split page placement</string>
     <string name="pref_dual_page_invert_summary">If the placement of the split wide pages don\'t match reading direction</string>
+    <string name="pref_combined_pages">Combine pages for side-by-side view (experimental)</string>
+    <string name="pref_combined_pages_show_cover">Show first page separately</string>
     <string name="pref_page_rotate">Rotate wide pages to fit</string>
     <string name="pref_page_rotate_invert">Flip orientation of rotated wide pages</string>
     <string name="pref_double_tap_zoom">Double tap to zoom</string>


### PR DESCRIPTION
Took a stab at https://github.com/mihonapp/mihon/issues/28 :v: 

- Added the setting `Combine pages for side-by-side view` and `Show first page separately`
- Pages are combined to be shown together whenever possible
- Spreads are preserved and shown separately
- Works for all paged reading modes (R2L is assumed for vertical)

### How it works

In the regular single-page view, the adapter keeps an array of items, each representing one page (held by a `PageHolder`) which is loaded lazily. In the side-by-side view, every `PageHolder` holds its own page, but when loading also tries to combine and show the next page. If it succeeds, the next page is marked hidden (since it's already shown) and the current page is marked combined (to prevent it from being hidden by the previous page, which could happen if the user is jumping around in the chapter). 

### Limitations

- Due to the nature of lazy loading, there is no way of knowing ahead of time which page is supposed to be on which side. When opening a chapter and jumping to a random page, it will simply try to combine with the page that comes after. 
- A user that jumps around a lot within a chapter will trigger many parallel page loads, possibly leading to race conditions that could cause pages to be hidden from the user. 
- Only implemented for the `PagerViewer` for now.

### Images
| ![Screenshot_20250728_200146_Mihon](https://github.com/user-attachments/assets/596b55ee-8e68-4312-b9a4-0b2ea30b1496) | ![Screenshot_20250728_200257_Mihon](https://github.com/user-attachments/assets/f2c21377-5321-454f-8d94-d3fc4cc2ef38) |
| ------- | ------- |

Started off working on this thinking this would be an easy one, boy was I wrong. It seems to work pretty well for the regular case of reading a chapter from front to back. I tried to keep it as simple as possible while still working around the lazy loading, and this is the best I could come up with. Very receptive to any feedback on how to improve it :smile: 