### PR TITLE
Fix SIGSEGV crash from ArchiveReader use-after-close

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ArchivePageLoader.kt
@@ -26,7 +26,7 @@ internal class ArchivePageLoader(private val reader: ArchiveReader) : PageLoader
     }
 
     override suspend fun loadPage(page: ReaderPage) {
-        check(!isRecycled)
+        if (isRecycled) return
     }
 
     override fun recycle() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/EpubPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/EpubPageLoader.kt
@@ -21,7 +21,7 @@ internal class EpubPageLoader(private val reader: EpubReader) : PageLoader() {
     }
 
     override suspend fun loadPage(page: ReaderPage) {
-        check(!isRecycled)
+        if (isRecycled) return
     }
 
     override fun recycle() {

--- a/core/archive/src/main/kotlin/mihon/core/archive/ArchiveReader.kt
+++ b/core/archive/src/main/kotlin/mihon/core/archive/ArchiveReader.kt
@@ -6,16 +6,25 @@ import android.system.OsConstants
 import me.zhanghai.android.libarchive.ArchiveException
 import java.io.Closeable
 import java.io.InputStream
+import kotlin.concurrent.Volatile
 
 class ArchiveReader(pfd: ParcelFileDescriptor) : Closeable {
     private val size = pfd.statSize
     private val address = Os.mmap(0, size, OsConstants.PROT_READ, OsConstants.MAP_PRIVATE, pfd.fileDescriptor, 0)
+    private val lock = Any()
 
-    fun <T> useEntries(block: (Sequence<ArchiveEntry>) -> T): T = ArchiveInputStream(address, size).use {
-        block(generateSequence { it.getNextEntry() })
+    @Volatile
+    private var isClosed = false
+
+    fun <T> useEntries(block: (Sequence<ArchiveEntry>) -> T): T {
+        check(!isClosed) { "ArchiveReader is closed" }
+        return ArchiveInputStream(address, size).use {
+            block(generateSequence { it.getNextEntry() })
+        }
     }
 
     fun getInputStream(entryName: String): InputStream? {
+        if (isClosed) return null
         val archive = ArchiveInputStream(address, size)
         try {
             while (true) {
@@ -33,6 +42,11 @@ class ArchiveReader(pfd: ParcelFileDescriptor) : Closeable {
     }
 
     override fun close() {
+        synchronized(lock) {
+            if (isClosed) return
+            isClosed = true
+        }
+
         Os.munmap(address, size)
     }
 }


### PR DESCRIPTION
Add thread-safety guards to ArchiveReader to prevent accessing memory-mapped buffer after close(). When multiple coroutines read pages concurrently in webtoon mode, recycle() can unmap the buffer while other coroutines are still reading from it, causing a native SIGSEGV in libarchive-jni.so.

Changes:
- ArchiveReader: Add @Volatile isClosed flag and synchronized close() to prevent double-munmap and use-after-free (mirrors existing pattern in ArchiveInputStream)
- ArchiveReader.getInputStream(): Return null early if closed
- ArchiveReader.useEntries(): Check isClosed before proceeding
- ArchivePageLoader.loadPage(): Return gracefully instead of throwing IllegalStateException via check()
- EpubPageLoader.loadPage(): Same fix for consistency

Fixes #3076