### PR TITLE
Adding option to export to local source

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -113,6 +113,7 @@ fun MangaScreen(
     onEditFetchIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
     onEditNotesClicked: () -> Unit,
+    onClickExportToLocal: (() -> Unit)?,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -170,6 +171,7 @@ fun MangaScreen(
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
             onInvertSelection = onInvertSelection,
+            onClickExportToLocal = onClickExportToLocal
         )
     } else {
         MangaScreenLargeImpl(
@@ -206,6 +208,7 @@ fun MangaScreen(
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
             onInvertSelection = onInvertSelection,
+            onClickExportToLocal = onClickExportToLocal
         )
     }
 }
@@ -244,6 +247,7 @@ private fun MangaScreenSmallImpl(
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
     onEditNotesClicked: () -> Unit,
+    onClickExportToLocal: (() -> Unit)?,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -303,6 +307,7 @@ private fun MangaScreenSmallImpl(
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
                 onClickEditNotes = onEditNotesClicked,
+                onClickExportToLocal = onClickExportToLocal,
                 actionModeCounter = selectedChapterCount,
                 onCancelActionMode = { onAllChapterSelected(false) },
                 onSelectAll = { onAllChapterSelected(true) },
@@ -488,6 +493,7 @@ fun MangaScreenLargeImpl(
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
     onEditNotesClicked: () -> Unit,
+    onClickExportToLocal: (() -> Unit)?,
 
     // For bottom action menu
     onMultiBookmarkClicked: (List<Chapter>, bookmarked: Boolean) -> Unit,
@@ -540,6 +546,7 @@ fun MangaScreenLargeImpl(
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
                 onClickEditNotes = onEditNotesClicked,
+                onClickExportToLocal = onClickExportToLocal,
                 onCancelActionMode = { onAllChapterSelected(false) },
                 actionModeCounter = selectedChapterCount,
                 onSelectAll = { onAllChapterSelected(true) },

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreenConstants.kt
@@ -20,3 +20,8 @@ enum class MangaScreenItem {
     CHAPTER_HEADER,
     CHAPTER,
 }
+
+enum class ExportToLocalReason {
+    ALREADY_EXISTS,
+    NO_DOWNLOADS
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -1,12 +1,15 @@
 package eu.kanade.presentation.manga.components
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -19,6 +22,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import eu.kanade.presentation.manga.ExportToLocalReason
 import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import kotlinx.collections.immutable.toImmutableList
 import tachiyomi.domain.manga.interactor.FetchInterval
@@ -148,5 +153,75 @@ fun SetIntervalDialog(
                 Text(text = stringResource(MR.strings.action_ok))
             }
         },
+    )
+}
+
+@Composable
+fun ExportToLocalDialog(
+    reason: ExportToLocalReason,
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val textRes = remember(reason) {
+        when (reason) {
+            ExportToLocalReason.ALREADY_EXISTS -> MR.strings.export_to_local_already_exists
+            ExportToLocalReason.NO_DOWNLOADS -> MR.strings.export_to_local_no_downloads
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onDismissRequest()
+                    onConfirm()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        title = {
+            Text(text = stringResource(MR.strings.are_you_sure))
+        },
+        text = {
+            Text(text = stringResource(textRes))
+        },
+    )
+}
+
+@Composable
+fun ExportToLocalProgressDialog(
+    progress: Float,
+    exitMigration: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = {},
+        confirmButton = {
+            TextButton(onClick = exitMigration) {
+                Text(text = stringResource(MR.strings.migrationListScreen_progressDialog_cancelLabel))
+            }
+        },
+        text = {
+            if (!progress.isNaN()) {
+                val progressAnimated by animateFloatAsState(
+                    targetValue = progress,
+                    animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
+                    label = "migration_progress",
+                )
+                LinearProgressIndicator(
+                    progress = { progressAnimated },
+                )
+            }
+        },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+        ),
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -38,6 +38,7 @@ fun MangaToolbar(
     onClickRefresh: () -> Unit,
     onClickMigrate: (() -> Unit)?,
     onClickEditNotes: () -> Unit,
+    onClickExportToLocal: (() -> Unit)?,
 
     // For action mode
     actionModeCounter: Int,
@@ -147,6 +148,14 @@ fun MangaToolbar(
                             onClick = onClickEditNotes,
                         ),
                     )
+                    if (onClickExportToLocal != null) {
+                        add(
+                            AppBar.OverflowAction(
+                                title = stringResource(MR.strings.action_export_to_local),
+                                onClick = onClickExportToLocal
+                            )
+                        )
+                    }
                 }
                     .build(),
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/export/ExportToLocalImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/export/ExportToLocalImpl.kt
@@ -1,0 +1,164 @@
+package eu.kanade.tachiyomi.data.export
+
+import android.content.Context
+import androidx.core.net.toUri
+import com.hippo.unifile.UniFile
+import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.util.storage.DiskUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import nl.adaptivity.xmlutil.serialization.XML
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.core.metadata.comicinfo.COMIC_INFO_FILE
+import tachiyomi.core.metadata.comicinfo.ComicInfo
+import tachiyomi.core.metadata.comicinfo.getComicInfo
+import tachiyomi.domain.export.service.ExportService
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
+
+class ExportToLocalImpl(
+    private val context: Context,
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val storageManager: StorageManager = Injekt.get(),
+    private val coverCache: CoverCache = Injekt.get(),
+) : ExportService {
+
+    private val xml: XML by injectLazy()
+
+    override suspend fun exportChapter(file: UniFile, destinationSubfolder: UniFile): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val destinationFile = destinationSubfolder.createFile(file.name)
+                    ?: return@withContext Result.failure(Exception("Failed to create destination file"))
+
+                context.contentResolver.openInputStream(file.uri)?.use { input ->
+                    context.contentResolver.openOutputStream(destinationFile.uri)?.use { output ->
+                        input.copyTo(output, bufferSize = DEFAULT_BUFFER_SIZE)
+                    }
+                }
+
+                Result.success(Unit)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to export ${file.name} to $destinationSubfolder" }
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun exportCover(manga: Manga, destinationSubfolder: UniFile): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val coverFile = coverCache.getCoverFile(manga.thumbnailUrl)
+                if (coverFile != null) {
+                    val destinationCover = destinationSubfolder.createFile(DEFAULT_COVER_NAME)
+
+                    context.contentResolver.openInputStream(coverFile.toUri())?.use { input ->
+                        context.contentResolver.openOutputStream(destinationCover!!.uri)?.use { output ->
+                            input.copyTo(output, bufferSize = DEFAULT_BUFFER_SIZE)
+                        }
+                    }
+                }
+                Result.success(Unit)
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) { "Failed to export cover for manga ${manga.title}" }
+                Result.success(Unit)
+            }
+        }
+    }
+
+    override suspend fun exportComicInfo(manga: Manga, destinationSubfolder: UniFile): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val comicInfo = manga.toSManga().getComicInfo()
+                destinationSubfolder.createFile(COMIC_INFO_FILE)?.openOutputStream()?.use {
+                    val comicInfoString = xml.encodeToString(ComicInfo.serializer(), comicInfo)
+                    it.write(comicInfoString.toByteArray())
+                }
+                Result.success(Unit)
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) { "Failed to export ComicInfo for manga ${manga.title}" }
+                Result.success(Unit)
+            }
+        }
+    }
+
+    override suspend fun getItemsToExport(manga: Manga): Result<Array<UniFile>> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val mangaSource = sourceManager.get(manga.source)
+                    ?: return@withContext Result.failure(Exception("Source not found"))
+
+                val folder = downloadProvider.findMangaDir(manga.title, mangaSource)
+                    ?: return@withContext Result.failure(Exception("Manga directory not found"))
+
+                val files = folder.listFiles()
+                    ?: return@withContext Result.failure(Exception("Failed to list manga files"))
+
+                Result.success(files)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to get export items for manga ${manga.title}" }
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun getDestinationSubfolder(manga: Manga): Result<UniFile> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val mangaSource = sourceManager.get(manga.source)
+                    ?: return@withContext Result.failure(Exception("Source not found"))
+
+                val folder = downloadProvider.findMangaDir(manga.title, mangaSource)
+                    ?: return@withContext Result.failure(Exception("Manga directory not found"))
+
+                val destinationFolder = storageManager.getLocalSourceDirectory()
+                    ?: return@withContext Result.failure(Exception("Local source directory not available"))
+
+                val destination = destinationFolder.createDirectory(folder.name)
+                    ?: return@withContext Result.failure(Exception("Failed to create destination directory"))
+
+                Result.success(destination)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to get destination subfolder for manga ${manga.title}" }
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun destinationSubfolderExists(mangaTitle: String): Result<Boolean> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val localSourceDir = storageManager.getLocalSourceDirectory()
+                val exists = localSourceDir?.findFile(mangaTitle) != null
+                Result.success(exists)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to check if destination subfolder exists for $mangaTitle" }
+                Result.failure(e)
+            }
+        }
+    }
+
+    override suspend fun deleteAllItemsInSubfolder(subfolder: UniFile): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                subfolder.delete()
+                Result.success(Unit)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e) { "Failed to delete subfolder $subfolder" }
+                Result.failure(e)
+            }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_COVER_NAME = "cover.jpg"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.data.export.ExportToLocalImpl
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.extension.ExtensionManager
@@ -44,6 +45,10 @@ import uy.kohesive.injekt.api.InjektRegistrar
 import uy.kohesive.injekt.api.addSingleton
 import uy.kohesive.injekt.api.addSingletonFactory
 import uy.kohesive.injekt.api.get
+import tachiyomi.domain.export.service.ExportService
+import tachiyomi.domain.export.interactor.ExportMangaToLocal
+import tachiyomi.domain.export.interactor.GetExportItems
+import tachiyomi.domain.export.interactor.GetExportDestination
 
 class AppModule(val app: Application) : InjektModule {
 
@@ -133,6 +138,11 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { LocalSourceFileSystem(get()) }
         addSingletonFactory { LocalCoverManager(app, get()) }
         addSingletonFactory { StorageManager(app, get()) }
+
+        addSingletonFactory<ExportService> { ExportToLocalImpl(app) }
+        addSingletonFactory { ExportMangaToLocal(get()) }
+        addSingletonFactory { GetExportItems(get()) }
+        addSingletonFactory { GetExportDestination(get()) }
 
         // Asynchronously init expensive components for a faster cold start
         ContextCompat.getMainExecutor(app).execute {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -34,6 +34,8 @@ import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.manga.EditCoverAction
 import eu.kanade.presentation.manga.MangaScreen
 import eu.kanade.presentation.manga.components.DeleteChaptersDialog
+import eu.kanade.presentation.manga.components.ExportToLocalDialog
+import eu.kanade.presentation.manga.components.ExportToLocalProgressDialog
 import eu.kanade.presentation.manga.components.MangaCoverDialog
 import eu.kanade.presentation.manga.components.ScanlatorFilterDialog
 import eu.kanade.presentation.manga.components.SetIntervalDialog
@@ -173,6 +175,7 @@ class MangaScreen(
             onChapterSelected = screenModel::toggleSelection,
             onAllChapterSelected = screenModel::toggleAllSelection,
             onInvertSelection = screenModel::invertSelection,
+            onClickExportToLocal = screenModel::verifyExportToLocal.takeIf { isHttpSource }
         )
 
         var showScanlatorsDialog by remember { mutableStateOf(false) }
@@ -277,6 +280,25 @@ class MangaScreen(
                     onValueChanged = { interval: Int -> screenModel.setFetchInterval(dialog.manga, interval) }
                         .takeIf { screenModel.isUpdateIntervalEnabled },
                 )
+            }
+            is MangaScreenModel.Dialog.ExportToLocal -> {
+                ExportToLocalDialog(
+                    reason = dialog.reason,
+                    onDismissRequest = onDismissRequest,
+                    onConfirm = screenModel::exportToLocal
+                )
+            }
+            is MangaScreenModel.Dialog.Progress -> {
+                ExportToLocalProgressDialog(
+                    progress = dialog.progress,
+                    exitMigration = screenModel::cancelExport
+                )
+            }
+        }
+
+        LaunchedEffect(screenModel) {
+            screenModel.navigateBackEvent.collect {
+                navigator.pop()
             }
         }
 

--- a/domain/src/main/java/tachiyomi/domain/export/interactor/ExportMangaToLocal.kt
+++ b/domain/src/main/java/tachiyomi/domain/export/interactor/ExportMangaToLocal.kt
@@ -1,0 +1,44 @@
+package tachiyomi.domain.export.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.export.service.ExportService
+import tachiyomi.domain.manga.model.Manga
+
+class ExportMangaToLocal(
+    private val exportService: ExportService,
+) {
+
+    suspend fun await(manga: Manga, onProgress: (Float) -> Unit = {}): Result {
+        return try {
+            val items = exportService.getItemsToExport(manga).getOrThrow()
+            val destination = exportService.getDestinationSubfolder(manga).getOrThrow()
+
+            items.forEachIndexed { index, item ->
+                val progress = (index.toFloat() / items.size).coerceAtMost(1f)
+                onProgress(progress)
+
+                exportService.exportChapter(item, destination).getOrElse {
+                    exportService.deleteAllItemsInSubfolder(destination)
+                    return Result.Error(it)
+                }
+            }
+
+            exportService.exportCover(manga, destination)
+            exportService.exportComicInfo(manga, destination)
+
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to export manga ${manga.title}" }
+            exportService.getDestinationSubfolder(manga).getOrNull()?.let {
+                exportService.deleteAllItemsInSubfolder(it)
+            }
+            Result.Error(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data class Error(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/export/interactor/GetExportDestination.kt
+++ b/domain/src/main/java/tachiyomi/domain/export/interactor/GetExportDestination.kt
@@ -1,0 +1,27 @@
+package tachiyomi.domain.export.interactor
+
+import com.hippo.unifile.UniFile
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.export.service.ExportService
+import tachiyomi.domain.manga.model.Manga
+
+class GetExportDestination(
+    private val exportService: ExportService,
+) {
+
+    suspend fun await(manga: Manga): UniFile? {
+        return try {
+            val result = exportService.getDestinationSubfolder(manga)
+            if (result.isSuccess) {
+                result.getOrNull()
+            } else {
+                logcat(LogPriority.ERROR) { "Failed to get export destination for manga ${manga.title}" }
+                null
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to get export destination for manga ${manga.title}" }
+            null
+        }
+    }
+} 

--- a/domain/src/main/java/tachiyomi/domain/export/interactor/GetExportItems.kt
+++ b/domain/src/main/java/tachiyomi/domain/export/interactor/GetExportItems.kt
@@ -1,0 +1,27 @@
+package tachiyomi.domain.export.interactor
+
+import com.hippo.unifile.UniFile
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.export.service.ExportService
+import tachiyomi.domain.manga.model.Manga
+
+class GetExportItems(
+    private val exportService: ExportService,
+) {
+
+    suspend fun await(manga: Manga): Array<UniFile>? {
+        return try {
+            val result = exportService.getItemsToExport(manga)
+            if (result.isSuccess) {
+                result.getOrNull()
+            } else {
+                logcat(LogPriority.ERROR) { "Failed to get export items for manga ${manga.title}" }
+                null
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to get export items for manga ${manga.title}" }
+            null
+        }
+    }
+} 

--- a/domain/src/main/java/tachiyomi/domain/export/service/ExportService.kt
+++ b/domain/src/main/java/tachiyomi/domain/export/service/ExportService.kt
@@ -1,0 +1,42 @@
+package tachiyomi.domain.export.service
+
+import com.hippo.unifile.UniFile
+import tachiyomi.domain.manga.model.Manga
+
+interface ExportService {
+
+    /**
+     * Exports a chapter file to the specified destination
+     */
+    suspend fun exportChapter(file: UniFile, destinationSubfolder: UniFile): Result<Unit>
+
+    /**
+     * Exports the cover image for a manga
+     */
+    suspend fun exportCover(manga: Manga, destinationSubfolder: UniFile): Result<Unit>
+
+    /**
+     * Exports ComicInfo metadata for a manga
+     */
+    suspend fun exportComicInfo(manga: Manga, destinationSubfolder: UniFile): Result<Unit>
+
+    /**
+     * Gets all items that can be exported for a manga
+     */
+    suspend fun getItemsToExport(manga: Manga): Result<Array<UniFile>>
+
+    /**
+     * Gets or creates the destination subfolder for a manga
+     */
+    suspend fun getDestinationSubfolder(manga: Manga): Result<UniFile>
+
+    /**
+     * Checks if a destination subfolder already exists
+     */
+    suspend fun destinationSubfolderExists(mangaTitle: String): Result<Boolean>
+
+    /**
+     * Deletes all items in a subfolder
+     */
+    suspend fun deleteAllItemsInSubfolder(subfolder: UniFile): Result<Unit>
+} 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -167,6 +167,7 @@
     <string name="action_start_downloading_now">Start downloading now</string>
     <string name="action_not_now">Not now</string>
     <string name="action_add_anyway">Add anyway</string>
+    <string name="action_export_to_local">Export to Local</string>
 
     <!-- Operations -->
     <string name="loading">Loading…</string>
@@ -1040,4 +1041,9 @@
     <string name="migrationListScreen.migrateDialog.cancelLabel">Cancel</string>
     <string name="migrationListScreen.progressDialog.cancelLabel">Cancel</string>
     <string name="migrationListScreen.matchWithoutChapterToast">No chapters found, this entry cannot be used for migration</string>
+
+    <!-- Export To Local -->
+    <string name="export_to_local_already_exists">The current manga has already been exported to local. Are you sure you want to export?</string>
+    <string name="export_to_local_no_downloads">The current manga has no chapters downloaded. Are you sure you want to export?</string>
+    <string name="export_to_local_success">Successfully exported to local source</string>
 </resources>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
Closes #2166 by adding an option in the manga screen toolbar to export a manga to the local source.

The issue suggests having this option in the migration menu, but I believe it makes more sense to have a dedicated option. Migration requires having a corresponding manga in the target source, whereas in this case we are essentially creating a new entry in the local source.

This feature copies every downloaded chapter of the manga, along with its cover and metadata, to the local source, without requiring the user to manually rearrange files in their file explorer.

### Images

<img width="411" height="905" alt="image" src="https://github.com/user-attachments/assets/76ce7bf9-abb2-40b3-83e1-02f3a2f0af5e" />

