### PR TITLE
Avoid recreate resetJob on recompose

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -94,7 +94,7 @@ fun MangaBottomActionMenu(
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                (0..<7).forEach { i -> confirm[i] = i == toConfirmIndex }
+                confirm.indices.forEach { i -> confirm[i] = i == toConfirmIndex }
                 resetJob?.cancel()
                 resetJob = scope.launch {
                     delay(1.seconds)
@@ -255,7 +255,7 @@ fun LibraryBottomActionMenu(
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                (0..5).forEach { i -> confirm[i] = i == toConfirmIndex }
+                confirm.indices.forEach { i -> confirm[i] = i == toConfirmIndex }
                 resetJob?.cancel()
                 resetJob = scope.launch {
                     delay(1.seconds)


### PR DESCRIPTION
The `resetJob` handling with `remember` won’t persist correctly across recompositions and may not cancel the previous job as intended.

`var resetJob: Job? = remember { null }` behaves the same as `var resetJob: Job? = null` on each recomposition, so the job reference isn’t kept in composition and previously launched jobs may not be cancellable after recomposition.