### PR TITLE
Enable Gradle Configuration Cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,6 @@ kotlin.code.style=official
 # Configuration should be synced with [/gradle/build-logic/gradle.properties]
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true


### PR DESCRIPTION
Gradle did a magic: https://docs.gradle.org/9.4.1/userguide/configuration_cache.html

> Gradle’s Build Cache has long optimized the execution phase by reusing previously built outputs and parallelizing as much work as possible.
>
> The Configuration Cache builds on this idea of work avoidance and parallelization. When enabled, the Configuration Cache allows Gradle to skip the configuration phase entirely if nothing that affects the build configuration (such as build scripts) has changed. Additionally, Gradle applies performance optimizations to task execution.

In the docs, they also note the following:

> This feature is not enabled by default and has the following limitations:
>
> It does not yet support all [Core Gradle Plugins](https://docs.gradle.org/9.4.1/userguide/configuration_cache_status.html#config_cache:plugins:core) and [features](https://docs.gradle.org/9.4.1/userguide/configuration_cache_status.html#config_cache:not_yet_implemented). Full support is in progress.
>
> Your build and its plugins may require modifications to meet the [Configuration Cache requirements](https://docs.gradle.org/9.4.1/userguide/configuration_cache_requirements.html#config_cache:requirements).
>
> [IDE imports and syncs](https://docs.gradle.org/9.4.1/userguide/configuration_cache.html#config_cache:ide) do not yet use the Configuration Cache.
>
> Continuous Integration (CI) support is actively evolving.
>
> Since Gradle 9.0.0 the Configuration Cache is the [preferred mode of execution](https://blog.gradle.org/road-to-configuration-cache#preferred-mode-of-execution).