### PR TITLE
Add label to privately installed extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
-### Added
-- Add "Private" label to extensions installed with the Private installer ([@MajorTanya](https://github.com/MajorTanya)) ([#2349](https://github.com/mihonapp/mihon/pull/2349))
 
 ## [v0.19.0] - 2025-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Add "Private" label to extensions installed with the Private installer ([@MajorTanya](https://github.com/MajorTanya)) ([#2349](https://github.com/mihonapp/mihon/pull/2349))
 
 ## [v0.19.0] - 2025-08-04
 ### Added

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
@@ -353,13 +353,17 @@ private fun ExtensionItemContent(
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
         ) {
             ProvideTextStyle(value = MaterialTheme.typography.bodySmall) {
+                var hasAlreadyShownAnElement by remember { mutableStateOf(false) }
                 if (extension is Extension.Installed && extension.lang.isNotEmpty()) {
+                    hasAlreadyShownAnElement = true
                     Text(
                         text = LocaleHelper.getSourceDisplayName(extension.lang, LocalContext.current),
                     )
                 }
 
                 if (extension.versionName.isNotEmpty()) {
+                    if (hasAlreadyShownAnElement) DotSeparatorNoSpaceText()
+                    hasAlreadyShownAnElement = true
                     Text(
                         text = extension.versionName,
                     )
@@ -372,6 +376,8 @@ private fun ExtensionItemContent(
                     else -> null
                 }
                 if (warning != null) {
+                    if (hasAlreadyShownAnElement) DotSeparatorNoSpaceText()
+                    hasAlreadyShownAnElement = true
                     Text(
                         text = stringResource(warning).uppercase(),
                         color = MaterialTheme.colorScheme.error,
@@ -380,6 +386,7 @@ private fun ExtensionItemContent(
                     )
                 }
                 if (extension is Extension.Installed && !extension.isShared) {
+                    if (hasAlreadyShownAnElement) DotSeparatorNoSpaceText()
                     Text(
                         text = stringResource(MR.strings.ext_installer_private),
                     )

--- a/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/ExtensionsScreen.kt
@@ -379,6 +379,11 @@ private fun ExtensionItemContent(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+                if (extension is Extension.Installed && !extension.isShared) {
+                    Text(
+                        text = stringResource(MR.strings.ext_installer_private),
+                    )
+                }
 
                 if (!installStep.isCompleted()) {
                     DotSeparatorNoSpaceText()


### PR DESCRIPTION
Just adds the same word as the install option ("Private" in English) next to the extension version and 18+ label (if present).

Added this for my personal fork but thought it might be nice for others as well.

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.com/user-attachments/assets/08438d9c-ebaf-4505-9ad2-334316027df7) | ![](https://github.com/user-attachments/assets/a1d9f955-2b6d-473c-9f9c-5beed752d536) |
