### PR TITLE
fix: null baseDir with no retry

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/storage/service/StorageManager.kt
+++ b/domain/src/main/java/tachiyomi/domain/storage/service/StorageManager.kt
@@ -30,7 +30,6 @@ class StorageManager(
 
     init {
         storagePreferences.baseStorageDirectory.changes()
-            .drop(1)
             .distinctUntilChanged()
             .onEach { uri ->
                 baseDir = getBaseDir(uri)


### PR DESCRIPTION
During cold start (especially when StorageManager is instantiated during Application.onCreate()), the DocumentsProvider backing the SAF URI may not be fully ready, or the persisted URI permissions haven't been restored yet. The exists() implementation catches all exceptions (including SecurityException) and returns false. The init block subscribes to preference changes with .drop(1), which skips the initial emission. So once the field initializer fails, baseDir stays null until the user manually changes the directory.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
