### PR TITLE
Address Gradle warning about `Task.project`

### DIFF
--- a/gradle/build-logic/src/main/kotlin/mihon/gradle/tasks/GenerateLocalesConfigTask.kt
+++ b/gradle/build-logic/src/main/kotlin/mihon/gradle/tasks/GenerateLocalesConfigTask.kt
@@ -2,19 +2,24 @@ package mihon.gradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
 abstract class GenerateLocalesConfigTask : DefaultTask() {
+
+    @get:Inject
+    abstract val objectFactory: ObjectFactory
 
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
 
     @TaskAction
     fun action() {
-        val locales = project.fileTree("src/commonMain/moko-resources") {
-            matching { include("**/strings.xml") }
-        }
+        val locales = objectFactory.fileTree()
+            .from("src/commonMain/moko-resources")
+            .matching { include("**/strings.xml") }
             .asSequence()
             .filterNot { it.readText().contains(emptyResourcesElement) }
             .map {


### PR DESCRIPTION
Apparently, this is all that's needed to replace the forbidden `Task.project` accessor, which would be an error in Gradle v10 (it's been deprecated for a while)

This will also allow us to use the Configuration Cache if we wanted to (which we should since that'll be mandatory for v10 as well and it seems to be quite speedy from some cursory testing on my machine).

I checked, and the output XML contents generated by the previous code and this new code is identical.


Gradle docs about this:
https://docs.gradle.org/9.4.1/userguide/upgrading_version_7.html#task_project
https://docs.gradle.org/9.4.1/userguide/configuration_cache_requirements.html#config_cache:requirements:use_project_during_execution
