### PR TITLE
Migrate Manga Screen Long Click Range Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Show informative error when trying to add unapproved titles to list on MAL ([@MajorTanya](https://github.com/MajorTanya)) ([#3155](https://github.com/mihonapp/mihon/pull/3155))
 - Show AniList publishing type based on country of origin ([@zweimach](https://github.com/zweimach)) ([#3100](https://github.com/mihonapp/mihon/pull/3100))
+- Add long click range selection on migrate manga screen ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#3171](https://github.com/mihonapp/mihon/pull/3171))
 
 ### Fixed
 - Fix app trying to split long strip when not needed ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3121](https://github.com/mihonapp/mihon/pull/3121))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Improved
+- Add long click range selection on migrate manga screen ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#3171](https://github.com/mihonapp/mihon/pull/3171))
 
 ## [v0.19.9] - 2026-04-11
 ### Fixed
@@ -28,7 +30,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Improved
 - Show informative error when trying to add unapproved titles to list on MAL ([@MajorTanya](https://github.com/MajorTanya)) ([#3155](https://github.com/mihonapp/mihon/pull/3155))
 - Show AniList publishing type based on country of origin ([@zweimach](https://github.com/zweimach)) ([#3100](https://github.com/mihonapp/mihon/pull/3100))
-- Add long click range selection on migrate manga screen ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#3171](https://github.com/mihonapp/mihon/pull/3171))
 
 ### Fixed
 - Fix app trying to split long strip when not needed ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3121](https://github.com/mihonapp/mihon/pull/3121))

--- a/app/src/main/java/eu/kanade/presentation/manga/components/BaseMangaListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/BaseMangaListItem.kt
@@ -1,6 +1,6 @@
 package eu.kanade.presentation.manga.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -22,6 +22,7 @@ fun BaseMangaListItem(
     manga: Manga,
     modifier: Modifier = Modifier,
     onClickItem: () -> Unit = {},
+    onLongClickItem: () -> Unit = {},
     onClickCover: () -> Unit = onClickItem,
     cover: @Composable RowScope.() -> Unit = { defaultCover(manga, onClickCover) },
     actions: @Composable RowScope.() -> Unit = {},
@@ -29,7 +30,10 @@ fun BaseMangaListItem(
 ) {
     Row(
         modifier = modifier
-            .clickable(onClick = onClickItem)
+            .combinedClickable(
+                onClick = onClickItem,
+                onLongClick = onLongClickItem,
+            )
             .height(56.dp)
             .padding(horizontal = MaterialTheme.padding.medium),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -108,6 +108,7 @@ data class MigrateMangaScreen(
                 contentPadding = contentPadding,
                 state = state,
                 onClickItem = screenModel::toggleSelection,
+                onLongClickItem = screenModel::toggleRangeSelection,
                 onClickCover = { navigator.push(MangaScreen(it.id)) },
             )
         }
@@ -129,6 +130,7 @@ data class MigrateMangaScreen(
         contentPadding: PaddingValues,
         state: MigrateMangaScreenModel.State,
         onClickItem: (Manga) -> Unit,
+        onLongClickItem: (Manga) -> Unit,
         onClickCover: (Manga) -> Unit,
     ) {
         FastScrollLazyColumn(
@@ -140,6 +142,7 @@ data class MigrateMangaScreen(
                     manga = manga,
                     isSelected = manga.id in state.selection,
                     onClickItem = onClickItem,
+                    onLongClickItem = onLongClickItem,
                     onClickCover = onClickCover,
                 )
             }
@@ -151,6 +154,7 @@ data class MigrateMangaScreen(
         manga: Manga,
         isSelected: Boolean,
         onClickItem: (Manga) -> Unit,
+        onLongClickItem: (Manga) -> Unit,
         onClickCover: (Manga) -> Unit,
         modifier: Modifier = Modifier,
     ) {
@@ -158,6 +162,7 @@ data class MigrateMangaScreen(
             modifier = modifier.selectedBackground(isSelected),
             manga = manga,
             onClickItem = { onClickItem(manga) },
+            onLongClickItem = { onLongClickItem(manga) },
             onClickCover = { onClickCover(manga) },
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -23,6 +23,7 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.manga.components.BaseMangaListItem
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -47,7 +48,7 @@ data class MigrateMangaScreen(
     override fun Content() {
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
-        val screenModel = rememberScreenModel { MigrateMangaScreenModel(sourceId) }
+        val screenModel = rememberScreenModel { MigrateMangaScreenModel(context, sourceId) }
 
         val state by screenModel.state.collectAsState()
 
@@ -66,6 +67,7 @@ data class MigrateMangaScreen(
             topBar = { scrollBehavior ->
                 AppBar(
                     title = state.source!!.name,
+                    subtitle = state.selection.size.toString() + '/' + screenModel.maximumMigrationSelection,
                     navigateUp = {
                         if (state.selectionMode) {
                             screenModel.clearSelection()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -1,9 +1,11 @@
 package eu.kanade.tachiyomi.ui.browse.migration.manga
 
+import android.content.Context
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -17,14 +19,19 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import mihon.core.common.utils.mutate
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.interactor.GetFavorites
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 class MigrateMangaScreenModel(
+    private val context: Context,
     private val sourceId: Long,
     private val sourceManager: SourceManager = Injekt.get(),
     private val getFavorites: GetFavorites = Injekt.get(),
@@ -32,6 +39,7 @@ class MigrateMangaScreenModel(
 
     private val _events: Channel<MigrationMangaEvent> = Channel()
     val events: Flow<MigrationMangaEvent> = _events.receiveAsFlow()
+    val maximumMigrationSelection = 50
 
     init {
         screenModelScope.launch {
@@ -61,7 +69,17 @@ class MigrateMangaScreenModel(
     fun toggleSelection(item: Manga) {
         mutableState.update { state ->
             val selection = state.selection.mutate { list ->
-                if (!list.remove(item.id)) list.add(item.id)
+                if (!list.remove(item.id)) {
+                    if (state.selection.size == maximumMigrationSelection) {
+                        screenModelScope.launchIO {
+                            withUIContext {
+                                context.toast(context.stringResource(MR.strings.migration_limit_reached))
+                            }
+                        }
+                        return@mutate
+                    }
+                    list.add(item.id)
+                }
             }
             state.copy(selection = selection)
         }
@@ -72,7 +90,6 @@ class MigrateMangaScreenModel(
             val newSelection = state.selection.mutate { list ->
                 val lastSelectedId = list.lastOrNull()
                 val lastSelectedManga = state.titles.find { it.id == lastSelectedId }
-                list.add(item.id)
                 val lastMangaIndex = state.titles.indexOf(lastSelectedManga)
                 val curMangaIndex = state.titles.indexOf(item)
 
@@ -82,7 +99,18 @@ class MigrateMangaScreenModel(
                     // We shouldn't reach this point
                     else -> return@mutate
                 }
-                selectionRange.mapNotNull { state.titles[it].id }.let(list::addAll)
+
+                val selectionLimit = maximumMigrationSelection - list.size
+                val limitedSelectionRange = selectionRange.take(selectionLimit + 1)
+                if (limitedSelectionRange.last() != selectionRange.last) {
+                    screenModelScope.launchIO {
+                        withUIContext {
+                            context.toast(context.stringResource(MR.strings.migration_limit_reached))
+                        }
+                    }
+                }
+
+                limitedSelectionRange.map { state.titles[it].id }.let(list::addAll)
             }
             state.copy(selection = newSelection)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -67,6 +67,27 @@ class MigrateMangaScreenModel(
         }
     }
 
+    fun toggleRangeSelection(item: Manga) {
+        mutableState.update { state ->
+            val newSelection = state.selection.mutate { list ->
+                val lastSelectedId = list.lastOrNull()
+                val lastSelectedManga = state.titles.find { it.id == lastSelectedId }
+                list.add(item.id)
+                val lastMangaIndex = state.titles.indexOf(lastSelectedManga)
+                val curMangaIndex = state.titles.indexOf(item)
+
+                val selectionRange = when {
+                    lastMangaIndex < curMangaIndex -> lastMangaIndex..curMangaIndex
+                    curMangaIndex < lastMangaIndex -> curMangaIndex..lastMangaIndex
+                    // We shouldn't reach this point
+                    else -> return@mutate
+                }
+                selectionRange.mapNotNull { state.titles[it].id }.let(list::addAll)
+            }
+            state.copy(selection = newSelection)
+        }
+    }
+
     fun clearSelection() {
         mutableState.update { it.copy(selection = emptySet()) }
     }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -879,6 +879,7 @@
     <string name="migration_help_guide">Source migration guide</string>
     <string name="migration_dialog_what_to_include">Select data to include</string>
     <string name="migration_selection_prompt">Select a source to migrate from</string>
+    <string name="migration_limit_reached">Batch migration limit reached</string>
     <string name="migrate">Migrate</string>
     <!-- Make a copy (noun) when migrating. Don't use for copying to clipboard. -->
     <string name="copy">Copy</string>


### PR DESCRIPTION
long click on manga migrate screen to select the range of items between previous selection and long held one, just used the same logic as the library screen.