### PR TITLE
Add vertical padding preference for fit height scale type in paged reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Added
 - Advanced setting to limit download filenames to ASCII characters. This is provided only as a workaround for OSes that do not properly handle standard Unicode filenames. This setting is generally not recommended and should only be used as a last resort ([@raxod502](https://github.com/radian-software)) ([#2305](https://github.com/mihonapp/mihon/pull/2305))
+- Add vertical padding when fit height scale type is used ([@Akylzhan](https://github.com/Akylzhan)) ([#2623](https://github.com/mihonapp/mihon/pull/2623))
 
 ### Changed
 - Delegate Suwayomi tracker authentication to extension ([@cpiber](https://github.com/cpiber)) ([#2476](https://github.com/mihonapp/mihon/pull/2476))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Added
 - Advanced setting to limit download filenames to ASCII characters. This is provided only as a workaround for OSes that do not properly handle standard Unicode filenames. This setting is generally not recommended and should only be used as a last resort ([@raxod502](https://github.com/radian-software)) ([#2305](https://github.com/mihonapp/mihon/pull/2305))
-- Add vertical padding when fit height scale type is used ([@Akylzhan](https://github.com/Akylzhan)) ([#2623](https://github.com/mihonapp/mihon/pull/2623))
+- Add vertical padding preference for fit height scale type in paged reader ([@Akylzhan](https://github.com/Akylzhan)) ([#2623](https://github.com/mihonapp/mihon/pull/2623))
 
 ### Changed
 - Delegate Suwayomi tracker authentication to extension ([@cpiber](https://github.com/cpiber)) ([#2476](https://github.com/mihonapp/mihon/pull/2476))

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -207,13 +207,13 @@ object SettingsReaderScreen : SearchableSettings {
 
         val navModePref = readerPreferences.navigationModePager()
         val imageScaleTypePref = readerPreferences.imageScaleType()
-        val imageVerticalPaddingPref = readerPreferences.imageVerticalPadding()
+        val pagedVerticalPaddingPref = readerPreferences.pagedVerticalPadding()
         val dualPageSplitPref = readerPreferences.dualPageSplitPaged()
         val rotateToFitPref = readerPreferences.dualPageRotateToFit()
 
         val navMode by navModePref.collectAsState()
         val imageScaleType by imageScaleTypePref.collectAsState()
-        val imageVerticalPadding by imageVerticalPaddingPref.collectAsState()
+        val pagedVerticalPadding by pagedVerticalPaddingPref.collectAsState()
         val dualPageSplit by dualPageSplitPref.collectAsState()
         val rotateToFit by rotateToFitPref.collectAsState()
 
@@ -250,14 +250,14 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_image_scale_type),
                 ),
                 Preference.PreferenceItem.SliderPreference(
-                    value = imageVerticalPadding,
+                    value = pagedVerticalPadding,
                     valueRange = ReaderPreferences.let {
                         it.PADDING_MIN..it.PADDING_MAX
                     },
                     title = stringResource(MR.strings.pref_vertical_padding),
-                    subtitle = numberFormat.format(imageVerticalPadding / 100f),
+                    subtitle = numberFormat.format(pagedVerticalPadding / 100f),
                     onValueChanged = {
-                        imageVerticalPaddingPref.set(it)
+                        pagedVerticalPaddingPref.set(it)
                         true
                     },
                     enabled = imageScaleType == 4

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -252,7 +252,7 @@ object SettingsReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.SliderPreference(
                     value = imageVerticalPadding,
                     valueRange = ReaderPreferences.let {
-                        it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX
+                        it.PADDING_MIN..it.PADDING_MAX
                     },
                     title = stringResource(MR.strings.pref_webtoon_side_padding),
                     subtitle = numberFormat.format(imageVerticalPadding / 100f),
@@ -356,7 +356,7 @@ object SettingsReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.SliderPreference(
                     value = webtoonSidePadding,
                     valueRange = ReaderPreferences.let {
-                        it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX
+                        it.PADDING_MIN..it.PADDING_MAX
                     },
                     title = stringResource(MR.strings.pref_webtoon_side_padding),
                     subtitle = numberFormat.format(webtoonSidePadding / 100f),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -254,7 +254,7 @@ object SettingsReaderScreen : SearchableSettings {
                     valueRange = ReaderPreferences.let {
                         it.PADDING_MIN..it.PADDING_MAX
                     },
-                    title = stringResource(MR.strings.pref_webtoon_side_padding),
+                    title = stringResource(MR.strings.pref_vertical_padding),
                     subtitle = numberFormat.format(imageVerticalPadding / 100f),
                     onValueChanged = {
                         imageVerticalPaddingPref.set(it)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -203,13 +203,17 @@ object SettingsReaderScreen : SearchableSettings {
 
     @Composable
     private fun getPagedGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
+        val numberFormat = remember { NumberFormat.getPercentInstance() }
+
         val navModePref = readerPreferences.navigationModePager()
         val imageScaleTypePref = readerPreferences.imageScaleType()
+        val imageVerticalPaddingPref = readerPreferences.imageVerticalPadding()
         val dualPageSplitPref = readerPreferences.dualPageSplitPaged()
         val rotateToFitPref = readerPreferences.dualPageRotateToFit()
 
         val navMode by navModePref.collectAsState()
         val imageScaleType by imageScaleTypePref.collectAsState()
+        val imageVerticalPadding by imageVerticalPaddingPref.collectAsState()
         val dualPageSplit by dualPageSplitPref.collectAsState()
         val rotateToFit by rotateToFitPref.collectAsState()
 
@@ -244,6 +248,19 @@ object SettingsReaderScreen : SearchableSettings {
                         .toMap()
                         .toImmutableMap(),
                     title = stringResource(MR.strings.pref_image_scale_type),
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = imageVerticalPadding,
+                    valueRange = ReaderPreferences.let {
+                        it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX
+                    },
+                    title = stringResource(MR.strings.pref_webtoon_side_padding),
+                    subtitle = numberFormat.format(imageVerticalPadding / 100f),
+                    onValueChanged = {
+                        imageVerticalPaddingPref.set(it)
+                        true
+                    },
+                    enabled = imageScaleType == 4
                 ),
                 Preference.PreferenceItem.ListPreference(
                     preference = readerPreferences.zoomStart(),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -83,6 +83,22 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         }
     }
 
+    val numberFormat = remember { NumberFormat.getPercentInstance() }
+
+    if (imageScaleType == ReaderPreferences.ImageScaleType.indexOf(MR.strings.scale_type_fit_height) + 1) {
+        val imagePadding by screenModel.preferences.imageVerticalPadding().collectAsState()
+        SliderItem(
+            value = imagePadding,
+            valueRange = ReaderPreferences.let { it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX },
+            label = stringResource(MR.strings.pref_webtoon_side_padding),
+            valueText = numberFormat.format(imagePadding / 100f),
+            onChange = {
+                screenModel.preferences.imageVerticalPadding().set(it)
+            },
+            pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        )
+    }
+
     val zoomStart by screenModel.preferences.zoomStart().collectAsState()
     SettingsChipRow(MR.strings.pref_zoom_start) {
         ReaderPreferences.ZoomStart.mapIndexed { index, it ->

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -90,7 +90,7 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         SliderItem(
             value = imagePadding,
             valueRange = ReaderPreferences.let { it.PADDING_MIN..it.PADDING_MAX },
-            label = stringResource(MR.strings.pref_webtoon_side_padding),
+            label = stringResource(MR.strings.pref_vertical_padding),
             valueText = numberFormat.format(imagePadding / 100f),
             onChange = {
                 screenModel.preferences.imageVerticalPadding().set(it)

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -89,7 +89,7 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         val imagePadding by screenModel.preferences.imageVerticalPadding().collectAsState()
         SliderItem(
             value = imagePadding,
-            valueRange = ReaderPreferences.let { it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX },
+            valueRange = ReaderPreferences.let { it.PADDING_MIN..it.PADDING_MAX },
             label = stringResource(MR.strings.pref_webtoon_side_padding),
             valueText = numberFormat.format(imagePadding / 100f),
             onChange = {
@@ -170,7 +170,7 @@ private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenM
     val webtoonSidePadding by screenModel.preferences.webtoonSidePadding().collectAsState()
     SliderItem(
         value = webtoonSidePadding,
-        valueRange = ReaderPreferences.let { it.WEBTOON_PADDING_MIN..it.WEBTOON_PADDING_MAX },
+        valueRange = ReaderPreferences.let { it.PADDING_MIN..it.PADDING_MAX },
         label = stringResource(MR.strings.pref_webtoon_side_padding),
         valueText = numberFormat.format(webtoonSidePadding / 100f),
         onChange = {

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -86,14 +86,14 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
     val numberFormat = remember { NumberFormat.getPercentInstance() }
 
     if (imageScaleType == ReaderPreferences.ImageScaleType.indexOf(MR.strings.scale_type_fit_height) + 1) {
-        val imagePadding by screenModel.preferences.imageVerticalPadding().collectAsState()
+        val imagePadding by screenModel.preferences.pagedVerticalPadding().collectAsState()
         SliderItem(
             value = imagePadding,
             valueRange = ReaderPreferences.let { it.PADDING_MIN..it.PADDING_MAX },
             label = stringResource(MR.strings.pref_vertical_padding),
             valueText = numberFormat.format(imagePadding / 100f),
             onChange = {
-                screenModel.preferences.imageVerticalPadding().set(it)
+                screenModel.preferences.pagedVerticalPadding().set(it)
             },
             pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -65,7 +65,7 @@ class ReaderPreferences(
 
     fun cropBordersWebtoon() = preferenceStore.getBoolean("crop_borders_webtoon", false)
 
-    fun webtoonSidePadding() = preferenceStore.getInt("webtoon_side_padding", WEBTOON_PADDING_MIN)
+    fun webtoonSidePadding() = preferenceStore.getInt("webtoon_side_padding", PADDING_MIN)
 
     fun readerHideThreshold() = preferenceStore.getEnum("reader_hide_threshold", ReaderHideThreshold.LOW)
 
@@ -166,8 +166,8 @@ class ReaderPreferences(
     }
 
     companion object {
-        const val WEBTOON_PADDING_MIN = 0
-        const val WEBTOON_PADDING_MAX = 25
+        const val PADDING_MIN = 0
+        const val PADDING_MAX = 25
 
         const val MILLI_CONVERSION = 100
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -49,6 +49,8 @@ class ReaderPreferences(
 
     fun imageScaleType() = preferenceStore.getInt("pref_image_scale_type_key", 1)
 
+    fun imageVerticalPadding() = preferenceStore.getInt("pref_image_vertical_padding_key", 0)
+
     fun zoomStart() = preferenceStore.getInt("pref_zoom_start_key", 1)
 
     fun readerTheme() = preferenceStore.getInt("pref_reader_theme_key", 1)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -49,7 +49,7 @@ class ReaderPreferences(
 
     fun imageScaleType() = preferenceStore.getInt("pref_image_scale_type_key", 1)
 
-    fun imageVerticalPadding() = preferenceStore.getInt("pref_image_vertical_padding_key", 0)
+    fun pagedVerticalPadding() = preferenceStore.getInt("paged_vertical_padding_key", PADDING_MIN)
 
     fun zoomStart() = preferenceStore.getInt("pref_zoom_start_key", 1)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.reader.viewer
 
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.PointF
 import android.graphics.RectF
 import android.graphics.drawable.Animatable
@@ -32,6 +33,8 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_IN_OUT_QUAD
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_OUT_QUAD
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_HEIGHT
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH
 import com.github.chrisbanes.photoview.PhotoView
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.coil.cropBorders
@@ -279,6 +282,12 @@ open class ReaderPageImageView @JvmOverloads constructor(
     ) = (pageView as? SubsamplingScaleImageView)?.apply {
         setDoubleTapZoomDuration(config.zoomDuration.getSystemScaledDuration())
         setMinimumScaleType(config.minimumScaleType)
+
+        if (config.minimumScaleType == SCALE_TYPE_FIT_HEIGHT) {
+            val padding = Resources.getSystem().displayMetrics.heightPixels * (config.verticalPadding / 100f)
+            setPaddingRelative(0, padding.toInt(), 0, padding.toInt())
+        }
+
         setMinimumDpi(1) // Just so that very small image will be fit for initial load
         setCropBorders(config.cropBorders)
         setOnImageEventListener(
@@ -418,6 +427,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     data class Config(
         val zoomDuration: Int,
         val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
+        val verticalPadding: Int = 0,
         val cropBorders: Boolean = false,
         val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
         val landscapeZoom: Boolean = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -34,7 +34,6 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_IN_OUT
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_OUT_QUAD
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_HEIGHT
-import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH
 import com.github.chrisbanes.photoview.PhotoView
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.coil.cropBorders
@@ -284,7 +283,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
         setMinimumScaleType(config.minimumScaleType)
 
         if (config.minimumScaleType == SCALE_TYPE_FIT_HEIGHT) {
-            val padding = Resources.getSystem().displayMetrics.heightPixels * (config.verticalPadding / 100f)
+            val padding = Resources.getSystem().displayMetrics.heightPixels * (config.pagedVerticalPadding / 100f)
             setPaddingRelative(0, padding.toInt(), 0, padding.toInt())
         }
 
@@ -427,7 +426,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     data class Config(
         val zoomDuration: Int,
         val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
-        val verticalPadding: Int = 0,
+        val pagedVerticalPadding: Int = 0,
         val cropBorders: Boolean = false,
         val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
         val landscapeZoom: Boolean = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -36,7 +36,7 @@ class PagerConfig(
     var imageScaleType = 1
         private set
 
-    var imageVerticalPadding = 0
+    var pagedVerticalPadding = 0
         private set
 
     var imageZoomType = ReaderPageImageView.ZoomStartPosition.LEFT
@@ -64,8 +64,8 @@ class PagerConfig(
         readerPreferences.imageScaleType()
             .register({ imageScaleType = it }, { imagePropertyChangedListener?.invoke() })
 
-        readerPreferences.imageVerticalPadding()
-            .register({ imageVerticalPadding = it }, { imagePropertyChangedListener?.invoke() })
+        readerPreferences.pagedVerticalPadding()
+            .register({ pagedVerticalPadding = it }, { imagePropertyChangedListener?.invoke() })
 
         readerPreferences.zoomStart()
             .register({ zoomTypeFromPreference(it) }, { imagePropertyChangedListener?.invoke() })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -36,6 +36,9 @@ class PagerConfig(
     var imageScaleType = 1
         private set
 
+    var imageVerticalPadding = 0
+        private set
+
     var imageZoomType = ReaderPageImageView.ZoomStartPosition.LEFT
         private set
 
@@ -60,6 +63,9 @@ class PagerConfig(
 
         readerPreferences.imageScaleType()
             .register({ imageScaleType = it }, { imagePropertyChangedListener?.invoke() })
+
+        readerPreferences.imageVerticalPadding()
+            .register({ imageVerticalPadding = it }, { imagePropertyChangedListener?.invoke() })
 
         readerPreferences.zoomStart()
             .register({ zoomTypeFromPreference(it) }, { imagePropertyChangedListener?.invoke() })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -167,6 +167,7 @@ class PagerPageHolder(
                     Config(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
                         minimumScaleType = viewer.config.imageScaleType,
+                        verticalPadding = viewer.config.imageVerticalPadding,
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -167,7 +167,7 @@ class PagerPageHolder(
                     Config(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
                         minimumScaleType = viewer.config.imageScaleType,
-                        verticalPadding = viewer.config.imageVerticalPadding,
+                        pagedVerticalPadding = viewer.config.pagedVerticalPadding,
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -464,6 +464,7 @@
     <string name="scale_type_fit_height">Fit height</string>
     <string name="scale_type_original_size">Original size</string>
     <string name="scale_type_smart_fit">Smart fit</string>
+    <string name="pref_vertical_padding">Vertical padding</string>
     <string name="pref_navigate_pan">Pan wide images</string>
     <string name="pref_landscape_zoom">Automatically zoom into wide images</string>
     <string name="pref_zoom_start">Zoom start position</string>


### PR DESCRIPTION
Closes https://github.com/mihonapp/mihon/issues/2229
Works only for "fit height" scale type

Image used:
<img width="504" height="717" alt="image_2" src="https://github.com/user-attachments/assets/b10c05b5-49da-4200-9528-a643992dd17f" />
Settings page:
<img width="1080" height="2400" alt="Screenshot_1761927691" src="https://github.com/user-attachments/assets/0239b369-c5d5-4f66-8545-063cda9f51b5" />

Padding = 0% (which is current default):
<img width="1080" height="2400" alt="Screenshot_1761927707" src="https://github.com/user-attachments/assets/ae0b144b-7439-4f04-bc67-8b1e2be8e45c" />

Padding = 10%:
<img width="1080" height="2400" alt="Screenshot_1761927731" src="https://github.com/user-attachments/assets/2c29301b-28c0-43f6-876c-a88a176f1a0a" />

