### PR TITLE
Fix scrollbar not showing when animator duration scale is zero

### DIFF
--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastLastOrNull
 import androidx.compose.ui.util.fastMaxBy
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.sample
@@ -177,7 +178,8 @@ fun VerticalFastScroller(
                     .collectLatest {
                         if (thumbAllowed()) {
                             alpha.snapTo(1f)
-                            alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                            delay(ScrollBarVisibilityDurationMillis)
+                            alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         } else {
                             alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         }
@@ -366,7 +368,8 @@ fun VerticalGridFastScroller(
                     .collectLatest {
                         if (thumbAllowed()) {
                             alpha.snapTo(1f)
-                            alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                            delay(ScrollBarVisibilityDurationMillis)
+                            alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         } else {
                             alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         }
@@ -460,10 +463,7 @@ object Scroller {
 private val ThumbLength = 48.dp
 private val ThumbThickness = 12.dp
 private val ThumbShape = RoundedCornerShape(ThumbThickness / 2)
-private val FadeOutAnimationSpec = tween<Float>(
-    durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
-    delayMillis = 2000,
-)
+private val ScrollBarVisibilityDurationMillis = 2000L
 private val ImmediateFadeOutAnimationSpec = tween<Float>(
     durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
 )

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/util/Scrollbar.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/util/Scrollbar.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastSumBy
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.sample
@@ -218,7 +219,8 @@ private fun Modifier.drawScrollbar(
             .sample(100)
             .collectLatest {
                 alpha.snapTo(1f)
-                alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                delay(ScrollBarVisibilityDurationMillis)
+                alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
             }
     }
 
@@ -241,9 +243,9 @@ private fun Modifier.drawScrollbar(
         }
 }
 
-private val FadeOutAnimationSpec = tween<Float>(
+private val ScrollBarVisibilityDurationMillis = ViewConfiguration.getScrollDefaultDelay().toLong()
+private val ImmediateFadeOutAnimationSpec = tween<Float>(
     durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
-    delayMillis = ViewConfiguration.getScrollDefaultDelay(),
 )
 
 @Preview(widthDp = 400, heightDp = 400, showBackground = true)


### PR DESCRIPTION
Closes the discussion at #1385.

The scrollbar wasn't showing for users that had animations disabled. Now, the scrollbar renders unconditionally, and only its disappearance is affected by the animator duration scale. 

| Issue | Fix |
| ------- | ------- |
| <video src='https://github.com/user-attachments/assets/364dcf0e-5b33-44ef-987c-e7284b5aeb71'>) | <video src='https://github.com/user-attachments/assets/eb8b57ac-34ad-4c8b-ba05-70ed03a717b1'> |
