### PR TITLE
Improves the user experience when viewing entries from the local source

### DIFF
--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -83,7 +83,7 @@ actual class LocalSource(
             0L
         }
 
-        var mangaDirs = fileSystem.getFilesInBaseDirectory()
+        var allMangaDirs = fileSystem.getFilesInBaseDirectory()
             // Filter out files that are hidden and is not a folder
             .filter { it.isDirectory && !it.name.orEmpty().startsWith('.') }
             .distinctBy { it.name }
@@ -95,7 +95,9 @@ actual class LocalSource(
                 } else {
                     it.lastModified() >= lastModifiedLimit
                 }
-            }
+            }.chunked(MANGA_PER_PAGE)
+
+        var mangaDirs = allMangaDirs.getOrElse(page - 1) { emptyList() }
 
         filters.forEach { filter ->
             when (filter) {
@@ -135,7 +137,7 @@ actual class LocalSource(
             }
             .awaitAll()
 
-        MangasPage(mangas, false)
+        MangasPage(mangas, allMangaDirs.getOrNull(page) != null)
     }
 
     // Manga details related
@@ -364,6 +366,7 @@ actual class LocalSource(
     companion object {
         const val ID = 0L
         const val HELP_URL = "https://mihon.app/docs/guides/local-source/"
+        const val MANGA_PER_PAGE = 15
 
         private val LATEST_THRESHOLD = 7.days.inWholeMilliseconds
     }


### PR DESCRIPTION
When viewing entries from local source, the entire directory is loaded, which means users with large local sources experience a very slow initial view. The goal, therefore, is to use the pagination feature, which is currently underutilized in local source

Port of https://github.com/aniyomiorg/aniyomi/pull/2264

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
