### PR TITLE
make the in‑chapter page preload amount configurable and exposes it as a user setting in the reader settings

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -170,6 +170,8 @@ object SettingsReaderScreen : SearchableSettings {
 
     @Composable
     private fun getReadingGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
+        val pagePreloadPref = readerPreferences.pagePreloadAmount()
+        val pagePreload by pagePreloadPref.collectAsState()
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_reading),
             preferenceItems = persistentListOf(
@@ -188,6 +190,13 @@ object SettingsReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.alwaysShowChapterTransition(),
                     title = stringResource(MR.strings.pref_always_show_chapter_transition),
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = pagePreload,
+                    valueRange = ReaderPreferences.PAGE_PRELOAD_MIN..ReaderPreferences.PAGE_PRELOAD_MAX,
+                    title = stringResource(MR.strings.pref_page_preload_amount),
+                    valueString = pluralStringResource(MR.plurals.pref_pages, pagePreload, pagePreload),
+                    onValueChanged = { pagePreloadPref.set(it) },
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -37,6 +37,9 @@ internal fun ColumnScope.GeneralPage(screenModel: ReaderSettingsScreenModel) {
 
     val flashPageState by screenModel.preferences.flashOnPageChange().collectAsState()
 
+    val pagePreloadPref = screenModel.preferences.pagePreloadAmount()
+    val pagePreload by pagePreloadPref.collectAsState()
+
     val flashMillisPref = screenModel.preferences.flashDurationMillis()
     val flashMillis by flashMillisPref.collectAsState()
 
@@ -92,6 +95,15 @@ internal fun ColumnScope.GeneralPage(screenModel: ReaderSettingsScreenModel) {
     CheckboxItem(
         label = stringResource(MR.strings.pref_page_transitions),
         pref = screenModel.preferences.pageTransitions(),
+    )
+
+    SliderItem(
+        value = pagePreload,
+        valueRange = ReaderPreferences.PAGE_PRELOAD_MIN..ReaderPreferences.PAGE_PRELOAD_MAX,
+        label = stringResource(MR.strings.pref_page_preload_amount),
+        valueString = pluralStringResource(MR.plurals.pref_pages, pagePreload, pagePreload),
+        onChange = { pagePreloadPref.set(it) },
+        pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
     )
 
     CheckboxItem(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -65,6 +65,11 @@ class ReaderPreferences(
 
     fun webtoonSidePadding() = preferenceStore.getInt("webtoon_side_padding", WEBTOON_PADDING_MIN)
 
+    fun pagePreloadAmount() = preferenceStore.getInt(
+        "reader_page_preload_amount",
+        PAGE_PRELOAD_DEFAULT,
+    )
+
     fun readerHideThreshold() = preferenceStore.getEnum("reader_hide_threshold", ReaderHideThreshold.LOW)
 
     fun folderPerManga() = preferenceStore.getBoolean("create_folder_per_manga", false)
@@ -166,6 +171,10 @@ class ReaderPreferences(
     companion object {
         const val WEBTOON_PADDING_MIN = 0
         const val WEBTOON_PADDING_MAX = 25
+
+        const val PAGE_PRELOAD_MIN = 0
+        const val PAGE_PRELOAD_MAX = 10
+        const val PAGE_PRELOAD_DEFAULT = 4
 
         const val MILLI_CONVERSION = 100
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -390,6 +390,7 @@
     <string name="pref_double_tap_zoom">Double tap to zoom</string>
     <string name="pref_cutout_short">Show content in cutout area</string>
     <string name="pref_page_transitions">Animate page transitions</string>
+    <string name="pref_page_preload_amount">Preload next pages</string>
     <string name="pref_flash_page">Flash on page change</string>
     <string name="pref_flash_page_summ">Reduces ghosting on e-ink displays</string>
     <string name="pref_flash_duration">Flash duration</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -102,6 +102,7 @@
 \n信任此插件即代表你愿意承担上述风险。</string>
     <string name="pref_fullscreen">全屏</string>
     <string name="pref_page_transitions">翻页动画</string>
+    <string name="pref_page_preload_amount">预载后续页数</string>
     <string name="pref_double_tap_anim_speed">双击动画速度</string>
     <string name="pref_show_page_number">显示页码</string>
     <string name="pref_crop_borders">裁剪边缘</string>

--- a/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -152,6 +152,7 @@
     <string name="download_notifier_download_paused">下載已暫停</string>
     <string name="pref_library_columns">每列數目</string>
     <string name="pref_page_transitions">翻頁轉場動畫</string>
+    <string name="pref_page_preload_amount">預載後續頁數</string>
     <string name="pref_crop_borders">邊緣裁剪</string>
     <string name="pref_color_filter_mode">濾鏡融合機制</string>
     <string name="filter_mode_overlay">覆蓋</string>


### PR DESCRIPTION
This PR makes the in‑chapter page preload amount configurable and exposes it as a user setting
  in the reader settings. Previously, HttpPageLoader always preloaded 4 pages ahead; now users can
  choose how many pages to preload, including disabling it entirely.
<img width="720" height="1280" alt="Screenshot_20251205-173015" src="https://github.com/user-attachments/assets/fa1c6e24-b92f-449c-ac81-2735ce7c1ec1" />
