### PR TITLE
fix black titles in mass migration

### DIFF
--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
@@ -216,6 +216,7 @@ fun MigrationListItem(
                 maxLines = 2,
                 style = MaterialTheme.typography.labelMedium
                     .merge(shadow = Shadow(color = Color.Black, blurRadius = 4f)),
+                color = Color.White,
             )
             BadgeGroup(modifier = Modifier.padding(4.dp)) {
                 Badge(text = "$chapterCount")


### PR DESCRIPTION
This fixes the problem in #2347

added color white to the text