### PR TITLE
change library title text and background based on theme

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -131,10 +131,10 @@ private fun BoxScope.CoverTextOverlay(
             .background(
                 Brush.verticalGradient(
                     0f to Color.Transparent,
-                    1f to Color(0xAA000000),
+                    1f to MaterialTheme.colorScheme.background,
                 ),
             )
-            .fillMaxHeight(0.33f)
+            .fillMaxHeight(0.4f)
             .fillMaxWidth()
             .align(Alignment.BottomCenter),
     )
@@ -147,12 +147,7 @@ private fun BoxScope.CoverTextOverlay(
                 .weight(1f)
                 .padding(8.dp),
             title = title,
-            style = MaterialTheme.typography.titleSmall.copy(
-                color = Color.White,
-                shadow = Shadow(
-                    color = Color.Black,
-                    blurRadius = 4f,
-                ),
+            style = MaterialTheme.typography.labelMedium,
             ),
             minLines = 1,
         )

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -148,7 +148,6 @@ private fun BoxScope.CoverTextOverlay(
                 .padding(8.dp),
             title = title,
             style = MaterialTheme.typography.labelMedium,
-            ),
             minLines = 1,
         )
         if (onClickContinueReading != null) {


### PR DESCRIPTION
Same change like in the #2370, so the title and the background is based on the theme.

Somehow I like the colors in the migration list

So I also changed it in the library to see what it looks like there.
I like it that way, but many people are already used to the style that is right now.

That is the result:

<img width="369" height="831" alt="2025-08-07 23_08_33-Mihon – CommonMangaItem kt  Mihon app main" src="https://github.com/user-attachments/assets/94bd8276-bc57-4bf9-869e-7247534dd065" />
<img width="377" height="837" alt="2025-08-07 23_08_49-Mihon – CommonMangaItem kt  Mihon app main" src="https://github.com/user-attachments/assets/b1fff4f1-fb3e-431a-aee0-28524ce9a272" />
