### PR TITLE
Include read history when migrating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Show informative error when trying to add unapproved titles to list on MAL ([@MajorTanya](https://github.com/MajorTanya)) ([#3155](https://github.com/mihonapp/mihon/pull/3155))
+- Include read history when migrating an entry with Chapters ([@BrutuZ](https://github.com/BrutuZ)) ([#3163](https://github.com/mihonapp/mihon/pull/3163))
 
 ## [v0.19.7] - 2026-03-23
 Same as v0.19.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Batch database operations during backup restore for improved performance ([@Lolle2000la](https://github.com/Lolle2000la)) ([#3267](https://github.com/mihonapp/mihon/pull/3267))
+- Include read history when migrating an entry with Chapters ([@BrutuZ](https://github.com/BrutuZ)) ([#3163](https://github.com/mihonapp/mihon/pull/3163))
 
 ### Fixed
 - Add missing `outlineVariant` color to Nord theme ([@CompileConnected](https://github.com/CompileConnected)) ([#3184](https://github.com/mihonapp/mihon/pull/3184))

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -138,7 +138,7 @@ class DomainModule : InjektModule {
         addFactory { SetExcludedScanlators(get()) }
         addFactory {
             MigrateMangaUseCase(
-                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
+                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()
             )
         }
 

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -138,7 +138,7 @@ class DomainModule : InjektModule {
         addFactory { SetExcludedScanlators(get()) }
         addFactory {
             MigrateMangaUseCase(
-                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get()
+                get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),
             )
         }
 

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -16,6 +16,9 @@ import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.toChapterUpdate
+import tachiyomi.domain.history.interactor.GetHistory
+import tachiyomi.domain.history.interactor.UpsertHistory
+import tachiyomi.domain.history.model.toHistoryUpdate
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.source.service.SourceManager
@@ -30,8 +33,10 @@ class MigrateMangaUseCase(
     private val downloadManager: DownloadManager,
     private val updateManga: UpdateManga,
     private val getChaptersByMangaId: GetChaptersByMangaId,
+    private val getHistoryByMangaId: GetHistory,
     private val syncChaptersWithSource: SyncChaptersWithSource,
     private val updateChapter: UpdateChapter,
+    private val updateHistory: UpsertHistory,
     private val getCategories: GetCategories,
     private val setMangaCategories: SetMangaCategories,
     private val getTracks: GetTracks,
@@ -86,6 +91,26 @@ class MigrateMangaUseCase(
 
                 val chapterUpdates = updatedMangaChapters.map { it.toChapterUpdate() }
                 updateChapter.awaitAll(chapterUpdates)
+
+                val prevMangaHistory = getHistoryByMangaId.await(current.id)
+
+                val updateChaptersHistory = prevMangaHistory.map { history ->
+                    var updatedHistory = history
+                    val prevChapter = prevMangaChapters.find { it.id == history.chapterId }
+                    if (history.readAt != null && prevChapter != null) {
+                        val prevHistory = prevMangaHistory.find { it.readAt !== null && it.chapterId == prevChapter.id }
+                        val currentChapter = mangaChapters.find { it.chapterNumber == prevChapter.chapterNumber }
+
+                        if (prevHistory != null && currentChapter != null) {
+                            updatedHistory = updatedHistory.copy(chapterId = currentChapter.id)
+                        }
+                    }
+
+                    updatedHistory
+                }
+
+                val historyUpdates = updateChaptersHistory.map { it.toHistoryUpdate() }
+                updateHistory.awaitAll(historyUpdates)
             }
 
             // Update categories

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -64,20 +64,21 @@ class MigrateMangaUseCase(
             // Update chapters read state, history, bookmark and dateFetch
             if (MigrationFlag.CHAPTER in flags) {
                 val chapterUpdates = mutableListOf<ChapterUpdate>()
-                val mangaChapters = getChaptersByMangaId.await(target.id)
-                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val targetChapters = getChaptersByMangaId.await(target.id)
+                val currentChapters = getChaptersByMangaId.await(current.id)
                 val historyUpdates = mutableListOf<HistoryUpdate>()
-                val prevMangaHistory = getHistoryByMangaId.await(current.id)
+                val targetHistory = getHistoryByMangaId.await(target.id)
+                val currentHistory = getHistoryByMangaId.await(current.id)
 
-                val maxChapterRead = prevMangaChapters
+                val maxChapterRead = currentChapters
                     .filter { it.read }
                     .maxOfOrNull { it.chapterNumber }
 
-                mangaChapters.forEach { mangaChapter ->
+                targetChapters.forEach { mangaChapter ->
                     var updatedChapter = mangaChapter
 
                     if (updatedChapter.isRecognizedNumber) {
-                        val prevChapter = prevMangaChapters
+                        val prevChapter = currentChapters
                             .find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
 
                         if (prevChapter != null) {
@@ -86,9 +87,11 @@ class MigrateMangaUseCase(
                                 bookmark = prevChapter.bookmark,
                             )
 
-                            var updatedHistory = prevMangaHistory.find { it.chapterId == prevChapter.id }
+                            var updatedHistory = currentHistory.find { it.chapterId == prevChapter.id }
+                            val chapterHasHistory =
+                                mangaChapter.read && targetHistory.find { it.chapterId == mangaChapter.id } != null
 
-                            if (updatedHistory != null) {
+                            if (updatedHistory != null && !chapterHasHistory) {
                                 updatedHistory = updatedHistory.copy(chapterId = updatedChapter.id)
                                 historyUpdates.add(updatedHistory.toHistoryUpdate())
                             }

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -15,9 +15,11 @@ import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.model.toChapterUpdate
 import tachiyomi.domain.history.interactor.GetHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
+import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.history.model.toHistoryUpdate
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
@@ -59,17 +61,21 @@ class MigrateMangaUseCase(
                 // Worst case, chapters won't be synced
             }
 
-            // Update chapters read, bookmark and dateFetch
+            // Update chapters read state, history, bookmark and dateFetch
             if (MigrationFlag.CHAPTER in flags) {
-                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val chapterUpdates = mutableListOf<ChapterUpdate>()
                 val mangaChapters = getChaptersByMangaId.await(target.id)
+                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val historyUpdates = mutableListOf<HistoryUpdate>()
+                val prevMangaHistory = getHistoryByMangaId.await(current.id)
 
                 val maxChapterRead = prevMangaChapters
                     .filter { it.read }
                     .maxOfOrNull { it.chapterNumber }
 
-                val updatedMangaChapters = mangaChapters.map { mangaChapter ->
+                mangaChapters.forEach { mangaChapter ->
                     var updatedChapter = mangaChapter
+
                     if (updatedChapter.isRecognizedNumber) {
                         val prevChapter = prevMangaChapters
                             .find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
@@ -79,37 +85,23 @@ class MigrateMangaUseCase(
                                 dateFetch = prevChapter.dateFetch,
                                 bookmark = prevChapter.bookmark,
                             )
+
+                            var updatedHistory = prevMangaHistory.find { it.chapterId == prevChapter.id }
+
+                            if (updatedHistory != null) {
+                                updatedHistory = updatedHistory.copy(chapterId = updatedChapter.id)
+                                historyUpdates.add(updatedHistory.toHistoryUpdate())
+                            }
                         }
 
                         if (maxChapterRead != null && updatedChapter.chapterNumber <= maxChapterRead) {
                             updatedChapter = updatedChapter.copy(read = true)
                         }
                     }
-
-                    updatedChapter
+                    chapterUpdates.add(updatedChapter.toChapterUpdate())
                 }
 
-                val chapterUpdates = updatedMangaChapters.map { it.toChapterUpdate() }
                 updateChapter.awaitAll(chapterUpdates)
-
-                val prevMangaHistory = getHistoryByMangaId.await(current.id)
-
-                val updateChaptersHistory = prevMangaHistory.map { history ->
-                    var updatedHistory = history
-                    val prevChapter = prevMangaChapters.find { it.id == history.chapterId }
-                    if (history.readAt != null && prevChapter != null) {
-                        val prevHistory = prevMangaHistory.find { it.readAt !== null && it.chapterId == prevChapter.id }
-                        val currentChapter = mangaChapters.find { it.chapterNumber == prevChapter.chapterNumber }
-
-                        if (prevHistory != null && currentChapter != null) {
-                            updatedHistory = updatedHistory.copy(chapterId = currentChapter.id)
-                        }
-                    }
-
-                    updatedHistory
-                }
-
-                val historyUpdates = updateChaptersHistory.map { it.toHistoryUpdate() }
                 updateHistory.awaitAll(historyUpdates)
             }
 

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -14,9 +14,11 @@ import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.model.toChapterUpdate
 import tachiyomi.domain.history.interactor.GetHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
+import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.history.model.toHistoryUpdate
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
@@ -52,17 +54,21 @@ class MigrateMangaUseCase(
         try {
             updateMangaFromRemote(target, fetchChapters = true).getOrThrow()
 
-            // Update chapters read, bookmark and dateFetch
+            // Update chapters read state, history, bookmark and dateFetch
             if (MigrationFlag.CHAPTER in flags) {
-                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val chapterUpdates = mutableListOf<ChapterUpdate>()
                 val mangaChapters = getChaptersByMangaId.await(target.id)
+                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val historyUpdates = mutableListOf<HistoryUpdate>()
+                val prevMangaHistory = getHistoryByMangaId.await(current.id)
 
                 val maxChapterRead = prevMangaChapters
                     .filter { it.read }
                     .maxOfOrNull { it.chapterNumber }
 
-                val updatedMangaChapters = mangaChapters.map { mangaChapter ->
+                mangaChapters.forEach { mangaChapter ->
                     var updatedChapter = mangaChapter
+
                     if (updatedChapter.isRecognizedNumber) {
                         val prevChapter = prevMangaChapters
                             .find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
@@ -72,37 +78,23 @@ class MigrateMangaUseCase(
                                 dateFetch = prevChapter.dateFetch,
                                 bookmark = prevChapter.bookmark,
                             )
+
+                            var updatedHistory = prevMangaHistory.find { it.chapterId == prevChapter.id }
+
+                            if (updatedHistory != null) {
+                                updatedHistory = updatedHistory.copy(chapterId = updatedChapter.id)
+                                historyUpdates.add(updatedHistory.toHistoryUpdate())
+                            }
                         }
 
                         if (maxChapterRead != null && updatedChapter.chapterNumber <= maxChapterRead) {
                             updatedChapter = updatedChapter.copy(read = true)
                         }
                     }
-
-                    updatedChapter
+                    chapterUpdates.add(updatedChapter.toChapterUpdate())
                 }
 
-                val chapterUpdates = updatedMangaChapters.map { it.toChapterUpdate() }
                 updateChapter.awaitAll(chapterUpdates)
-
-                val prevMangaHistory = getHistoryByMangaId.await(current.id)
-
-                val updateChaptersHistory = prevMangaHistory.map { history ->
-                    var updatedHistory = history
-                    val prevChapter = prevMangaChapters.find { it.id == history.chapterId }
-                    if (history.readAt != null && prevChapter != null) {
-                        val prevHistory = prevMangaHistory.find { it.readAt !== null && it.chapterId == prevChapter.id }
-                        val currentChapter = mangaChapters.find { it.chapterNumber == prevChapter.chapterNumber }
-
-                        if (prevHistory != null && currentChapter != null) {
-                            updatedHistory = updatedHistory.copy(chapterId = currentChapter.id)
-                        }
-                    }
-
-                    updatedHistory
-                }
-
-                val historyUpdates = updateChaptersHistory.map { it.toHistoryUpdate() }
                 updateHistory.awaitAll(historyUpdates)
             }
 

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -84,7 +84,7 @@ class MigrateMangaUseCase(
                             val chapterHasHistory =
                                 mangaChapter.read && targetHistory.find { it.chapterId == mangaChapter.id } != null
 
-                            if (updatedHistory != null && !chapterHasHistory) {
+                            if (!chapterHasHistory && updatedHistory?.readAt != null) {
                                 updatedHistory = updatedHistory.copy(chapterId = updatedChapter.id)
                                 historyUpdates.add(updatedHistory.toHistoryUpdate())
                             }

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -15,6 +15,9 @@ import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.toChapterUpdate
+import tachiyomi.domain.history.interactor.GetHistory
+import tachiyomi.domain.history.interactor.UpsertHistory
+import tachiyomi.domain.history.model.toHistoryUpdate
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.source.service.SourceManager
@@ -29,7 +32,9 @@ class MigrateMangaUseCase(
     private val downloadManager: DownloadManager,
     private val updateManga: UpdateManga,
     private val getChaptersByMangaId: GetChaptersByMangaId,
+    private val getHistoryByMangaId: GetHistory,
     private val updateChapter: UpdateChapter,
+    private val updateHistory: UpsertHistory,
     private val getCategories: GetCategories,
     private val setMangaCategories: SetMangaCategories,
     private val getTracks: GetTracks,
@@ -79,6 +84,26 @@ class MigrateMangaUseCase(
 
                 val chapterUpdates = updatedMangaChapters.map { it.toChapterUpdate() }
                 updateChapter.awaitAll(chapterUpdates)
+
+                val prevMangaHistory = getHistoryByMangaId.await(current.id)
+
+                val updateChaptersHistory = prevMangaHistory.map { history ->
+                    var updatedHistory = history
+                    val prevChapter = prevMangaChapters.find { it.id == history.chapterId }
+                    if (history.readAt != null && prevChapter != null) {
+                        val prevHistory = prevMangaHistory.find { it.readAt !== null && it.chapterId == prevChapter.id }
+                        val currentChapter = mangaChapters.find { it.chapterNumber == prevChapter.chapterNumber }
+
+                        if (prevHistory != null && currentChapter != null) {
+                            updatedHistory = updatedHistory.copy(chapterId = currentChapter.id)
+                        }
+                    }
+
+                    updatedHistory
+                }
+
+                val historyUpdates = updateChaptersHistory.map { it.toHistoryUpdate() }
+                updateHistory.awaitAll(historyUpdates)
             }
 
             // Update categories

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -57,20 +57,21 @@ class MigrateMangaUseCase(
             // Update chapters read state, history, bookmark and dateFetch
             if (MigrationFlag.CHAPTER in flags) {
                 val chapterUpdates = mutableListOf<ChapterUpdate>()
-                val mangaChapters = getChaptersByMangaId.await(target.id)
-                val prevMangaChapters = getChaptersByMangaId.await(current.id)
+                val targetChapters = getChaptersByMangaId.await(target.id)
+                val currentChapters = getChaptersByMangaId.await(current.id)
                 val historyUpdates = mutableListOf<HistoryUpdate>()
-                val prevMangaHistory = getHistoryByMangaId.await(current.id)
+                val targetHistory = getHistoryByMangaId.await(target.id)
+                val currentHistory = getHistoryByMangaId.await(current.id)
 
-                val maxChapterRead = prevMangaChapters
+                val maxChapterRead = currentChapters
                     .filter { it.read }
                     .maxOfOrNull { it.chapterNumber }
 
-                mangaChapters.forEach { mangaChapter ->
+                targetChapters.forEach { mangaChapter ->
                     var updatedChapter = mangaChapter
 
                     if (updatedChapter.isRecognizedNumber) {
-                        val prevChapter = prevMangaChapters
+                        val prevChapter = currentChapters
                             .find { it.isRecognizedNumber && it.chapterNumber == updatedChapter.chapterNumber }
 
                         if (prevChapter != null) {
@@ -79,9 +80,11 @@ class MigrateMangaUseCase(
                                 bookmark = prevChapter.bookmark,
                             )
 
-                            var updatedHistory = prevMangaHistory.find { it.chapterId == prevChapter.id }
+                            var updatedHistory = currentHistory.find { it.chapterId == prevChapter.id }
+                            val chapterHasHistory =
+                                mangaChapter.read && targetHistory.find { it.chapterId == mangaChapter.id } != null
 
-                            if (updatedHistory != null) {
+                            if (updatedHistory != null && !chapterHasHistory) {
                                 updatedHistory = updatedHistory.copy(chapterId = updatedChapter.id)
                                 historyUpdates.add(updatedHistory.toHistoryUpdate())
                             }

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -58,15 +58,23 @@ class HistoryRepositoryImpl(
             false
         }
     }
-
     override suspend fun upsertHistory(historyUpdate: HistoryUpdate) {
+        partialUpdate(historyUpdate)
+    }
+
+    override suspend fun upsertAllHistory(historyUpdate: List<HistoryUpdate>) {
+        partialUpdate(*historyUpdate.toTypedArray())
+    }
+    private suspend fun partialUpdate(vararg historyUpdates: HistoryUpdate) {
         try {
-            handler.await {
-                historyQueries.upsert(
-                    historyUpdate.chapterId,
-                    historyUpdate.readAt,
-                    historyUpdate.sessionReadDuration,
-                )
+            handler.await(inTransaction = true) {
+                historyUpdates.forEach { historyUpdate ->
+                    historyQueries.upsert(
+                        chapterId = historyUpdate.chapterId,
+                        readAt = historyUpdate.readAt,
+                        time_read = historyUpdate.sessionReadDuration
+                    )
+                }
             }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -58,6 +58,7 @@ class HistoryRepositoryImpl(
             false
         }
     }
+
     override suspend fun upsertHistory(historyUpdate: HistoryUpdate) {
         partialUpdate(historyUpdate)
     }
@@ -65,6 +66,7 @@ class HistoryRepositoryImpl(
     override suspend fun upsertAllHistory(historyUpdate: List<HistoryUpdate>) {
         partialUpdate(*historyUpdate.toTypedArray())
     }
+
     private suspend fun partialUpdate(vararg historyUpdates: HistoryUpdate) {
         try {
             handler.await(inTransaction = true) {
@@ -72,7 +74,7 @@ class HistoryRepositoryImpl(
                     historyQueries.upsert(
                         chapterId = historyUpdate.chapterId,
                         readAt = historyUpdate.readAt,
-                        time_read = historyUpdate.sessionReadDuration
+                        time_read = historyUpdate.sessionReadDuration,
                     )
                 }
             }

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -77,14 +77,12 @@ class HistoryRepositoryImpl(
 
     private suspend fun partialUpdate(vararg historyUpdates: HistoryUpdate) {
         try {
-            handler.await(inTransaction = true) {
-                historyUpdates.forEach { historyUpdate ->
-                    database.historyQueries.upsert(
-                        chapterId = historyUpdate.chapterId,
-                        readAt = historyUpdate.readAt,
-                        time_read = historyUpdate.sessionReadDuration,
-                    )
-                }
+            historyUpdates.forEach { historyUpdate ->
+                database.historyQueries.upsert(
+                    chapterId = historyUpdate.chapterId,
+                    readAt = historyUpdate.readAt,
+                    time_read = historyUpdate.sessionReadDuration,
+                )
             }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -66,14 +66,24 @@ class HistoryRepositoryImpl(
             false
         }
     }
-
     override suspend fun upsertHistory(historyUpdate: HistoryUpdate) {
+        partialUpdate(historyUpdate)
+    }
+
+    override suspend fun upsertAllHistory(historyUpdate: List<HistoryUpdate>) {
+        partialUpdate(*historyUpdate.toTypedArray())
+    }
+    private suspend fun partialUpdate(vararg historyUpdates: HistoryUpdate) {
         try {
-            database.historyQueries.upsert(
-                historyUpdate.chapterId,
-                historyUpdate.readAt,
-                historyUpdate.sessionReadDuration,
-            )
+            handler.await(inTransaction = true) {
+                historyUpdates.forEach { historyUpdate ->
+                    database.historyQueries.upsert(
+                        chapterId = historyUpdate.chapterId,
+                        readAt = historyUpdate.readAt,
+                        time_read = historyUpdate.sessionReadDuration
+                    )
+                }
+            }
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)
         }

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -66,6 +66,7 @@ class HistoryRepositoryImpl(
             false
         }
     }
+
     override suspend fun upsertHistory(historyUpdate: HistoryUpdate) {
         partialUpdate(historyUpdate)
     }
@@ -73,6 +74,7 @@ class HistoryRepositoryImpl(
     override suspend fun upsertAllHistory(historyUpdate: List<HistoryUpdate>) {
         partialUpdate(*historyUpdate.toTypedArray())
     }
+
     private suspend fun partialUpdate(vararg historyUpdates: HistoryUpdate) {
         try {
             handler.await(inTransaction = true) {
@@ -80,7 +82,7 @@ class HistoryRepositoryImpl(
                     database.historyQueries.upsert(
                         chapterId = historyUpdate.chapterId,
                         readAt = historyUpdate.readAt,
-                        time_read = historyUpdate.sessionReadDuration
+                        time_read = historyUpdate.sessionReadDuration,
                     )
                 }
             }

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
@@ -14,7 +14,6 @@ class UpsertHistory(
             historyRepository.upsertHistory(historyUpdate)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
-
         }
     }
 
@@ -23,7 +22,6 @@ class UpsertHistory(
             historyRepository.upsertAllHistory(historyUpdate)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
-
         }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/UpsertHistory.kt
@@ -1,5 +1,7 @@
 package tachiyomi.domain.history.interactor
 
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.history.repository.HistoryRepository
 
@@ -8,6 +10,20 @@ class UpsertHistory(
 ) {
 
     suspend fun await(historyUpdate: HistoryUpdate) {
-        historyRepository.upsertHistory(historyUpdate)
+        try {
+            historyRepository.upsertHistory(historyUpdate)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+
+        }
+    }
+
+    suspend fun awaitAll(historyUpdate: List<HistoryUpdate>) {
+        try {
+            historyRepository.upsertAllHistory(historyUpdate)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+
+        }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/history/model/HistoryUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/model/HistoryUpdate.kt
@@ -7,3 +7,11 @@ data class HistoryUpdate(
     val readAt: Date,
     val sessionReadDuration: Long,
 )
+
+fun History.toHistoryUpdate(): HistoryUpdate {
+    return HistoryUpdate(
+        chapterId,
+        readAt?: Date(0),
+        readDuration,
+    )
+}

--- a/domain/src/main/java/tachiyomi/domain/history/model/HistoryUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/model/HistoryUpdate.kt
@@ -11,7 +11,7 @@ data class HistoryUpdate(
 fun History.toHistoryUpdate(): HistoryUpdate {
     return HistoryUpdate(
         chapterId,
-        readAt?: Date(0),
+        readAt ?: Date(0),
         readDuration,
     )
 }

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -22,4 +22,6 @@ interface HistoryRepository {
     suspend fun deleteAllHistory(): Boolean
 
     suspend fun upsertHistory(historyUpdate: HistoryUpdate)
+
+    suspend fun upsertAllHistory(historyUpdate: List<HistoryUpdate>)
 }


### PR DESCRIPTION
If `Chapters` is checked when migrating entries from library, also migrate the read history, matched by chapter number

Closes #3005 