### PR TITLE
Update LibraryScreenModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix local source EPUB files not loading ([@AntsyLich](https://github.com/AntsyLich)) ([#2369](https://github.com/mihonapp/mihon/pull/2369))
 - Fix title text color in light mode on mass migration list ([@AntsyLich](https://github.com/AntsyLich)) ([#2370](https://github.com/mihonapp/mihon/pull/2370))
 - Fix 'Default' category showing in library with no user-added categories ([@AntsyLich](https://github.com/AntsyLich)) ([#2371](https://github.com/mihonapp/mihon/pull/2371))
+- Fix crash when opening filter sheet with an empty library ([@krysanify](https://github.com/krysanify/)) ([#2355](https://github.com/mihonapp/mihon/pull/2355))
+- Fix mark as read/unread not working for selected library items ([@krysanify](https://github.com/krysanify/)) ([#2355](https://github.com/mihonapp/mihon/pull/2355))
 
 ## [v0.19.0] - 2025-08-04
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -499,8 +499,9 @@ class LibraryScreenModel(
      * Marks mangas' chapters read status.
      */
     fun markReadSelection(read: Boolean) {
+        val selection = state.value.selectedManga
         screenModelScope.launchNonCancellable {
-            state.value.selectedManga.forEach { manga ->
+            selection.forEach { manga ->
                 setReadStatus.await(
                     manga = manga,
                     read = read,
@@ -573,7 +574,7 @@ class LibraryScreenModel(
 
     fun getRandomLibraryItemForCurrentCategory(): LibraryItem? {
         val state = state.value
-        return state.getItemsForCategoryId(state.activeCategory.id).randomOrNull()
+        return state.getItemsForCategoryId(state.activeCategory?.id).randomOrNull()
     }
 
     fun showSettingsDialog() {
@@ -631,7 +632,7 @@ class LibraryScreenModel(
         lastSelectionCategory = null
         mutableState.update { state ->
             val newSelection = state.selection.mutate { list ->
-                state.getItemsForCategoryId(state.activeCategory.id).map { it.id }.let(list::addAll)
+                state.getItemsForCategoryId(state.activeCategory?.id).map { it.id }.let(list::addAll)
             }
             state.copy(selection = newSelection)
         }
@@ -641,7 +642,7 @@ class LibraryScreenModel(
         lastSelectionCategory = null
         mutableState.update { state ->
             val newSelection = state.selection.mutate { list ->
-                val itemIds = state.getItemsForCategoryId(state.activeCategory.id).fastMap { it.id }
+                val itemIds = state.getItemsForCategoryId(state.activeCategory?.id).fastMap { it.id }
                 val (toRemove, toAdd) = itemIds.partition { it in list }
                 list.removeAll(toRemove)
                 list.addAll(toAdd)
@@ -756,7 +757,7 @@ class LibraryScreenModel(
             maximumValue = displayedCategories.lastIndex.coerceAtLeast(0),
         )
 
-        val activeCategory: Category by lazy { displayedCategories[coercedActiveCategoryIndex] }
+        val activeCategory: Category? = displayedCategories.getOrNull(coercedActiveCategoryIndex)
 
         val isLibraryEmpty = libraryData.favorites.isEmpty()
 
@@ -764,7 +765,8 @@ class LibraryScreenModel(
 
         val selectedManga by lazy { selection.mapNotNull { libraryData.favoritesById[it]?.libraryManga?.manga } }
 
-        fun getItemsForCategoryId(categoryId: Long): List<LibraryItem> {
+        fun getItemsForCategoryId(categoryId: Long?): List<LibraryItem> {
+            if (categoryId == null) return emptyList()
             val category = displayedCategories.find { it.id == categoryId } ?: return emptyList()
             return getItemsForCategory(category)
         }


### PR DESCRIPTION
Closes #2345
Closes #2351
 - Get `selectedManga` before switching scope
 - Provide default category for `activeCategory` on empty favorites (library)
