### PR TITLE
Refactor: "Pinned Only" toggle for global search

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -64,6 +64,11 @@ class SourcePreferences(
         false,
     )
 
+    val globalSearchPinnedOnly: Preference<Boolean> = preferenceStore.getBoolean(
+        Preference.appStateKey("global_search_pinned_only"),
+        false,
+    )
+
     val migrationSources: Preference<List<Long>> = preferenceStore.getLongArray("migration_sources", emptyList())
 
     val migrationFlags: Preference<Set<MigrationFlag>> = preferenceStore.getObjectFromInt(

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -39,6 +39,7 @@ fun GlobalSearchScreen(
                 navigateUp = navigateUp,
                 onChangeSearchQuery = onChangeSearchQuery,
                 onSearch = onSearch,
+                hasPinnedSources = state.hasPinnedSources,
                 pinnedOnly = state.pinnedOnly,
                 onTogglePinnedOnly = onTogglePinnedOnly,
                 onlyShowHasResults = state.onlyShowHasResults,

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -13,7 +13,6 @@ import eu.kanade.presentation.browse.components.GlobalSearchToolbar
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchItemResult
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchViewModel
-import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -24,7 +23,7 @@ fun GlobalSearchScreen(
     navigateUp: () -> Unit,
     onChangeSearchQuery: (String?) -> Unit,
     onSearch: (String) -> Unit,
-    onChangeSearchFilter: (SourceFilter) -> Unit,
+    onTogglePinnedOnly: () -> Unit,
     onToggleResults: () -> Unit,
     getManga: @Composable (Manga) -> State<Manga>,
     onClickSource: (Source) -> Unit,
@@ -40,9 +39,8 @@ fun GlobalSearchScreen(
                 navigateUp = navigateUp,
                 onChangeSearchQuery = onChangeSearchQuery,
                 onSearch = onSearch,
-                hideSourceFilter = false,
-                sourceFilter = state.sourceFilter,
-                onChangeSearchFilter = onChangeSearchFilter,
+                pinnedOnly = state.pinnedOnly,
+                onTogglePinnedOnly = onTogglePinnedOnly,
                 onlyShowHasResults = state.onlyShowHasResults,
                 onToggleResults = onToggleResults,
                 scrollBehavior = scrollBehavior,

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
@@ -31,6 +31,7 @@ fun MigrateSearchScreen(
                 navigateUp = navigateUp,
                 onChangeSearchQuery = onChangeSearchQuery,
                 onSearch = onSearch,
+                hasPinnedSources = false,
                 pinnedOnly = state.pinnedOnly,
                 onTogglePinnedOnly = onTogglePinnedOnly,
                 onlyShowHasResults = state.onlyShowHasResults,

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.State
 import eu.kanade.presentation.browse.components.GlobalSearchToolbar
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchViewModel
-import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
 
@@ -16,7 +15,7 @@ fun MigrateSearchScreen(
     navigateUp: () -> Unit,
     onChangeSearchQuery: (String?) -> Unit,
     onSearch: (String) -> Unit,
-    onChangeSearchFilter: (SourceFilter) -> Unit,
+    onTogglePinnedOnly: () -> Unit,
     onToggleResults: () -> Unit,
     getManga: @Composable (Manga) -> State<Manga>,
     onClickSource: (Source) -> Unit,
@@ -32,9 +31,8 @@ fun MigrateSearchScreen(
                 navigateUp = navigateUp,
                 onChangeSearchQuery = onChangeSearchQuery,
                 onSearch = onSearch,
-                hideSourceFilter = true,
-                sourceFilter = state.sourceFilter,
-                onChangeSearchFilter = onChangeSearchFilter,
+                pinnedOnly = state.pinnedOnly,
+                onTogglePinnedOnly = onTogglePinnedOnly,
                 onlyShowHasResults = state.onlyShowHasResults,
                 onToggleResults = onToggleResults,
                 scrollBehavior = scrollBehavior,

--- a/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.FilterChip
@@ -22,12 +21,10 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.components.SearchToolbar
-import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
@@ -40,9 +37,8 @@ fun GlobalSearchToolbar(
     navigateUp: () -> Unit,
     onChangeSearchQuery: (String?) -> Unit,
     onSearch: (String) -> Unit,
-    hideSourceFilter: Boolean,
-    sourceFilter: SourceFilter,
-    onChangeSearchFilter: (SourceFilter) -> Unit,
+    pinnedOnly: Boolean,
+    onTogglePinnedOnly: () -> Unit,
     onlyShowHasResults: Boolean,
     onToggleResults: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -73,41 +69,21 @@ fun GlobalSearchToolbar(
                 .padding(horizontal = MaterialTheme.padding.small),
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
         ) {
-            // TODO: make this UX better; it only applies when triggering a new search
-            if (!hideSourceFilter) {
-                FilterChip(
-                    selected = sourceFilter == SourceFilter.PinnedOnly,
-                    onClick = { onChangeSearchFilter(SourceFilter.PinnedOnly) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Outlined.PushPin,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(FilterChipDefaults.IconSize),
-                        )
-                    },
-                    label = {
-                        Text(text = stringResource(MR.strings.pinned_sources))
-                    },
-                )
-                FilterChip(
-                    selected = sourceFilter == SourceFilter.All,
-                    onClick = { onChangeSearchFilter(SourceFilter.All) },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Outlined.DoneAll,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(FilterChipDefaults.IconSize),
-                        )
-                    },
-                    label = {
-                        Text(text = stringResource(MR.strings.all))
-                    },
-                )
-
-                VerticalDivider()
-            }
+            FilterChip(
+                selected = pinnedOnly,
+                onClick = onTogglePinnedOnly,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.PushPin,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(FilterChipDefaults.IconSize),
+                    )
+                },
+                label = {
+                    Text(text = stringResource(MR.strings.pinned_sources_only))
+                },
+            )
 
             FilterChip(
                 selected = onlyShowHasResults,

--- a/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
@@ -37,6 +37,7 @@ fun GlobalSearchToolbar(
     navigateUp: () -> Unit,
     onChangeSearchQuery: (String?) -> Unit,
     onSearch: (String) -> Unit,
+    hasPinnedSources: Boolean,
     pinnedOnly: Boolean,
     onTogglePinnedOnly: () -> Unit,
     onlyShowHasResults: Boolean,
@@ -69,21 +70,23 @@ fun GlobalSearchToolbar(
                 .padding(horizontal = MaterialTheme.padding.small),
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
         ) {
-            FilterChip(
-                selected = pinnedOnly,
-                onClick = onTogglePinnedOnly,
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Outlined.PushPin,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .size(FilterChipDefaults.IconSize),
-                    )
-                },
-                label = {
-                    Text(text = stringResource(MR.strings.pinned_sources_only))
-                },
-            )
+            if (hasPinnedSources) {
+                FilterChip(
+                    selected = pinnedOnly,
+                    onClick = onTogglePinnedOnly,
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.PushPin,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(FilterChipDefaults.IconSize),
+                        )
+                    },
+                    label = {
+                        Text(text = stringResource(MR.strings.pinned_sources_only))
+                    },
+                )
+            }
 
             FilterChip(
                 selected = onlyShowHasResults,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -35,7 +35,7 @@ class MigrateSearchScreen(private val mangaId: Long) : Screen() {
             onChangeSearchQuery = viewModel::updateSearchQuery,
             onSearch = { viewModel.search() },
             getManga = { viewModel.getManga(it) },
-            onChangeSearchFilter = viewModel::setSourceFilter,
+            onTogglePinnedOnly = viewModel::togglePinnedOnly,
             onToggleResults = viewModel::toggleFilterResults,
             onClickSource = { navigator.push(MigrateSourceSearchScreen(state.from!!, it.id, state.searchQuery)) },
             onClickItem = {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -69,7 +69,7 @@ class GlobalSearchScreen(
                 onChangeSearchQuery = viewModel::updateSearchQuery,
                 onSearch = { viewModel.search() },
                 getManga = { viewModel.getManga(it) },
-                onChangeSearchFilter = viewModel::setSourceFilter,
+                onTogglePinnedOnly = viewModel::togglePinnedOnly,
                 onToggleResults = viewModel::toggleFilterResults,
                 onClickSource = {
                     navigator.push(BrowseSourceScreen(it.id, state.searchQuery))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchViewModel.kt
@@ -27,16 +27,12 @@ class GlobalSearchViewModel(
     init {
         extensionFilter = initialExtensionFilter
         if (initialQuery.isNotBlank() || !initialExtensionFilter.isNullOrBlank()) {
-            if (extensionFilter != null) {
-                // we're going to use custom extension filter instead
-                setSourceFilter(SourceFilter.All)
-            }
             search()
         }
     }
 
     override fun getEnabledSources(): List<Source> {
         return super.getEnabledSources()
-            .filter { state.value.sourceFilter != SourceFilter.PinnedOnly || "${it.id}" in pinnedSources }
+            .filter { extensionFilter != null || !state.value.pinnedOnly || "${it.id}" in pinnedSources }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
@@ -58,7 +58,7 @@ abstract class SearchViewModel(
     protected val pinnedSources = sourcePreferences.pinnedSources.get()
 
     private var lastQuery: String? = null
-    private var lastSourceFilter: SourceFilter? = null
+    private var lastPinnedOnly: Boolean? = null
 
     protected var extensionFilter: String? = null
 
@@ -74,6 +74,12 @@ abstract class SearchViewModel(
         viewModelScope.launch {
             preferences.globalSearchFilterState.changes().collectLatest { onlyShowHasResults ->
                 state.update { it.copy(onlyShowHasResults = onlyShowHasResults) }
+            }
+        }
+        viewModelScope.launch {
+            preferences.globalSearchPinnedOnly.changes().collectLatest { pinned ->
+                state.update { it.copy(pinnedOnly = pinned) }
+                search()
             }
         }
     }
@@ -118,9 +124,8 @@ abstract class SearchViewModel(
         state.update { it.copy(searchQuery = query) }
     }
 
-    fun setSourceFilter(filter: SourceFilter) {
-        state.update { it.copy(sourceFilter = filter) }
-        search()
+    fun togglePinnedOnly() {
+        preferences.globalSearchPinnedOnly.toggle()
     }
 
     fun toggleFilterResults() {
@@ -129,15 +134,15 @@ abstract class SearchViewModel(
 
     fun search() {
         val query = state.value.searchQuery
-        val sourceFilter = state.value.sourceFilter
+        val pinnedOnly = state.value.pinnedOnly
 
         if (query.isNullOrBlank()) return
 
         val sameQuery = this.lastQuery == query
-        if (sameQuery && this.lastSourceFilter == sourceFilter) return
+        if (sameQuery && this.lastPinnedOnly == pinnedOnly) return
 
         this.lastQuery = query
-        this.lastSourceFilter = sourceFilter
+        this.lastPinnedOnly = pinnedOnly
 
         searchJob?.cancel()
 
@@ -216,7 +221,7 @@ abstract class SearchViewModel(
     data class State(
         val from: Manga? = null,
         val searchQuery: String? = null,
-        val sourceFilter: SourceFilter = SourceFilter.PinnedOnly,
+        val pinnedOnly: Boolean = false,
         val onlyShowHasResults: Boolean = false,
         val items: Map<Source, SearchItemResult> = mapOf(),
         val dialog: Dialog? = null,
@@ -229,11 +234,6 @@ abstract class SearchViewModel(
     sealed interface Dialog {
         data class Migrate(val target: Manga, val current: Manga) : Dialog
     }
-}
-
-enum class SourceFilter {
-    All,
-    PinnedOnly,
 }
 
 sealed interface SearchItemResult {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
@@ -65,12 +65,13 @@ abstract class SearchViewModel(
     open val sortComparator = { map: Map<Source, SearchItemResult> ->
         compareBy<Source>(
             { (map[it] as? SearchItemResult.Success)?.isEmpty ?: true },
-            { "${it.id}" !in pinnedSources },
+            { it.id.toString() !in pinnedSources },
             { "${it.name.lowercase()} (${it.lang})" },
         )
     }
 
     init {
+        state.update { it.copy(hasPinnedSources = pinnedSources.isNotEmpty()) }
         viewModelScope.launch {
             preferences.globalSearchFilterState.changes().collectLatest { onlyShowHasResults ->
                 state.update { it.copy(onlyShowHasResults = onlyShowHasResults) }
@@ -78,7 +79,7 @@ abstract class SearchViewModel(
         }
         viewModelScope.launch {
             preferences.globalSearchPinnedOnly.changes().collectLatest { pinned ->
-                state.update { it.copy(pinnedOnly = pinned) }
+                state.update { it.copy(pinnedOnly = pinned && it.hasPinnedSources) }
                 search()
             }
         }
@@ -222,6 +223,7 @@ abstract class SearchViewModel(
         val from: Manga? = null,
         val searchQuery: String? = null,
         val pinnedOnly: Boolean = false,
+        val hasPinnedSources: Boolean = false,
         val onlyShowHasResults: Boolean = false,
         val items: Map<Source, SearchItemResult> = mapOf(),
         val dialog: Dialog? = null,

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModelTest.kt
@@ -1,0 +1,153 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch
+
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.tachiyomi.extension.ExtensionManager
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
+import tachiyomi.domain.source.service.SourceManager
+import kotlin.time.Duration.Companion.seconds
+
+class SearchViewModelTest {
+
+    companion object {
+        @OptIn(DelicateCoroutinesApi::class)
+        private val mainThreadSurrogate = newSingleThreadContext("UI thread")
+
+        @BeforeAll
+        @JvmStatic
+        fun setUp() {
+            Dispatchers.setMain(mainThreadSurrogate)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            Dispatchers.resetMain()
+            mainThreadSurrogate.close()
+        }
+    }
+
+    private fun mockPreference(value: Set<String>): Preference<Set<String>> = mockk {
+        every { get() } returns value
+        every { changes() } returns MutableStateFlow(value)
+    }
+
+    private fun createModel(
+        pinnedSources: Set<String> = emptySet(),
+        pinnedOnlyFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    ): Pair<TestSearchViewModel, MutableStateFlow<Boolean>> {
+        val filterStateFlow = MutableStateFlow(false)
+
+        val pinnedOnlyPref = mockk<Preference<Boolean>> {
+            every { get() } returns pinnedOnlyFlow.value
+            every { changes() } returns pinnedOnlyFlow
+        }
+        val filterStatePref = mockk<Preference<Boolean>> {
+            every { get() } returns false
+            every { changes() } returns filterStateFlow
+        }
+
+        val sourcePreferences = mockk<SourcePreferences> {
+            every { this@mockk.pinnedSources } returns mockPreference(pinnedSources)
+            every { this@mockk.enabledLanguages } returns mockPreference(setOf("en"))
+            every { this@mockk.disabledSources } returns mockPreference(emptySet())
+            every { this@mockk.globalSearchPinnedOnly } returns pinnedOnlyPref
+            every { this@mockk.globalSearchFilterState } returns filterStatePref
+        }
+
+        val model = TestSearchViewModel(
+            sourcePreferences = sourcePreferences,
+            sourceManager = mockk(relaxed = true),
+            extensionManager = mockk(relaxed = true),
+            networkToLocalManga = mockk(relaxed = true),
+            getManga = mockk(relaxed = true),
+            preferences = sourcePreferences,
+        )
+
+        return model to pinnedOnlyFlow
+    }
+
+    @Test
+    fun `pinnedOnly is false when preference is true but no pinned sources`() {
+        runBlocking {
+            val pinnedOnlyFlow = MutableStateFlow(false)
+            val (model, _) = createModel(
+                pinnedSources = emptySet(),
+                pinnedOnlyFlow = pinnedOnlyFlow,
+            )
+
+            pinnedOnlyFlow.value = true
+
+            eventually(2.seconds) {
+                model.state.value.pinnedOnly shouldBe false
+                model.state.value.hasPinnedSources shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `pinnedOnly is true when preference is true and pinned sources exist`() {
+        runBlocking {
+            val pinnedOnlyFlow = MutableStateFlow(false)
+            val (model, _) = createModel(
+                pinnedSources = setOf("1"),
+                pinnedOnlyFlow = pinnedOnlyFlow,
+            )
+
+            pinnedOnlyFlow.value = true
+
+            eventually(2.seconds) {
+                model.state.value.pinnedOnly shouldBe true
+                model.state.value.hasPinnedSources shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `pinnedOnly is false when preference is false regardless of pinned sources`() {
+        runBlocking {
+            val pinnedOnlyFlow = MutableStateFlow(false)
+            val (model, _) = createModel(
+                pinnedSources = setOf("1"),
+                pinnedOnlyFlow = pinnedOnlyFlow,
+            )
+
+            eventually(2.seconds) {
+                model.state.value.pinnedOnly shouldBe false
+                model.state.value.hasPinnedSources shouldBe true
+            }
+        }
+    }
+}
+
+private class TestSearchViewModel(
+    sourcePreferences: SourcePreferences,
+    sourceManager: SourceManager,
+    extensionManager: ExtensionManager,
+    networkToLocalManga: NetworkToLocalManga,
+    getManga: GetManga,
+    preferences: SourcePreferences,
+) : SearchViewModel(
+    initialState = State(),
+    sourcePreferences = sourcePreferences,
+    sourceManager = sourceManager,
+    extensionManager = extensionManager,
+    networkToLocalManga = networkToLocalManga,
+    getManga = getManga,
+    preferences = preferences,
+)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -720,6 +720,7 @@
     <string name="other_source">Other</string>
     <string name="last_used_source">Last used</string>
     <string name="pinned_sources">Pinned</string>
+    <string name="pinned_sources_only">Pinned only</string>
     <string name="action_global_search_hint">Global search…</string>
     <string name="action_global_search_query">Search for \"%1$s\" globally</string>
     <string name="latest">Latest</string>


### PR DESCRIPTION
## Motivation
The global search screen currently defaults to showing only pinned sources. This behavior is bad, especially for first-time users. When someone installs the app for the first time, they will not have any pinned sources, and as a result, their initial searches will always be an empty list unless they notice that there's a filter already applied that they need to remove (the "show results from pinned sources only" filter).

In general, we should assume that users don't want any filters applied unless they explicitly choose them. The current default assumes that users want to see results from pinned sources only, instead of showing results from all sources by default.

Additionally, since the state of this option is not persisted, users must manually switch to the "All" view every time they perform a search if they want results from all sources.

As a side note, the current UI uses two mutually exclusive filter chips ("Pinned Sources" and "All") for a binary choice. This is redundant and can be replaced with a more intuitive ON/OFF toggle.

## Changes
1. Replace the two filter chips with a single "Pinned Only" toggle chip that defaults to OFF (showing all sources) instead of ON (showing only pinned sources)
2. Persist the toggle state in `SourcePreferences` so the app remembers the user's choice across searched. This is aligned with the behavior of "Has results" chip
3. Automatically hides the "Pinned only" chip when there are no pinned sources. This prevents filtering the search result set into an empty result set and avoids confusing users who haven't pinned any sources

## Video

Check the video below to see a demonstration of my proposed changes.

https://github.com/user-attachments/assets/01a98c7b-6a2b-46ba-be5b-74d6b1ad87e6

_A short video showing the improvements on the search UI/UX_

## Notes
I considered not removing the `SourceFilter` enum, but I ended up not coming up with a good reason to keep this value as an enum, so I went ahead and modified it to be a simple boolean instead.