### PR TITLE
Replace Material View loading indicator with Compose-based one in reader transitions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
@@ -9,10 +9,10 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatTextView
-import com.google.android.material.progressindicator.CircularProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderButton
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderTransitionView
 import eu.kanade.tachiyomi.util.system.dpToPx
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
@@ -100,8 +100,11 @@ class PagerTransitionHolder(
      * Sets the loading state on the pages container.
      */
     private fun setLoading() {
-        val progress = CircularProgressIndicator(context)
-        progress.isIndeterminate = true
+        val progress = ReaderProgressIndicator(context).apply {
+            layoutParams = LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
+                gravity = Gravity.CENTER_HORIZONTAL
+            }
+        }
 
         val textView = AppCompatTextView(context).apply {
             wrapContent()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
@@ -8,9 +8,9 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.isNotEmpty
 import androidx.core.view.isVisible
-import com.google.android.material.progressindicator.CircularProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderTransitionView
 import eu.kanade.tachiyomi.util.system.dpToPx
 import kotlinx.coroutines.Job
@@ -102,8 +102,11 @@ class WebtoonTransitionHolder(
      * Sets the loading state on the pages container.
      */
     private fun setLoading() {
-        val progress = CircularProgressIndicator(context)
-        progress.isIndeterminate = true
+        val progress = ReaderProgressIndicator(context).apply {
+            layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT).apply {
+                gravity = Gravity.CENTER_HORIZONTAL
+            }
+        }
 
         val textView = AppCompatTextView(context).apply {
             wrapContent()

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/CircularProgressIndicator.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/CircularProgressIndicator.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 
 /**
@@ -47,9 +48,9 @@ fun CombinedCircularProgressIndicator(
         label = "progressState",
         modifier = modifier,
     ) { indeterminate ->
+        val trackColor = Color.Transparent
         if (indeterminate) {
-            // Indeterminate
-            CircularProgressIndicator()
+            CircularProgressIndicator(trackColor = trackColor)
         } else {
             // Determinate
             val infiniteTransition = rememberInfiniteTransition(label = "infiniteRotation")
@@ -70,6 +71,7 @@ fun CombinedCircularProgressIndicator(
             CircularProgressIndicator(
                 progress = { animatedProgress },
                 modifier = Modifier.rotate(rotation),
+                trackColor = trackColor,
             )
         }
     }


### PR DESCRIPTION
Replace Material View loading indicator with Compose-based one in reader transitions

- The loading circle on chapter transition screens (next/prev chapter) wasn't animating properly.
It was using the old Material View CircularProgressIndicator while everything else in the reader uses the Compose-based ReaderProgressIndicator. I swapped it out so it's consistent and actually spins.

- Fixed the track color flickering when the progress indicator switches between indeterminate and determinate states, both now use the same secondaryContainer track color so it doesn't randomly change appearance mid-load.

Changes:

- PagerTransitionHolder / WebtoonTransitionHolder: use ReaderProgressIndicator instead of Material View indicator.

- CombinedCircularProgressIndicator: use consistent track color across both states.

OLD:

https://github.com/user-attachments/assets/9bdc9573-3796-482a-b719-d4f941befe3f

CHANGES:

https://github.com/user-attachments/assets/5b093281-473c-421e-9397-aab7374a08c7