### PR TITLE
Fix AniList user list item fetch erroring

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearchItem.kt
@@ -9,12 +9,12 @@ data class ALSearchItem(
     val coverImage: ItemCover,
     val description: String?,
     val format: String,
-    val countryOfOrigin: String,
     val status: String?,
     val startDate: ALFuzzyDate,
     val chapters: Long?,
     val averageScore: Int?,
     val staff: ALStaff,
+    val countryOfOrigin: String = "",
 ) {
     fun toALManga(): ALManga = ALManga(
         remoteId = id,


### PR DESCRIPTION
The countryOfOrigin field was not included in the findLibManga query so it is not returned by AniList. Defaulting to an empty string here should be fine since neither countryOfOrigin nor format are shown in the findLibManga consumers (i.e. the tracker sheet of a given library entry).

Fixes an error toast that'd appear when a user opens the tracker sheet.