### PR TITLE
Created a feature that displays the chapter's list with a long press …

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -54,6 +54,7 @@ fun MangaChapterListItem(
     read: Boolean,
     bookmark: Boolean,
     selected: Boolean,
+    showDownloadIndicator: Boolean = true,
     downloadIndicatorEnabled: Boolean,
     downloadStateProvider: () -> Download.State,
     downloadProgressProvider: () -> Int,
@@ -171,13 +172,15 @@ fun MangaChapterListItem(
                 }
             }
 
-            ChapterDownloadIndicator(
-                enabled = downloadIndicatorEnabled,
-                modifier = Modifier.padding(start = 4.dp),
-                downloadStateProvider = downloadStateProvider,
-                downloadProgressProvider = downloadProgressProvider,
-                onClick = { onDownloadClick?.invoke(it) },
-            )
+            if (showDownloadIndicator) {
+                ChapterDownloadIndicator(
+                    enabled = downloadIndicatorEnabled,
+                    modifier = Modifier.padding(start = 4.dp),
+                    downloadStateProvider = downloadStateProvider,
+                    downloadProgressProvider = downloadProgressProvider,
+                    onClick = { onDownloadClick?.invoke(it) },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/reader/ChapterNavigationDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ChapterNavigationDialog.kt
@@ -1,0 +1,118 @@
+package eu.kanade.presentation.reader
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.components.AdaptiveSheet
+import eu.kanade.presentation.components.relativeDateText
+import eu.kanade.presentation.manga.components.MangaChapterListItem
+import eu.kanade.presentation.util.formatChapterNumber
+import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.ui.reader.ReaderViewModel
+import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import kotlin.math.abs
+
+@Composable
+fun ChapterNavigationDialog(
+    chapters: List<ReaderViewModel.ChapterNavigationItem>,
+    direction: ReaderViewModel.ChapterNavigationDirection,
+    mangaDisplayMode: Long,
+    currentChapterNumber: Double?,
+    onDismissRequest: () -> Unit,
+    onChapterClick: (Long) -> Unit,
+) {
+    AdaptiveSheet(onDismissRequest = onDismissRequest) {
+        BoxWithConstraints {
+            val title = stringResource(
+                when (direction) {
+                    ReaderViewModel.ChapterNavigationDirection.Previous -> MR.strings.label_previous_chapters
+                    ReaderViewModel.ChapterNavigationDirection.Next -> MR.strings.label_next_chapters
+                },
+            )
+            val initialItemIndex = remember(chapters, currentChapterNumber) {
+                if (chapters.isEmpty() || currentChapterNumber == null) {
+                    0
+                } else {
+                    chapters.indices.minByOrNull { index ->
+                        abs(chapters[index].chapter.chapterNumber - currentChapterNumber)
+                    } ?: 0
+                }
+            }
+            val listState = rememberLazyListState(
+                initialFirstVisibleItemIndex = initialItemIndex,
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxHeight * 0.75f),
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+
+                LazyColumn(
+                    state = listState,
+                ) {
+                    items(
+                        items = chapters,
+                        key = { it.chapter.id },
+                    ) { chapterItem ->
+                        val chapter = chapterItem.chapter
+                        MangaChapterListItem(
+                            title = if (mangaDisplayMode == Manga.CHAPTER_DISPLAY_NUMBER) {
+                                stringResource(
+                                    MR.strings.display_mode_chapter,
+                                    formatChapterNumber(chapter.chapterNumber),
+                                )
+                            } else {
+                                chapter.name
+                            },
+                            date = relativeDateText(chapter.dateUpload),
+                            readProgress = chapter.lastPageRead
+                                .takeIf { !chapter.read && it > 0L }
+                                ?.let {
+                                    stringResource(
+                                        MR.strings.chapter_progress,
+                                        it + 1,
+                                    )
+                                },
+                            scanlator = chapter.scanlator.takeIf { !it.isNullOrBlank() },
+                            read = chapter.read,
+                            bookmark = chapter.bookmark,
+                            selected = false,
+                            showDownloadIndicator = chapterItem.downloadState == Download.State.DOWNLOADED ||
+                                chapterItem.downloadState == Download.State.QUEUE ||
+                                chapterItem.downloadState == Download.State.DOWNLOADING,
+                            downloadIndicatorEnabled = false,
+                            downloadStateProvider = { chapterItem.downloadState },
+                            downloadProgressProvider = { chapterItem.downloadProgress },
+                            chapterSwipeStartAction = LibraryPreferences.ChapterSwipeAction.Disabled,
+                            chapterSwipeEndAction = LibraryPreferences.ChapterSwipeAction.Disabled,
+                            onLongClick = {},
+                            onClick = { onChapterClick(chapter.id) },
+                            onDownloadClick = null,
+                            onChapterSwipe = {},
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -50,8 +50,10 @@ fun ReaderAppBars(
 
     viewer: Viewer?,
     onNextChapter: () -> Unit,
+    onNextChapterLongClick: () -> Unit,
     enabledNext: Boolean,
     onPreviousChapter: () -> Unit,
+    onPreviousChapterLongClick: () -> Unit,
     enabledPrevious: Boolean,
     currentPage: Int,
     totalPages: Int,
@@ -106,8 +108,10 @@ fun ReaderAppBars(
                 ChapterNavigator(
                     isRtl = isRtl,
                     onNextChapter = onNextChapter,
+                    onNextChapterLongClick = onNextChapterLongClick,
                     enabledNext = enabledNext,
                     onPreviousChapter = onPreviousChapter,
+                    onPreviousChapterLongClick = onPreviousChapterLongClick,
                     enabledPrevious = enabledPrevious,
                     currentPage = currentPage,
                     totalPages = totalPages,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -103,6 +103,8 @@
     <string name="action_pause">Pause</string>
     <string name="action_previous_chapter">Previous chapter</string>
     <string name="action_next_chapter">Next chapter</string>
+    <string name="label_previous_chapters">Previous chapters</string>
+    <string name="label_next_chapters">Next chapters</string>
     <string name="action_retry">Retry</string>
     <string name="action_remove">Remove</string>
     <string name="action_remove_everything">Remove everything</string>


### PR DESCRIPTION
This adds a feature that will display the chapter's list when long pressing a navigation button.

Quick notes :
- Haptic feedback is included, couldn't try it on device though but i tried to compare debugs with haptic feedback elsewhere and it showed no issues with it.
- "FilledIconButton" was replaced in "ChapterNavigator.kt" because no onLongClick was present.
- Removing the download buttons was a bit of a necessity, because i for some reasons could not get the download icons to do anything at all, they would just exist and i would not be able to interact with them, so i've simply removed them altogether.
- I tried to add a scroll bar for better UX, but it would go out of bounds so i gave up.
- List uses user's sorting and naming configurations.


https://github.com/user-attachments/assets/cb1fde44-c15c-44db-bf45-b514142538aa

