### PR TITLE
add Fractional progress toggle for library update notifications

### DIFF
--- a/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/base/BasePreferences.kt
@@ -51,4 +51,10 @@ class BasePreferences(
         Preference.appStateKey("donation_campaign_shown"),
         false,
     )
+
+    val enableFractionalProgress: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_enable_fractional",
+        false,
+    )
+    
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -114,6 +114,11 @@ object SettingsAdvancedScreen : SearchableSettings {
             Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.pref_onboarding_guide),
                 onClick = { navigator.push(OnboardingScreen()) },
+            ),            
+            Preference.PreferenceItem.SwitchPreference(
+                preference = basePreferences.enableFractionalProgress,
+                title = stringResource(MR.strings.pref_enable_fractional),
+                subtitle = stringResource(MR.strings.pref_enable_fractional_summary),
             ),
             Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.pref_manage_notifications),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -46,6 +46,7 @@ class LibraryUpdateNotifier(
     private val context: Context,
 
     private val securityPreferences: SecurityPreferences = Injekt.get(),
+    private val basePreferences: BasePreferences = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
 ) {
 
@@ -90,26 +91,35 @@ class LibraryUpdateNotifier(
      * @param total the total progress.
      */
     fun showProgressNotification(manga: List<Manga>, current: Int, total: Int) {
+    // Determine the content text based on the user preference
+        val contentText = if (basePreferences.enableFractionalProgress.get()) {
+            // Show both fraction and percentage
+            "$current/$total (${percentFormatter.format(current.toFloat() / total)})"
+        } else {
+            // Show only percentage
+            percentFormatter.format(current.toFloat() / total)
+        }
+    
         progressNotificationBuilder
             .setContentTitle(
                 context.stringResource(
                     MR.strings.notification_updating_progress,
-                    percentFormatter.format(current.toFloat() / total),
+                    contentText,
                 ),
             )
-
+    
         if (!securityPreferences.hideNotificationContent.get()) {
             val updatingText = manga.joinToString("\n") { it.title.chop(40) }
             progressNotificationBuilder.setStyle(NotificationCompat.BigTextStyle().bigText(updatingText))
         }
-
+    
         context.notify(
             Notifications.ID_LIBRARY_PROGRESS,
             progressNotificationBuilder
                 .setProgress(total, current, false)
                 .build(),
-        )
-    }
+    )
+}
 
     /**
      * Warn when excessively checking any single source.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -32,6 +32,7 @@ import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchUI
+import eu.kanade.domain.base.BasePreferences
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.Manga

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -639,6 +639,8 @@
     <string name="pref_debug_info">Debug info</string>
     <string name="pref_update_library_manga_titles">Update library manga titles to match source</string>
     <string name="pref_update_library_manga_titles_summary">Warning: if a manga is renamed, it will be removed from the download queue (if present).</string>
+    <string name="pref_enable_fractional">Show fractional progress</string>
+    <string name="pref_enable_fractional_summary">Display progress as a fraction (e.g., 34/89) in addition to percentage.</string>
 
       <!-- About section -->
     <string name="website">Website</string>


### PR DESCRIPTION
### Summary
Adds a toggle in Advanced settings that controls whether library update notifications show fractional progress (e.g. 54/98) alongside percentage progress.

### Changes
Updated BasePreferences.kt to add preference for fractional progress display
Updated SettingsAdvancedScreen.kt to expose the toggle in Advanced settings
Updated LibraryUpdateNotifier.kt to apply the new display behavior
Updated res/values/strings.xml (or base/strings.xml) for new string resources

### Scope
UI + notification behavior change in library update system.
No database or migration changes required.

### Testing
Tested on a physical device via Android Studio run config.

Toggle disabled > default percentage-only behavior
Toggle enabled > notifications show X/Y + percentage
No crashes observed in Logcat
Verified during active library update flow