### PR TITLE
Address bundleOf deprecation

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/SourcePreferencesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/SourcePreferencesScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
@@ -167,7 +166,9 @@ class SourcePreferencesFragment : PreferenceFragmentCompat() {
 
         fun getInstance(sourceId: Long): SourcePreferencesFragment {
             return SourcePreferencesFragment().apply {
-                arguments = bundleOf(SOURCE_ID to sourceId)
+                arguments = Bundle().apply {
+                    putLong(SOURCE_ID, sourceId)
+                }
             }
         }
     }


### PR DESCRIPTION
I spotted a new deprecation message in the build logs:

> w: [...]/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/SourcePreferencesScreen.kt:170:29 'fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle' is deprecated. This method does not provide type safety at compile time. Use the platform `Bundle` class directly instead.

[Here it is in the build logs for 77a86d486fc1d1ec2968a51dbda6c8286bb20b55:](https://github.com/mihonapp/mihon/actions/runs/23105932997/job/67115046242#step:7:573)

And while it's sad that the `androidx.core.os` package this came from does not provide a nice `ReplaceWith`, it appears what I did is what they intend you to do.

SourcePreferences seems to be opening fine still, so it can't be super wrong or anything?

This came as a side effect of merging #3067, which bumped `androidx.core:core-ktx`.

In googlesource: https://android.googlesource.com/platform/frameworks/support/+/55240b01e2e2caa4c3cd667b7178a40538c60ff3
In their GitHub mirror: https://github.com/androidx/androidx/commit/55240b01e2e2caa4c3cd667b7178a40538c60ff3

Sadly even the commit has no hints at what is intended and itself is just an assload of Deprecation warning suppressions plus the actual deprecation...

Edit: And here you can notice the warning's absence in the logs for this PR: https://github.com/mihonapp/mihon/actions/runs/23121544378/job/67156400315?pr=3073#step:7:561