### PR TITLE
Discard the volume component earlier when parsing chapter number (#2492)

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/chapter/service/ChapterRecognition.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/service/ChapterRecognition.kt
@@ -22,7 +22,13 @@ object ChapterRecognition {
      * Regex used to remove unwanted tags
      * Example Prison School 12 v.1 vol004 version1243 volume64 -R> Prison School 12
      */
-    private val unwanted = Regex("""\b(?:v|ver|vol|version|volume|season|s)[^a-z]?[0-9]+""")
+    private val unwanted = Regex("""\b(?:v|ver|version|season|s)[^a-z]?[0-9]+""")
+
+    /**
+     * Regex used to remove volume component
+     * Example Volume 10 #58: A Fierce Battle
+     */
+    private val unwantedVolume = Regex("""([Vv]ol(ume)?)[ .]?$NUMBER_PATTERN""")
 
     /**
      * Regex used to remove unwanted whitespace
@@ -49,6 +55,8 @@ object ChapterRecognition {
             .replace('-', '.')
             // Remove unwanted white spaces.
             .replace(unwantedWhiteSpace, "")
+            // Remove unwanted volume component.
+            .replace(unwantedVolume, "")
 
         val numberMatch = number.findAll(cleanChapterName)
 

--- a/domain/src/test/java/tachiyomi/domain/chapter/service/ChapterRecognitionTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/chapter/service/ChapterRecognitionTest.kt
@@ -271,6 +271,15 @@ class ChapterRecognitionTest {
         assertChapter(mangaTitle, "The 4th Night", 4.0)
     }
 
+    @Test
+    fun `Chapters in format Volume x #xx`() {
+        val mangaTitle = "...I Live as an Elf Girl's Pet"
+
+        assertChapter(mangaTitle, "Volume 10 #60 : A Visitor from the Future?", 60.0)
+        assertChapter(mangaTitle, "Volume 10 Bonus Story : Aria's Mother", -1.0)
+        assertChapter(mangaTitle, "Volume 10 #61 : The Young Girl Sets Off!", 61.0)
+    }
+
     private fun assertChapter(mangaTitle: String, name: String, expected: Double) {
         ChapterRecognition.parseChapterNumber(mangaTitle, name) shouldBe expected
     }


### PR DESCRIPTION
Now parses the chapter correctly instead of 60, 10, 61

<img width="1079" height="550" alt="image" src="https://github.com/user-attachments/assets/ffca2d5d-e84e-4777-9d26-ad60bb4874c6" />

Closes #2492