### PR TITLE
Fix horizontal zoom fling not stopping when expected

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -52,6 +52,8 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     var tapListener: ((MotionEvent) -> Unit)? = null
     var longTapListener: ((MotionEvent) -> Boolean)? = null
 
+    private var zoomFlingAnimatorSet: AnimatorSet? = null
+
     private var isManuallyScrolling = false
     private var tapDuringManualScroll = false
 
@@ -166,6 +168,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         animatorSet.duration = 400
         animatorSet.interpolator = DecelerateInterpolator()
         animatorSet.start()
+        zoomFlingAnimatorSet = animatorSet
 
         return true
     }
@@ -283,6 +286,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
                     scrollPointerId = ev.getPointerId(0)
                     downX = (ev.x + 0.5f).toInt()
                     downY = (ev.y + 0.5f).toInt()
+                    zoomFlingAnimatorSet?.cancel()
                 }
                 MotionEvent.ACTION_POINTER_DOWN -> {
                     scrollPointerId = ev.getPointerId(actionIndex)


### PR DESCRIPTION
Fixes #2621

stores the animation from zoomFling and cancels it on ACTION_DOWN 

@AntsyLich now re-checked with recent changes. issue still persisted and fix still fixes.

when I synced my fork it nuked my last pr. I really dont know my way around git, mb.