### PR TITLE
Fix Reader's system bars

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/PageIndicatorText.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
@@ -18,6 +19,7 @@ import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 fun PageIndicatorText(
     currentPage: Int,
     totalPages: Int,
+    modifier: Modifier = Modifier,
 ) {
     if (currentPage <= 0 || totalPages <= 0) return
 
@@ -35,6 +37,7 @@ fun PageIndicatorText(
     )
 
     Box(
+        modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -37,7 +37,6 @@ private val animationSpec = tween<IntOffset>(200)
 @Composable
 fun ReaderAppBars(
     visible: Boolean,
-    fullscreen: Boolean,
 
     mangaTitle: String?,
     chapterTitle: String?,
@@ -71,14 +70,10 @@ fun ReaderAppBars(
         .surfaceColorAtElevation(3.dp)
         .copy(alpha = if (isSystemInDarkTheme()) 0.9f else 0.95f)
 
-    val modifierWithInsetsPadding = if (fullscreen) {
-        Modifier.systemBarsPadding()
-    } else {
-        Modifier
-    }
-
     Column(
-        modifier = Modifier.fillMaxHeight(),
+        modifier = Modifier
+            .systemBarsPadding()
+            .fillMaxHeight(),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         AnimatedVisibility(
@@ -93,7 +88,7 @@ fun ReaderAppBars(
             ),
         ) {
             AppBar(
-                modifier = modifierWithInsetsPadding
+                modifier = Modifier
                     .clickable(onClick = onClickTopAppBar),
                 backgroundColor = backgroundColor,
                 title = mangaTitle,
@@ -165,7 +160,6 @@ fun ReaderAppBars(
             ),
         ) {
             Column(
-                modifier = modifierWithInsetsPadding,
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
             ) {
                 ChapterNavigator(

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -1,6 +1,8 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.view.insets.ProtectionLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/reader_protection"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <FrameLayout
         android:id="@+id/reader_container"
@@ -34,4 +36,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</FrameLayout>
+</androidx.core.view.insets.ProtectionLayout>


### PR DESCRIPTION
Fix these issues:
1. In fullscreen mode, the status bar is always transparent and hard to see
2. In non-fullscreen mode, the reader's bottom bar is hidden behind the system navigation bar
3. Also in non-fullscreen mode, the page indicator is put behind the system navigation bar

These issues happen after upgrading app to target Android SDK 35 and would affect devices running Android 15 and later.