### PR TITLE
Address CancellableContinuation.resume deprecation

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -77,7 +77,7 @@ private suspend fun Call.await(callStack: Array<StackTraceElement>): Response {
         val callback =
             object : Callback {
                 override fun onResponse(call: Call, response: Response) {
-                    continuation.resume(response) {
+                    continuation.resume(response) { _, _, _ ->
                         response.body.close()
                     }
                 }


### PR DESCRIPTION
According to the source docs, this has been a warning since kotlinx.coroutines 1.9.0.