### PR TITLE
Add informative error for unapproved MAL titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Improved
+- Show informative error when trying to add unapproved titles to list on MAL ([@MajorTanya](https://github.com/MajorTanya)) ([#3155](https://github.com/mihonapp/mihon/pull/3155))
 
 ## [v0.19.7] - 2026-03-23
 Same as v0.19.6

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -12,7 +12,9 @@ import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALSearchResult
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUser
 import eu.kanade.tachiyomi.network.DELETE
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
 import eu.kanade.tachiyomi.util.PkceUtil
@@ -122,8 +124,23 @@ class MyAnimeListApi(
                 .put(formBodyBuilder.build())
                 .build()
             with(json) {
-                authClient.newCall(request)
-                    .awaitSuccess()
+                val response = authClient
+                    .newCall(request)
+                    .await()
+
+                if (!response.isSuccessful) {
+                    if (response.body.string().contains("invalid_content")) {
+                        // MAL returns unapproved titles in search but does not allow adding them to the list
+                        // returns 400 with this body: {"message":"Invalid content","error":"invalid_content"}
+                        // These unapproved titles cannot be filtered out in search and are also returned by the
+                        // endpoint we use for id prefix search
+                        throw MALTitleNotApproved()
+                    } else {
+                        throw HttpException(response.code)
+                    }
+                }
+
+                response
                     .parseAs<MALListItemStatus>()
                     .let { parseMangaItem(it, track) }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
@@ -80,5 +80,6 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList) : Interceptor
     }
 }
 
+class MALTitleNotApproved : IOException("MAL: This title can't be added because it is waiting for approval.")
 class MALTokenRefreshFailed : IOException("MAL: Failed to refresh account token")
 class MALTokenExpired : IOException("MAL: Login has expired")


### PR DESCRIPTION
MAL has a concept of "titles waiting for approval". These titles cannot be added to user lists, but they do show up on the website and crucially, in search results.

However, trying to add such an "unapproved" title will return a 400 error response with the error "invalid_content".

Previously, the awaitSuccess() call would mean the generic "HTTP 400" toast would be shown. Now, a dedicated informative error message is shown instead.

No, these cannnot be filtered out in the search in any way, and their JSON response body looks like any other normal title. Example response when searching `id:138242`:
```json
{
    "id": 138242,
    "title": "Houkai 3rd: The Comic",
    "main_picture": {
        "medium": "https://myanimelist.net/images/manga/1/247423.jpg",
        "large": "https://myanimelist.net/images/manga/1/247423l.jpg"
    },
    "synopsis": "2013: The 3rd Honkai War started in eastern Nagazora. 3 young girls survived the incident.  After being rescued by the Schicksal Far East Branch, these girls were found to hold immense powers that may very well help the human race survive the Honkai onslaught. This is their story.\n\n(Source: Chruncuroll)",
    "num_chapters": 0,
    "status": "currently_publishing",
    "media_type": "manga",
    "start_date": "2019-06-06"
}
```

<details>
<summary>Fuller response object with all available fields included</summary>

```json
{
	"id": 138242,
	"title": "Houkai 3rd: The Comic",
	"main_picture": {
		"medium": "https://myanimelist.net/images/manga/1/247423.jpg",
		"large": "https://myanimelist.net/images/manga/1/247423l.jpg"
	},
	"synopsis": "2013: The 3rd Honkai War started in eastern Nagazora. 3 young girls survived the incident.  After being rescued by the Schicksal Far East Branch, these girls were found to hold immense powers that may very well help the human race survive the Honkai onslaught. This is their story.\n\n(Source: Chruncuroll)",
	"num_chapters": 0,
	"status": "currently_publishing",
	"media_type": "manga",
	"start_date": "2019-06-06",
	"alternative_titles": {
		"synonyms": [
			"Honkai Impact 3rd"
		],
		"en": "",
		"ja": "崩壊3rd THE COMIC"
	},
	"rank": 0,
	"popularity": 0,
	"num_list_users": 0,
	"num_scoring_users": 0,
	"nsfw": "gray",
	"genres": [
		{
			"id": 1,
			"name": "Action"
		},
		{
			"id": 8,
			"name": "Drama"
		},
		{
			"id": 24,
			"name": "Sci-Fi"
		},
		{
			"id": 27,
			"name": "Shounen"
		}
	],
	"created_at": "1970-01-01T00:00:00+00:00",
	"updated_at": "2022-02-04T05:15:52+00:00",
	"num_volumes": 0,
	"pictures": [
		{
			"medium": "https://myanimelist.net/images/manga/1/247423.jpg",
			"large": "https://myanimelist.net/images/manga/1/247423l.jpg"
		}
	],
	"background": "Adaptation of miHoYo's Honkai Impact 3rd video game.",
	"related_anime": [],
	"related_manga": [],
	"recommendations": [],
	"serialization": []
}
```
</details>

[Screen_recording_20260326_095309.webm](https://github.com/user-attachments/assets/cd4649e3-2d39-40cb-944e-65414b953a01)
