### PR TITLE
Add "src:" prefix to search by source ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Automatically remove downloads on Suwayomi after reading, configurable via extension settings ([@cpiber](https://github.com/cpiber)) ([#2673](https://github.com/mihonapp/mihon/pull/2673))
 - Display author & artist name in MAL search results ([@MajorTanya](https://github.com/MajorTanya)) ([#2833](https://github.com/mihonapp/mihon/pull/2833))
 - Add filter options to Updates tab ([@MajorTanya](https://github.com/MajorTanya)) ([#2851](https://github.com/mihonapp/mihon/pull/2851))
+- Add `src:` prefix to search the library by source ID ([@MajorTanya](https://github.com/MajorTanya)) ([#2927](https://github.com/mihonapp/mihon/pull/2927))
 
 ### Improved
 - Minimize memory usage by reducing in-memory cover cache size ([@Lolle2000la](https://github.com/Lolle2000la)) ([#2266](https://github.com/mihonapp/mihon/pull/2266))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -23,9 +23,12 @@ data class LibraryItem(
      * @return true if the manga matches the query, false otherwise.
      */
     fun matches(constraint: String): Boolean {
-        val sourceName by lazy { sourceManager.getOrStub(libraryManga.manga.source).getNameForMangaInfo() }
+        val source = sourceManager.getOrStub(libraryManga.manga.source)
+        val sourceName by lazy { source.getNameForMangaInfo() }
         if (constraint.startsWith("id:", true)) {
             return id == constraint.substringAfter("id:").toLongOrNull()
+        } else if (constraint.startsWith("src:", true)) {
+            return source.id == constraint.substringAfter("src:").toLongOrNull()
         }
         return libraryManga.manga.title.contains(constraint, true) ||
             (libraryManga.manga.author?.contains(constraint, true) ?: false) ||


### PR DESCRIPTION
Allows users to search for the exact source ID in their library.

Similar to the Browse > Migrate screen, but filtered in the Library, where users can take all the usual actions.

Could be used in the future to change the search behaviour of tapping the source name in the title info view to search by the ID with this prefix.

### Images
| Unfiltered | Search with extension name | Search with `ext:` + source ID |
|-|-|-|
| <img width="407" height="317" alt="image" src="https://github.com/user-attachments/assets/3c662c45-87ce-4b1f-b4d9-6180aa0ffb22" /> | <img width="419" height="324" alt="image" src="https://github.com/user-attachments/assets/830f312f-acad-4de9-87d1-2ef8693db353" /><br>(two of them are from a different language source which is why they show up) | <img width="418" height="216" alt="image" src="https://github.com/user-attachments/assets/8a4b05a5-0665-4ca8-ba87-02f2e5775ea2" /> |

This has the (unintended but also convenient) side effect of allowing to filter for Local Source:
<img width="406" height="204" alt="image" src="https://github.com/user-attachments/assets/da4b3566-9407-4e6a-8a2d-f0431e640d0e" />

(I added this title after the previous screenshots to test stuff)

## Questions
- Should `src:local` be a hardcoded alias for `src:0`?