### PR TITLE
Fix Migrate Manga dialog won't show the second time

### DIFF
--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -150,6 +150,7 @@ private class MigrateDialogScreenModel(
                 target = target,
                 applicableFlags = applicableFlags,
                 selectedFlags = selectedFlags,
+                isMigrated = false,
             )
         }
     }


### PR DESCRIPTION
**Reproduce**
1. Add 2 entries from 1 source
2. Browse another source, tap & hold to favorite to migrate the same 2 entries
3. The second time tap & hold & migrate, it won't show the migrate manga dialog