### PR TITLE
Add Select All / Deselect All button and selection count to Migration screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowForward
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.animateFloatingActionButton
@@ -65,7 +68,11 @@ data class MigrateMangaScreen(
         Scaffold(
             topBar = { scrollBehavior ->
                 AppBar(
-                    title = state.source!!.name,
+                    title = if (state.selectionMode) {
+                        "${state.selection.size} selected"
+                    } else {
+                        state.source!!.name
+                    },
                     navigateUp = {
                         if (state.selectionMode) {
                             screenModel.clearSelection()
@@ -74,6 +81,34 @@ data class MigrateMangaScreen(
                         }
                     },
                     scrollBehavior = scrollBehavior,
+                    actions = {
+                        // 🆕 Select All / Deselect All Button
+                        if (state.selectionMode && state.titles.isNotEmpty()) {
+                            val isAllSelected = state.selection.size == state.titles.size
+                            IconButton(
+                                onClick = {
+                                    if (isAllSelected) {
+                                        screenModel.clearSelection()
+                                        context.toast("Deselected all manga")
+                                    } else {
+                                        screenModel.selectAll(state.titles)
+                                        context.toast("Selected all manga")
+                                    }
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = if (isAllSelected)
+                                        Icons.Default.DoneAll
+                                    else
+                                        Icons.Default.SelectAll,
+                                    contentDescription = if (isAllSelected)
+                                        "Deselect All"
+                                    else
+                                        "Select All",
+                                )
+                            }
+                        }
+                    },
                 )
             },
             floatingActionButton = {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -71,13 +71,19 @@ class MigrateMangaScreenModel(
         mutableState.update { it.copy(selection = emptySet()) }
     }
 
+    // 🆕 Add this function for "Select All"
+    fun selectAll(mangaList: List<Manga>) {
+        mutableState.update { state ->
+            state.copy(selection = mangaList.map { it.id }.toSet())
+        }
+    }
+
     @Immutable
     data class State(
         val source: Source? = null,
         val selection: Set<Long> = emptySet(),
         private val titleList: ImmutableList<Manga>? = null,
     ) {
-
         val titles: ImmutableList<Manga>
             get() = titleList ?: persistentListOf()
 
@@ -87,7 +93,8 @@ class MigrateMangaScreenModel(
         val isEmpty: Boolean
             get() = titles.isEmpty()
 
-        val selectionMode = selection.isNotEmpty()
+        val selectionMode: Boolean
+            get() = selection.isNotEmpty()
     }
 }
 


### PR DESCRIPTION
This PR adds a Select All / Deselect All button in the migration screen AppBar 
and updates the title to show how many manga are selected.
