### PR TITLE
Feat: add option to hide or show only sub-chapters

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/model/ChapterFilter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/ChapterFilter.kt
@@ -8,7 +8,6 @@ import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.source.local.isLocal
-import kotlin.math.floor
 
 /**
  * Applies the view filters to the list of chapters obtained from the database.
@@ -36,11 +35,7 @@ fun List<Chapter>.applyFilters(manga: Manga, downloadManager: DownloadManager): 
                 downloaded || isLocalManga
             }
         }
-        .filter { chapter ->
-            applyFilter(subChapterFilter) {
-                chapter.chapterNumber >= 0 && chapter.chapterNumber != floor(chapter.chapterNumber)
-            }
-        }
+        .filter { chapter -> applyFilter(subChapterFilter) { chapter.isSubChapter } }
         .sortedWith(getChapterSort(manga)).toList()
 }
 
@@ -58,10 +53,6 @@ fun List<ChapterList.Item>.applyFilters(manga: Manga): Sequence<ChapterList.Item
         .filter { (chapter) -> applyFilter(unreadFilter) { !chapter.read } }
         .filter { (chapter) -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
         .filter { applyFilter(downloadedFilter) { it.isDownloaded || isLocalManga } }
-        .filter { (chapter) ->
-            applyFilter(subChapterFilter) {
-                chapter.chapterNumber >= 0 && chapter.chapterNumber != floor(chapter.chapterNumber)
-            }
-        }
+        .filter { (chapter) -> applyFilter(subChapterFilter) { chapter.isSubChapter } }
         .sortedWith { (chapter1), (chapter2) -> getChapterSort(manga).invoke(chapter1, chapter2) }
 }

--- a/app/src/main/java/eu/kanade/domain/chapter/model/ChapterFilter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/ChapterFilter.kt
@@ -8,6 +8,7 @@ import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.source.local.isLocal
+import kotlin.math.floor
 
 /**
  * Applies the view filters to the list of chapters obtained from the database.
@@ -18,8 +19,10 @@ fun List<Chapter>.applyFilters(manga: Manga, downloadManager: DownloadManager): 
     val unreadFilter = manga.unreadFilter
     val downloadedFilter = manga.downloadedFilter
     val bookmarkedFilter = manga.bookmarkedFilter
+    val subChapterFilter = manga.subChapterFilter
 
-    return filter { chapter -> applyFilter(unreadFilter) { !chapter.read } }
+    return asSequence()
+        .filter { chapter -> applyFilter(unreadFilter) { !chapter.read } }
         .filter { chapter -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
         .filter { chapter ->
             applyFilter(downloadedFilter) {
@@ -33,7 +36,12 @@ fun List<Chapter>.applyFilters(manga: Manga, downloadManager: DownloadManager): 
                 downloaded || isLocalManga
             }
         }
-        .sortedWith(getChapterSort(manga))
+        .filter { chapter ->
+            applyFilter(subChapterFilter) {
+                chapter.chapterNumber >= 0 && chapter.chapterNumber != floor(chapter.chapterNumber)
+            }
+        }
+        .sortedWith(getChapterSort(manga)).toList()
 }
 
 /**
@@ -45,9 +53,15 @@ fun List<ChapterList.Item>.applyFilters(manga: Manga): Sequence<ChapterList.Item
     val unreadFilter = manga.unreadFilter
     val downloadedFilter = manga.downloadedFilter
     val bookmarkedFilter = manga.bookmarkedFilter
+    val subChapterFilter = manga.subChapterFilter
     return asSequence()
         .filter { (chapter) -> applyFilter(unreadFilter) { !chapter.read } }
         .filter { (chapter) -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
         .filter { applyFilter(downloadedFilter) { it.isDownloaded || isLocalManga } }
+        .filter { (chapter) ->
+            applyFilter(subChapterFilter) {
+                chapter.chapterNumber >= 0 && chapter.chapterNumber != floor(chapter.chapterNumber)
+            }
+        }
         .sortedWith { (chapter1), (chapter2) -> getChapterSort(manga).invoke(chapter1, chapter2) }
 }

--- a/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/model/Manga.kt
@@ -32,7 +32,8 @@ val Manga.downloadedFilter: TriState
 fun Manga.chaptersFiltered(): Boolean {
     return unreadFilter != TriState.DISABLED ||
         downloadedFilter != TriState.DISABLED ||
-        bookmarkedFilter != TriState.DISABLED
+        bookmarkedFilter != TriState.DISABLED ||
+        subChapterFilter != TriState.DISABLED
 }
 
 fun Manga.toSManga(): SManga = SManga.create().also {

--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -51,6 +51,7 @@ fun ChapterSettingsDialog(
     onDownloadFilterChanged: (TriState) -> Unit,
     onUnreadFilterChanged: (TriState) -> Unit,
     onBookmarkedFilterChanged: (TriState) -> Unit,
+    onSubChapterFilterChanged: (TriState) -> Unit,
     scanlatorFilterActive: Boolean,
     onScanlatorFilterClicked: (() -> Unit),
     onSortModeChanged: (Long) -> Unit,
@@ -107,6 +108,8 @@ fun ChapterSettingsDialog(
                         onUnreadFilterChanged = onUnreadFilterChanged,
                         bookmarkedFilter = manga?.bookmarkedFilter ?: TriState.DISABLED,
                         onBookmarkedFilterChanged = onBookmarkedFilterChanged,
+                        subChapterFilter = manga?.subChapterFilter ?: TriState.DISABLED,
+                        onSubChapterFilterChanged = onSubChapterFilterChanged,
                         scanlatorFilterActive = scanlatorFilterActive,
                         onScanlatorFilterClicked = onScanlatorFilterClicked,
                     )
@@ -137,6 +140,8 @@ private fun ColumnScope.FilterPage(
     onUnreadFilterChanged: (TriState) -> Unit,
     bookmarkedFilter: TriState,
     onBookmarkedFilterChanged: (TriState) -> Unit,
+    subChapterFilter: TriState,
+    onSubChapterFilterChanged: (TriState) -> Unit,
     scanlatorFilterActive: Boolean,
     onScanlatorFilterClicked: (() -> Unit),
 ) {
@@ -154,6 +159,11 @@ private fun ColumnScope.FilterPage(
         label = stringResource(MR.strings.action_filter_bookmarked),
         state = bookmarkedFilter,
         onClick = onBookmarkedFilterChanged,
+    )
+    TriStateItem(
+        label = stringResource(MR.strings.action_filter_sub_chapter),
+        state = subChapterFilter,
+        onClick = onSubChapterFilterChanged,
     )
     ScanlatorFilterItem(
         active = scanlatorFilterActive,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -222,6 +222,7 @@ class MangaScreen(
                 onDownloadFilterChanged = screenModel::setDownloadedFilter,
                 onUnreadFilterChanged = screenModel::setUnreadFilter,
                 onBookmarkedFilterChanged = screenModel::setBookmarkedFilter,
+                onSubChapterFilterChanged = screenModel::setSubChapterFilter,
                 onSortModeChanged = screenModel::setSorting,
                 onDisplayModeChanged = screenModel::setDisplayMode,
                 onSetAsDefault = screenModel::setCurrentSettingsAsDefault,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -917,6 +917,24 @@ class MangaScreenModel(
     }
 
     /**
+     * Sets the sub-chapter filter and requests an UI update.
+     * @param state whether to display only sub-chapters or only whole chapters or all chapters.
+     */
+    fun setSubChapterFilter(state: TriState) {
+        val manga = successState?.manga ?: return
+
+        val flag = when (state) {
+            TriState.DISABLED -> Manga.SHOW_ALL
+            TriState.ENABLED_IS -> Manga.CHAPTER_SHOW_SUB_CHAPTER
+            TriState.ENABLED_NOT -> Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER
+        }
+
+        screenModelScope.launchNonCancellable {
+            setMangaChapterFlags.awaitSetSubChapterFilter(manga, flag)
+        }
+    }
+
+    /**
      * Sets the active display mode.
      * @param mode the mode to set.
      */
@@ -1196,10 +1214,17 @@ class MangaScreenModel(
                 val unreadFilter = manga.unreadFilter
                 val downloadedFilter = manga.downloadedFilter
                 val bookmarkedFilter = manga.bookmarkedFilter
+                val subChapterFilter = manga.subChapterFilter
                 return asSequence()
                     .filter { (chapter) -> applyFilter(unreadFilter) { !chapter.read } }
                     .filter { (chapter) -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
                     .filter { applyFilter(downloadedFilter) { it.isDownloaded || isLocalManga } }
+                    .filter { (chapter) ->
+                        applyFilter(subChapterFilter) {
+                            chapter.chapterNumber >= 0 &&
+                                chapter.chapterNumber != floor(chapter.chapterNumber)
+                        }
+                    }
                     .sortedWith { (chapter1), (chapter2) -> getChapterSort(manga).invoke(chapter1, chapter2) }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1220,10 +1220,7 @@ class MangaScreenModel(
                     .filter { (chapter) -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
                     .filter { applyFilter(downloadedFilter) { it.isDownloaded || isLocalManga } }
                     .filter { (chapter) ->
-                        applyFilter(subChapterFilter) {
-                            chapter.chapterNumber >= 0 &&
-                                chapter.chapterNumber != floor(chapter.chapterNumber)
-                        }
+                        applyFilter(subChapterFilter) { chapter.isSubChapter }
                     }
                     .sortedWith { (chapter1), (chapter2) -> getChapterSort(manga).invoke(chapter1, chapter2) }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -198,20 +198,8 @@ class ReaderViewModel @JvmOverloads constructor(
                                     ) ||
                                 (manga.bookmarkedFilterRaw == Manga.CHAPTER_SHOW_BOOKMARKED && !it.bookmark) ||
                                 (manga.bookmarkedFilterRaw == Manga.CHAPTER_SHOW_NOT_BOOKMARKED && it.bookmark) ||
-                                (
-                                    manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_SUB_CHAPTER &&
-                                        !(
-                                            it.chapterNumber >= 0 &&
-                                                it.chapterNumber != kotlin.math.floor(it.chapterNumber)
-                                            )
-                                    ) ||
-                                (
-                                    manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER &&
-                                        (
-                                            it.chapterNumber >= 0 &&
-                                                it.chapterNumber != kotlin.math.floor(it.chapterNumber)
-                                            )
-                                    )
+                                (manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_SUB_CHAPTER && !it.isSubChapter) ||
+                                (manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER && it.isSubChapter)
                         }
                         else -> false
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -197,7 +197,21 @@ class ReaderViewModel @JvmOverloads constructor(
                                         )
                                     ) ||
                                 (manga.bookmarkedFilterRaw == Manga.CHAPTER_SHOW_BOOKMARKED && !it.bookmark) ||
-                                (manga.bookmarkedFilterRaw == Manga.CHAPTER_SHOW_NOT_BOOKMARKED && it.bookmark)
+                                (manga.bookmarkedFilterRaw == Manga.CHAPTER_SHOW_NOT_BOOKMARKED && it.bookmark) ||
+                                (
+                                    manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_SUB_CHAPTER &&
+                                        !(
+                                            it.chapterNumber >= 0 &&
+                                                it.chapterNumber != kotlin.math.floor(it.chapterNumber)
+                                            )
+                                    ) ||
+                                (
+                                    manga.subChapterFilterRaw == Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER &&
+                                        (
+                                            it.chapterNumber >= 0 &&
+                                                it.chapterNumber != kotlin.math.floor(it.chapterNumber)
+                                            )
+                                    )
                         }
                         else -> false
                     }

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/SetMangaDefaultChapterFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/SetMangaDefaultChapterFlags.kt
@@ -20,6 +20,7 @@ class SetMangaDefaultChapterFlags(
                     unreadFilter = filterChapterByRead().get(),
                     downloadedFilter = filterChapterByDownloaded().get(),
                     bookmarkedFilter = filterChapterByBookmarked().get(),
+                    subChapterFilter = filterChapterBySubChapter().get(),
                     sortingMode = sortChapterBySourceOrNumber().get(),
                     sortingDirection = sortChapterByAscendingOrDescending().get(),
                     displayMode = displayChapterByNameOrNumber().get(),

--- a/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/model/Chapter.kt
@@ -1,5 +1,7 @@
 package tachiyomi.domain.chapter.model
 
+import kotlin.math.floor
+
 data class Chapter(
     val id: Long,
     val mangaId: Long,
@@ -18,6 +20,9 @@ data class Chapter(
 ) {
     val isRecognizedNumber: Boolean
         get() = chapterNumber >= 0f
+
+    val isSubChapter: Boolean
+        get() = isRecognizedNumber && chapterNumber != floor(chapterNumber)
 
     fun copyFrom(other: Chapter): Chapter {
         return copy(

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -146,6 +146,11 @@ class LibraryPreferences(
         Manga.SHOW_ALL,
     )
 
+    fun filterChapterBySubChapter() = preferenceStore.getLong(
+        "default_chapter_filter_by_sub_chapter",
+        Manga.SHOW_ALL,
+    )
+
     // and upload date
     fun sortChapterBySourceOrNumber() = preferenceStore.getLong(
         "default_chapter_sort_by_source_or_number",
@@ -166,6 +171,7 @@ class LibraryPreferences(
         filterChapterByRead().set(manga.unreadFilterRaw)
         filterChapterByDownloaded().set(manga.downloadedFilterRaw)
         filterChapterByBookmarked().set(manga.bookmarkedFilterRaw)
+        filterChapterBySubChapter().set(manga.subChapterFilterRaw)
         sortChapterBySourceOrNumber().set(manga.sorting)
         displayChapterByNameOrNumber().set(manga.displayMode)
         sortChapterByAscendingOrDescending().set(

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/SetMangaChapterFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/SetMangaChapterFlags.kt
@@ -35,6 +35,15 @@ class SetMangaChapterFlags(
         )
     }
 
+    suspend fun awaitSetSubChapterFilter(manga: Manga, flag: Long): Boolean {
+        return mangaRepository.update(
+            MangaUpdate(
+                id = manga.id,
+                chapterFlags = manga.chapterFlags.setFlag(flag, Manga.CHAPTER_SUB_CHAPTER_MASK),
+            ),
+        )
+    }
+
     suspend fun awaitSetDisplayMode(manga: Manga, flag: Long): Boolean {
         return mangaRepository.update(
             MangaUpdate(
@@ -74,6 +83,7 @@ class SetMangaChapterFlags(
         unreadFilter: Long,
         downloadedFilter: Long,
         bookmarkedFilter: Long,
+        subChapterFilter: Long,
         sortingMode: Long,
         sortingDirection: Long,
         displayMode: Long,
@@ -84,6 +94,7 @@ class SetMangaChapterFlags(
                 chapterFlags = 0L.setFlag(unreadFilter, Manga.CHAPTER_UNREAD_MASK)
                     .setFlag(downloadedFilter, Manga.CHAPTER_DOWNLOADED_MASK)
                     .setFlag(bookmarkedFilter, Manga.CHAPTER_BOOKMARKED_MASK)
+                    .setFlag(subChapterFilter, Manga.CHAPTER_SUB_CHAPTER_MASK)
                     .setFlag(sortingMode, Manga.CHAPTER_SORTING_MASK)
                     .setFlag(sortingDirection, Manga.CHAPTER_SORT_DIR_MASK)
                     .setFlag(displayMode, Manga.CHAPTER_DISPLAY_MASK),

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -55,6 +55,9 @@ data class Manga(
     val bookmarkedFilterRaw: Long
         get() = chapterFlags and CHAPTER_BOOKMARKED_MASK
 
+    val subChapterFilterRaw: Long
+        get() = chapterFlags and CHAPTER_SUB_CHAPTER_MASK
+
     val unreadFilter: TriState
         get() = when (unreadFilterRaw) {
             CHAPTER_SHOW_UNREAD -> TriState.ENABLED_IS
@@ -66,6 +69,13 @@ data class Manga(
         get() = when (bookmarkedFilterRaw) {
             CHAPTER_SHOW_BOOKMARKED -> TriState.ENABLED_IS
             CHAPTER_SHOW_NOT_BOOKMARKED -> TriState.ENABLED_NOT
+            else -> TriState.DISABLED
+        }
+
+    val subChapterFilter: TriState
+        get() = when (subChapterFilterRaw) {
+            CHAPTER_SHOW_SUB_CHAPTER -> TriState.ENABLED_IS
+            CHAPTER_SHOW_NOT_SUB_CHAPTER -> TriState.ENABLED_NOT
             else -> TriState.DISABLED
         }
 
@@ -92,6 +102,10 @@ data class Manga(
         const val CHAPTER_SHOW_BOOKMARKED = 0x00000020L
         const val CHAPTER_SHOW_NOT_BOOKMARKED = 0x00000040L
         const val CHAPTER_BOOKMARKED_MASK = 0x00000060L
+
+        const val CHAPTER_SHOW_SUB_CHAPTER = 0x00000400L
+        const val CHAPTER_SHOW_NOT_SUB_CHAPTER = 0x00000800L
+        const val CHAPTER_SUB_CHAPTER_MASK = 0x00000C00L
 
         const val CHAPTER_SORTING_SOURCE = 0x00000000L
         const val CHAPTER_SORTING_NUMBER = 0x00000100L

--- a/domain/src/test/java/tachiyomi/domain/manga/model/MangaChapterFlagsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/model/MangaChapterFlagsTest.kt
@@ -1,60 +1,254 @@
 package tachiyomi.domain.manga.model
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import tachiyomi.core.common.preference.TriState
 
 class MangaChapterFlagsTest {
 
-    @Test
-    fun `Sub-chapter mask does not overlap with other masks`() {
-        val otherMasks = listOf(
-            Manga.CHAPTER_SORT_DIR_MASK,
-            Manga.CHAPTER_UNREAD_MASK,
-            Manga.CHAPTER_DOWNLOADED_MASK,
-            Manga.CHAPTER_BOOKMARKED_MASK,
-            Manga.CHAPTER_SORTING_MASK,
-            Manga.CHAPTER_DISPLAY_MASK,
-        )
-        for (mask in otherMasks) {
-            Manga.CHAPTER_SUB_CHAPTER_MASK and mask shouldBe 0L
+    private fun manga(flags: Long = 0L) = Manga.create().copy(chapterFlags = flags)
+
+    @Nested
+    inner class MaskOverlap {
+
+        @Test
+        fun `All masks are non-overlapping`() {
+            val masks = listOf(
+                Manga.CHAPTER_SORT_DIR_MASK,
+                Manga.CHAPTER_UNREAD_MASK,
+                Manga.CHAPTER_DOWNLOADED_MASK,
+                Manga.CHAPTER_BOOKMARKED_MASK,
+                Manga.CHAPTER_SORTING_MASK,
+                Manga.CHAPTER_SUB_CHAPTER_MASK,
+                Manga.CHAPTER_DISPLAY_MASK,
+            )
+            for (i in masks.indices) {
+                for (j in i + 1 until masks.size) {
+                    (masks[i] and masks[j]) shouldBe 0L
+                }
+            }
+        }
+
+        @Test
+        fun `SHOW_ALL is zero`() {
+            Manga.SHOW_ALL shouldBe 0L
         }
     }
 
-    @Test
-    fun `subChapterFilter returns DISABLED when flags are zero`() {
-        val manga = Manga.create().copy(chapterFlags = Manga.SHOW_ALL)
-        manga.subChapterFilter shouldBe TriState.DISABLED
+    @Nested
+    inner class SortDirection {
+
+        @Test
+        fun `Default flags give descending sort`() {
+            manga(Manga.CHAPTER_SORT_DESC).sortDescending() shouldBe true
+        }
+
+        @Test
+        fun `ASC flag gives ascending sort`() {
+            manga(Manga.CHAPTER_SORT_ASC).sortDescending() shouldBe false
+        }
+
+        @Test
+        fun `Sort direction is isolated from other flags`() {
+            val flags = Manga.CHAPTER_SORT_ASC or Manga.CHAPTER_SHOW_UNREAD or Manga.CHAPTER_SORTING_NUMBER
+            manga(flags).sortDescending() shouldBe false
+        }
     }
 
-    @Test
-    fun `subChapterFilter returns ENABLED_IS when CHAPTER_SHOW_SUB_CHAPTER is set`() {
-        val manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_SUB_CHAPTER)
-        manga.subChapterFilter shouldBe TriState.ENABLED_IS
+    @Nested
+    inner class UnreadFilter {
+
+        @Test
+        fun `Default is DISABLED`() {
+            manga().unreadFilter shouldBe TriState.DISABLED
+        }
+
+        @Test
+        fun `SHOW_UNREAD maps to ENABLED_IS`() {
+            manga(Manga.CHAPTER_SHOW_UNREAD).unreadFilter shouldBe TriState.ENABLED_IS
+        }
+
+        @Test
+        fun `SHOW_READ maps to ENABLED_NOT`() {
+            manga(Manga.CHAPTER_SHOW_READ).unreadFilter shouldBe TriState.ENABLED_NOT
+        }
+
+        @Test
+        fun `unreadFilterRaw extracts only unread bits`() {
+            val flags = Manga.CHAPTER_SHOW_UNREAD or Manga.CHAPTER_SHOW_BOOKMARKED or Manga.CHAPTER_SORT_ASC
+            manga(flags).unreadFilterRaw shouldBe Manga.CHAPTER_SHOW_UNREAD
+        }
     }
 
-    @Test
-    fun `subChapterFilter returns ENABLED_NOT when CHAPTER_SHOW_NOT_SUB_CHAPTER is set`() {
-        val manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER)
-        manga.subChapterFilter shouldBe TriState.ENABLED_NOT
+    @Nested
+    inner class DownloadedFilter {
+
+        @Test
+        fun `Default downloadedFilterRaw is zero`() {
+            manga().downloadedFilterRaw shouldBe 0L
+        }
+
+        @Test
+        fun `SHOW_DOWNLOADED is extracted correctly`() {
+            manga(Manga.CHAPTER_SHOW_DOWNLOADED).downloadedFilterRaw shouldBe Manga.CHAPTER_SHOW_DOWNLOADED
+        }
+
+        @Test
+        fun `SHOW_NOT_DOWNLOADED is extracted correctly`() {
+            manga(Manga.CHAPTER_SHOW_NOT_DOWNLOADED).downloadedFilterRaw shouldBe Manga.CHAPTER_SHOW_NOT_DOWNLOADED
+        }
+
+        @Test
+        fun `downloadedFilterRaw is isolated from other flags`() {
+            val flags = Manga.CHAPTER_SHOW_DOWNLOADED or Manga.CHAPTER_SHOW_UNREAD or Manga.CHAPTER_SORTING_ALPHABET
+            manga(flags).downloadedFilterRaw shouldBe Manga.CHAPTER_SHOW_DOWNLOADED
+        }
     }
 
-    @Test
-    fun `subChapterFilterRaw extracts only the sub-chapter bits`() {
-        val flags = Manga.CHAPTER_SHOW_SUB_CHAPTER or
-            Manga.CHAPTER_SHOW_UNREAD or
-            Manga.CHAPTER_SHOW_BOOKMARKED or
-            Manga.CHAPTER_SORTING_NUMBER
-        val manga = Manga.create().copy(chapterFlags = flags)
-        manga.subChapterFilterRaw shouldBe Manga.CHAPTER_SHOW_SUB_CHAPTER
+    @Nested
+    inner class BookmarkedFilter {
+
+        @Test
+        fun `Default is DISABLED`() {
+            manga().bookmarkedFilter shouldBe TriState.DISABLED
+        }
+
+        @Test
+        fun `SHOW_BOOKMARKED maps to ENABLED_IS`() {
+            manga(Manga.CHAPTER_SHOW_BOOKMARKED).bookmarkedFilter shouldBe TriState.ENABLED_IS
+        }
+
+        @Test
+        fun `SHOW_NOT_BOOKMARKED maps to ENABLED_NOT`() {
+            manga(Manga.CHAPTER_SHOW_NOT_BOOKMARKED).bookmarkedFilter shouldBe TriState.ENABLED_NOT
+        }
+
+        @Test
+        fun `bookmarkedFilterRaw extracts only bookmarked bits`() {
+            val flags = Manga.CHAPTER_SHOW_BOOKMARKED or Manga.CHAPTER_SHOW_UNREAD
+            manga(flags).bookmarkedFilterRaw shouldBe Manga.CHAPTER_SHOW_BOOKMARKED
+        }
     }
 
-    @Test
-    fun `Existing filters are unaffected by sub-chapter bits`() {
-        val manga = Manga.create().copy(
-            chapterFlags = Manga.CHAPTER_SHOW_SUB_CHAPTER or Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER,
-        )
-        manga.unreadFilter shouldBe TriState.DISABLED
-        manga.bookmarkedFilter shouldBe TriState.DISABLED
+    @Nested
+    inner class SubChapterFilter {
+
+        @Test
+        fun `Default is DISABLED`() {
+            manga().subChapterFilter shouldBe TriState.DISABLED
+        }
+
+        @Test
+        fun `SHOW_SUB_CHAPTER maps to ENABLED_IS`() {
+            manga(Manga.CHAPTER_SHOW_SUB_CHAPTER).subChapterFilter shouldBe TriState.ENABLED_IS
+        }
+
+        @Test
+        fun `SHOW_NOT_SUB_CHAPTER maps to ENABLED_NOT`() {
+            manga(Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER).subChapterFilter shouldBe TriState.ENABLED_NOT
+        }
+
+        @Test
+        fun `subChapterFilterRaw extracts only sub-chapter bits`() {
+            val flags = Manga.CHAPTER_SHOW_SUB_CHAPTER or
+                Manga.CHAPTER_SHOW_UNREAD or
+                Manga.CHAPTER_SHOW_BOOKMARKED or
+                Manga.CHAPTER_SORTING_NUMBER
+            manga(flags).subChapterFilterRaw shouldBe Manga.CHAPTER_SHOW_SUB_CHAPTER
+        }
+    }
+
+    @Nested
+    inner class Sorting {
+
+        @Test
+        fun `Default sorting is SOURCE`() {
+            manga().sorting shouldBe Manga.CHAPTER_SORTING_SOURCE
+        }
+
+        @Test
+        fun `SORTING_NUMBER is extracted correctly`() {
+            manga(Manga.CHAPTER_SORTING_NUMBER).sorting shouldBe Manga.CHAPTER_SORTING_NUMBER
+        }
+
+        @Test
+        fun `SORTING_UPLOAD_DATE is extracted correctly`() {
+            manga(Manga.CHAPTER_SORTING_UPLOAD_DATE).sorting shouldBe Manga.CHAPTER_SORTING_UPLOAD_DATE
+        }
+
+        @Test
+        fun `SORTING_ALPHABET is extracted correctly`() {
+            manga(Manga.CHAPTER_SORTING_ALPHABET).sorting shouldBe Manga.CHAPTER_SORTING_ALPHABET
+        }
+
+        @Test
+        fun `Sorting is isolated from other flags`() {
+            val flags = Manga.CHAPTER_SORTING_UPLOAD_DATE or Manga.CHAPTER_SORT_ASC or Manga.CHAPTER_SHOW_UNREAD
+            manga(flags).sorting shouldBe Manga.CHAPTER_SORTING_UPLOAD_DATE
+        }
+    }
+
+    @Nested
+    inner class DisplayMode {
+
+        @Test
+        fun `Default displayMode is NAME`() {
+            manga().displayMode shouldBe Manga.CHAPTER_DISPLAY_NAME
+        }
+
+        @Test
+        fun `DISPLAY_NUMBER is extracted correctly`() {
+            manga(Manga.CHAPTER_DISPLAY_NUMBER).displayMode shouldBe Manga.CHAPTER_DISPLAY_NUMBER
+        }
+
+        @Test
+        fun `Display mode is isolated from other flags`() {
+            val flags = Manga.CHAPTER_DISPLAY_NUMBER or Manga.CHAPTER_SORT_ASC or Manga.CHAPTER_SHOW_BOOKMARKED
+            manga(flags).displayMode shouldBe Manga.CHAPTER_DISPLAY_NUMBER
+        }
+    }
+
+    @Nested
+    inner class FlagIsolation {
+
+        @Test
+        fun `Setting sub-chapter flags does not affect unread or bookmarked`() {
+            val m = manga(Manga.CHAPTER_SHOW_SUB_CHAPTER or Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER)
+            m.unreadFilter shouldBe TriState.DISABLED
+            m.bookmarkedFilter shouldBe TriState.DISABLED
+        }
+
+        @Test
+        fun `All flags combined extract correctly`() {
+            val flags = Manga.CHAPTER_SORT_ASC or
+                Manga.CHAPTER_SHOW_UNREAD or
+                Manga.CHAPTER_SHOW_DOWNLOADED or
+                Manga.CHAPTER_SHOW_BOOKMARKED or
+                Manga.CHAPTER_SORTING_ALPHABET or
+                Manga.CHAPTER_SHOW_SUB_CHAPTER or
+                Manga.CHAPTER_DISPLAY_NUMBER
+            val m = manga(flags)
+
+            m.sortDescending() shouldBe false
+            m.unreadFilter shouldBe TriState.ENABLED_IS
+            m.downloadedFilterRaw shouldBe Manga.CHAPTER_SHOW_DOWNLOADED
+            m.bookmarkedFilter shouldBe TriState.ENABLED_IS
+            m.sorting shouldBe Manga.CHAPTER_SORTING_ALPHABET
+            m.subChapterFilter shouldBe TriState.ENABLED_IS
+            m.displayMode shouldBe Manga.CHAPTER_DISPLAY_NUMBER
+        }
+
+        @Test
+        fun `Zero flags give all defaults`() {
+            val m = manga(0L)
+            m.sortDescending() shouldBe true
+            m.unreadFilter shouldBe TriState.DISABLED
+            m.downloadedFilterRaw shouldBe 0L
+            m.bookmarkedFilter shouldBe TriState.DISABLED
+            m.sorting shouldBe Manga.CHAPTER_SORTING_SOURCE
+            m.subChapterFilter shouldBe TriState.DISABLED
+            m.displayMode shouldBe Manga.CHAPTER_DISPLAY_NAME
+        }
     }
 }

--- a/domain/src/test/java/tachiyomi/domain/manga/model/MangaChapterFlagsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/model/MangaChapterFlagsTest.kt
@@ -1,0 +1,60 @@
+package tachiyomi.domain.manga.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.TriState
+
+class MangaChapterFlagsTest {
+
+    @Test
+    fun `Sub-chapter mask does not overlap with other masks`() {
+        val otherMasks = listOf(
+            Manga.CHAPTER_SORT_DIR_MASK,
+            Manga.CHAPTER_UNREAD_MASK,
+            Manga.CHAPTER_DOWNLOADED_MASK,
+            Manga.CHAPTER_BOOKMARKED_MASK,
+            Manga.CHAPTER_SORTING_MASK,
+            Manga.CHAPTER_DISPLAY_MASK,
+        )
+        for (mask in otherMasks) {
+            Manga.CHAPTER_SUB_CHAPTER_MASK and mask shouldBe 0L
+        }
+    }
+
+    @Test
+    fun `subChapterFilter returns DISABLED when flags are zero`() {
+        val manga = Manga.create().copy(chapterFlags = Manga.SHOW_ALL)
+        manga.subChapterFilter shouldBe TriState.DISABLED
+    }
+
+    @Test
+    fun `subChapterFilter returns ENABLED_IS when CHAPTER_SHOW_SUB_CHAPTER is set`() {
+        val manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_SUB_CHAPTER)
+        manga.subChapterFilter shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `subChapterFilter returns ENABLED_NOT when CHAPTER_SHOW_NOT_SUB_CHAPTER is set`() {
+        val manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER)
+        manga.subChapterFilter shouldBe TriState.ENABLED_NOT
+    }
+
+    @Test
+    fun `subChapterFilterRaw extracts only the sub-chapter bits`() {
+        val flags = Manga.CHAPTER_SHOW_SUB_CHAPTER or
+            Manga.CHAPTER_SHOW_UNREAD or
+            Manga.CHAPTER_SHOW_BOOKMARKED or
+            Manga.CHAPTER_SORTING_NUMBER
+        val manga = Manga.create().copy(chapterFlags = flags)
+        manga.subChapterFilterRaw shouldBe Manga.CHAPTER_SHOW_SUB_CHAPTER
+    }
+
+    @Test
+    fun `Existing filters are unaffected by sub-chapter bits`() {
+        val manga = Manga.create().copy(
+            chapterFlags = Manga.CHAPTER_SHOW_SUB_CHAPTER or Manga.CHAPTER_SHOW_NOT_SUB_CHAPTER,
+        )
+        manga.unreadFilter shouldBe TriState.DISABLED
+        manga.bookmarkedFilter shouldBe TriState.DISABLED
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/manga/model/SubChapterFilterTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/model/SubChapterFilterTest.kt
@@ -1,67 +1,108 @@
 package tachiyomi.domain.manga.model
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.chapter.model.Chapter
-import kotlin.math.floor
 
 class SubChapterFilterTest {
 
-    private fun isSubChapter(chapterNumber: Double): Boolean {
-        return chapterNumber >= 0 && chapterNumber != floor(chapterNumber)
+    private fun chapter(number: Double) = Chapter.create().copy(chapterNumber = number)
+
+    @Nested
+    inner class IsSubChapterPredicate {
+
+        @Test
+        fun `Whole chapter numbers are not sub-chapters`() {
+            chapter(1.0).isSubChapter shouldBe false
+            chapter(2.0).isSubChapter shouldBe false
+            chapter(100.0).isSubChapter shouldBe false
+        }
+
+        @Test
+        fun `Fractional chapter numbers are sub-chapters`() {
+            chapter(1.1).isSubChapter shouldBe true
+            chapter(1.5).isSubChapter shouldBe true
+            chapter(5.99).isSubChapter shouldBe true
+        }
+
+        @Test
+        fun `Unrecognized chapters (negative) are never sub-chapters`() {
+            chapter(-1.0).isSubChapter shouldBe false
+            chapter(-0.5).isSubChapter shouldBe false
+        }
+
+        @Test
+        fun `Zero is not a sub-chapter`() {
+            chapter(0.0).isSubChapter shouldBe false
+        }
+
+        @Test
+        fun `Zero point five is a sub-chapter`() {
+            chapter(0.5).isSubChapter shouldBe true
+        }
+
+        @Test
+        fun `Very small fractional part is a sub-chapter`() {
+            chapter(1.001).isSubChapter shouldBe true
+        }
+
+        @Test
+        fun `Large chapter number with fraction is a sub-chapter`() {
+            chapter(999.5).isSubChapter shouldBe true
+        }
     }
 
-    private fun chapter(number: Double) = Chapter.create().copy(
-        chapterNumber = number,
-    )
+    @Nested
+    inner class ApplyFilterIntegration {
 
-    @Test
-    fun `Whole chapter numbers are not sub-chapters`() {
-        isSubChapter(1.0) shouldBe false
-        isSubChapter(2.0) shouldBe false
-        isSubChapter(100.0) shouldBe false
-    }
+        @Test
+        fun `DISABLED shows all chapters`() {
+            val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(-1.0))
+            val filtered = chapters.filter { applyFilter(TriState.DISABLED) { it.isSubChapter } }
+            filtered.size shouldBe 4
+        }
 
-    @Test
-    fun `Fractional chapter numbers are sub-chapters`() {
-        isSubChapter(1.1) shouldBe true
-        isSubChapter(1.5) shouldBe true
-        isSubChapter(5.99) shouldBe true
-    }
+        @Test
+        fun `ENABLED_IS shows only sub-chapters`() {
+            val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
+            val filtered = chapters.filter { applyFilter(TriState.ENABLED_IS) { it.isSubChapter } }
+            filtered.size shouldBe 2
+            filtered[0].chapterNumber shouldBe 1.5
+            filtered[1].chapterNumber shouldBe 5.99
+        }
 
-    @Test
-    fun `Unrecognized chapters (negative) are never sub-chapters`() {
-        isSubChapter(-1.0) shouldBe false
-    }
+        @Test
+        fun `ENABLED_NOT hides sub-chapters`() {
+            val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
+            val filtered = chapters.filter { applyFilter(TriState.ENABLED_NOT) { it.isSubChapter } }
+            filtered.size shouldBe 2
+            filtered[0].chapterNumber shouldBe 1.0
+            filtered[1].chapterNumber shouldBe 2.0
+        }
 
-    @Test
-    fun `Zero is not a sub-chapter`() {
-        isSubChapter(0.0) shouldBe false
-    }
+        @Test
+        fun `ENABLED_IS with no sub-chapters returns empty`() {
+            val chapters = listOf(chapter(1.0), chapter(2.0), chapter(3.0))
+            val filtered = chapters.filter { applyFilter(TriState.ENABLED_IS) { it.isSubChapter } }
+            filtered.size shouldBe 0
+        }
 
-    @Test
-    fun `applyFilter with DISABLED shows all chapters`() {
-        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(-1.0))
-        val filtered = chapters.filter { applyFilter(TriState.DISABLED) { isSubChapter(it.chapterNumber) } }
-        filtered.size shouldBe 4
-    }
+        @Test
+        fun `ENABLED_NOT with only sub-chapters returns empty`() {
+            val chapters = listOf(chapter(1.5), chapter(2.5), chapter(3.5))
+            val filtered = chapters.filter { applyFilter(TriState.ENABLED_NOT) { it.isSubChapter } }
+            filtered.size shouldBe 0
+        }
 
-    @Test
-    fun `applyFilter with ENABLED_IS shows only sub-chapters`() {
-        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
-        val filtered = chapters.filter { applyFilter(TriState.ENABLED_IS) { isSubChapter(it.chapterNumber) } }
-        filtered.size shouldBe 2
-        filtered[0].chapterNumber shouldBe 1.5
-        filtered[1].chapterNumber shouldBe 5.99
-    }
-
-    @Test
-    fun `applyFilter with ENABLED_NOT hides sub-chapters`() {
-        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
-        val filtered = chapters.filter { applyFilter(TriState.ENABLED_NOT) { isSubChapter(it.chapterNumber) } }
-        filtered.size shouldBe 2
-        filtered[0].chapterNumber shouldBe 1.0
-        filtered[1].chapterNumber shouldBe 2.0
+        @Test
+        fun `Unrecognized chapters are kept by ENABLED_NOT`() {
+            val chapters = listOf(chapter(-1.0), chapter(1.5), chapter(2.0))
+            val filtered = chapters.filter { applyFilter(TriState.ENABLED_NOT) { it.isSubChapter } }
+            filtered.size shouldBe 2
+            filtered[0].chapterNumber shouldBe -1.0
+            filtered[1].chapterNumber shouldBe 2.0
+        }
     }
 }

--- a/domain/src/test/java/tachiyomi/domain/manga/model/SubChapterFilterTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/model/SubChapterFilterTest.kt
@@ -1,0 +1,67 @@
+package tachiyomi.domain.manga.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.TriState
+import tachiyomi.domain.chapter.model.Chapter
+import kotlin.math.floor
+
+class SubChapterFilterTest {
+
+    private fun isSubChapter(chapterNumber: Double): Boolean {
+        return chapterNumber >= 0 && chapterNumber != floor(chapterNumber)
+    }
+
+    private fun chapter(number: Double) = Chapter.create().copy(
+        chapterNumber = number,
+    )
+
+    @Test
+    fun `Whole chapter numbers are not sub-chapters`() {
+        isSubChapter(1.0) shouldBe false
+        isSubChapter(2.0) shouldBe false
+        isSubChapter(100.0) shouldBe false
+    }
+
+    @Test
+    fun `Fractional chapter numbers are sub-chapters`() {
+        isSubChapter(1.1) shouldBe true
+        isSubChapter(1.5) shouldBe true
+        isSubChapter(5.99) shouldBe true
+    }
+
+    @Test
+    fun `Unrecognized chapters (negative) are never sub-chapters`() {
+        isSubChapter(-1.0) shouldBe false
+    }
+
+    @Test
+    fun `Zero is not a sub-chapter`() {
+        isSubChapter(0.0) shouldBe false
+    }
+
+    @Test
+    fun `applyFilter with DISABLED shows all chapters`() {
+        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(-1.0))
+        val filtered = chapters.filter { applyFilter(TriState.DISABLED) { isSubChapter(it.chapterNumber) } }
+        filtered.size shouldBe 4
+    }
+
+    @Test
+    fun `applyFilter with ENABLED_IS shows only sub-chapters`() {
+        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
+        val filtered = chapters.filter { applyFilter(TriState.ENABLED_IS) { isSubChapter(it.chapterNumber) } }
+        filtered.size shouldBe 2
+        filtered[0].chapterNumber shouldBe 1.5
+        filtered[1].chapterNumber shouldBe 5.99
+    }
+
+    @Test
+    fun `applyFilter with ENABLED_NOT hides sub-chapters`() {
+        val chapters = listOf(chapter(1.0), chapter(1.5), chapter(2.0), chapter(5.99))
+        val filtered = chapters.filter { applyFilter(TriState.ENABLED_NOT) { isSubChapter(it.chapterNumber) } }
+        filtered.size shouldBe 2
+        filtered[0].chapterNumber shouldBe 1.0
+        filtered[1].chapterNumber shouldBe 2.0
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -57,6 +57,7 @@
     <string name="action_filter_bookmarked">Bookmarked</string>
     <string name="action_filter_tracked">Tracked</string>
     <string name="action_filter_unread">Unread</string>
+    <string name="action_filter_sub_chapter">Sub-chapters</string>
     <string name="action_filter_interval_custom">Customized update frequency</string>
     <!-- reserved for #4048 -->
     <string name="action_filter_empty">Remove filter</string>


### PR DESCRIPTION
I saw [this](https://github.com/mihonapp/mihon/issues/3020) issue today and realized that I also wanted this feature in Mihon, so I went ahead and gave it a shot.

## Motivation
Some sources split chapters into intermediary parts like `12.1`, `12.2`, etc., alongside a combined `Chapter 12`, effectively duplicating content. After finishing a chapter, users must either manually skip all intermediary parts or exit the reader and select the next main entry. As you can imagine, this can get extremely annoying very quickly.

This PR adds an option in Mihon to filter out these sub-chapters, allowing users to read only the main chapters and keep their library cleaner while still supporting sources that rely on split numbering.

## Notes
I also added some unit tests to validate that the manga chapter flags behave as expected and that the `Chapter.isSubChapter` value is being set correctly.

## Images
| No filters | Enabling sub-chapter only mode | List w/ sub-chapter only mode | Enabling sub-chapters removal mode | Listing w/ sub-chapter removal mode |
| ------- | ------- | ------- | ------- | ------- |
| ![](https://github.com/user-attachments/assets/d73cd9b0-e00c-4f70-a8f9-9d1f4dc912f7) | ![](https://github.com/user-attachments/assets/c101ef55-e248-4070-a4ac-bce3fa896b73) | ![](https://github.com/user-attachments/assets/fe5e1bfe-e58d-4697-9a21-126b02001d7a) | ![](https://github.com/user-attachments/assets/33e1e053-352c-4615-b143-1162faecbc18)  | ![](https://github.com/user-attachments/assets/0252101a-8499-4786-9ab9-77d599d03a1a) |