### PR TITLE
Fix nullability of MAL authors breaking search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALManga.kt
@@ -18,7 +18,7 @@ data class MALManga(
     val mediaType: String,
     @SerialName("start_date")
     val startDate: String?,
-    val authors: List<MALAuthorNode>,
+    val authors: List<MALAuthorNode> = emptyList(),
 )
 
 @Serializable


### PR DESCRIPTION
One of these days I'll get through a tracker change without nullability problems...

Found this issue because https://myanimelist.net/manga/158061 was in the search results and it does, in fact, not have any associated authorship information. MAL leaves out the entire attribute from the response, but setting an empty list as the default fixes this for our purposes.
