### PR TITLE
Allow LibraryUpdateJob to run with VPN (#2477)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -436,6 +436,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                     NetworkType.CONNECTED
                 }
                 val networkRequestBuilder = NetworkRequest.Builder()
+                networkRequestBuilder.removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
                 if (DEVICE_ONLY_ON_WIFI in restrictions) {
                     networkRequestBuilder.addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
                 }


### PR DESCRIPTION
Hello,

To fix #2477, I took the least intrusive change because all other default capabilities might make sense to have (like BANDWIDTH_CONSTRAINED).

I also need some help testing the change (I never got around to installing any tooling for android)

The fix seems easy and I hope testing does not reveal some more complex mechanism I did not see, because otherwise I cannot promise a follow-up on this issue.

Again any help welcomed, I did not realise so much months passed since I last looked at this issue.