### PR TITLE
feat: add sidebar offset and "fill height" cropping for foldable devices

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -148,6 +148,11 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         },
         pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
     )
+
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_pager_cover_mode),
+        pref = screenModel.preferences.pagerCoverMode,
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -62,6 +62,12 @@ internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel)
 @Composable
 private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenModel) {
     val numberFormat = remember { NumberFormat.getPercentInstance() }
+    val edgeWidthFormat = remember {
+        NumberFormat.getPercentInstance().apply {
+            minimumFractionDigits = 2
+            maximumFractionDigits = 2
+        }
+    }
 
     HeadingItem(MR.strings.pager_viewer)
 
@@ -142,7 +148,7 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         value = pagerEdgeWidth,
         valueRange = ReaderPreferences.PAGER_EDGE_WIDTH_MIN..ReaderPreferences.PAGER_EDGE_WIDTH_MAX,
         label = stringResource(MR.strings.pref_pager_edge_width),
-        valueString = numberFormat.format(pagerEdgeWidth / 100f),
+        valueString = edgeWidthFormat.format(pagerEdgeWidth / 400f),
         onChange = {
             screenModel.preferences.pagerEdgeWidth.set(it)
         },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -205,8 +205,8 @@ class ReaderPreferences(
         const val WEBTOON_PADDING_MIN = 0
         const val WEBTOON_PADDING_MAX = 25
 
-        const val PAGER_EDGE_WIDTH_MIN = 70
-        const val PAGER_EDGE_WIDTH_MAX = 100
+        const val PAGER_EDGE_WIDTH_MIN = 280
+        const val PAGER_EDGE_WIDTH_MAX = 400
 
         const val MILLI_CONVERSION = 100
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -74,6 +74,8 @@ class ReaderPreferences(
 
     val pagerEdgeWidth: Preference<Int> = preferenceStore.getInt("pager_edge_width", PAGER_EDGE_WIDTH_MAX)
 
+    val pagerCoverMode: Preference<Boolean> = preferenceStore.getBoolean("pager_cover_mode", false)
+
     val readerHideThreshold: Preference<ReaderHideThreshold> = preferenceStore.getEnum(
         "reader_hide_threshold",
         ReaderHideThreshold.LOW,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -31,6 +31,7 @@ import com.davemorrissey.labs.subscaleview.ImageSource
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_IN_OUT_QUAD
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_OUT_QUAD
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_CROP
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
 import com.github.chrisbanes.photoview.PhotoView
 import eu.kanade.domain.base.BasePreferences
@@ -289,9 +290,11 @@ open class ReaderPageImageView @JvmOverloads constructor(
         config: Config,
     ) = (pageView as? SubsamplingScaleImageView)?.apply {
         setDoubleTapZoomDuration(config.zoomDuration.getSystemScaledDuration())
-        setMinimumScaleType(config.minimumScaleType)
+        setMinimumScaleType(if (config.coverMode) SCALE_TYPE_CENTER_CROP else config.minimumScaleType)
         setMinimumDpi(1) // Just so that very small image will be fit for initial load
         setCropBorders(config.cropBorders)
+        setPanEnabled(!config.coverMode)
+        setZoomEnabled(!config.coverMode)
         setOnImageEventListener(
             object : SubsamplingScaleImageView.DefaultOnImageEventListener() {
                 override fun onReady() {
@@ -394,6 +397,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     ) = (pageView as? AppCompatImageView)?.apply {
         if (this is PhotoView) {
             setZoomTransitionDuration(config.zoomDuration.getSystemScaledDuration())
+            isZoomable = !config.coverMode
         }
 
         val request = ImageRequest.Builder(context)
@@ -432,6 +436,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
         val cropBorders: Boolean = false,
         val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
         val landscapeZoom: Boolean = false,
+        val coverMode: Boolean = false,
     )
 
     enum class ZoomStartPosition {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -33,6 +33,9 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_IN_OUT
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.EASE_OUT_QUAD
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_CROP
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_HEIGHT
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView.SCALE_TYPE_ORIGINAL_SIZE
 import com.github.chrisbanes.photoview.PhotoView
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.coil.cropBorders
@@ -272,15 +275,15 @@ open class ReaderPageImageView @JvmOverloads constructor(
         addView(pageView, MATCH_PARENT, MATCH_PARENT)
     }
 
-    private fun SubsamplingScaleImageView.setupZoom(config: Config?) {
+    private fun SubsamplingScaleImageView.setupZoom(config: Config?, effectiveScale: Float = scale) {
         // 5x zoom
-        maxScale = scale * MAX_ZOOM_SCALE
-        setDoubleTapZoomScale(scale * 2)
+        maxScale = effectiveScale * MAX_ZOOM_SCALE
+        setDoubleTapZoomScale(effectiveScale * 2)
 
         when (config?.zoomStartPosition) {
-            ZoomStartPosition.LEFT -> setScaleAndCenter(scale, PointF(0F, 0F))
-            ZoomStartPosition.RIGHT -> setScaleAndCenter(scale, PointF(sWidth.toFloat(), 0F))
-            ZoomStartPosition.CENTER -> setScaleAndCenter(scale, center)
+            ZoomStartPosition.LEFT -> setScaleAndCenter(effectiveScale, PointF(0F, 0F))
+            ZoomStartPosition.RIGHT -> setScaleAndCenter(effectiveScale, PointF(sWidth.toFloat(), 0F))
+            ZoomStartPosition.CENTER -> setScaleAndCenter(effectiveScale, center)
             null -> {}
         }
     }
@@ -298,7 +301,26 @@ open class ReaderPageImageView @JvmOverloads constructor(
         setOnImageEventListener(
             object : SubsamplingScaleImageView.DefaultOnImageEventListener() {
                 override fun onReady() {
-                    setupZoom(config)
+                    // If cover mode is on but the image already fills the screen height
+                    // with normal scaling (portrait image taller than container aspect ratio),
+                    // cover mode is redundant — revert to normal config.
+                    val heightAlreadyFills = config.coverMode &&
+                        width > 0 && height > 0 &&
+                        sHeight.toFloat() / sWidth >= height.toFloat() / width
+                    if (heightAlreadyFills) {
+                        setMinimumScaleType(config.minimumScaleType)
+                        setPanEnabled(true)
+                        setZoomEnabled(true)
+                        val normalScale = when (config.minimumScaleType) {
+                            SCALE_TYPE_FIT_WIDTH -> width.toFloat() / sWidth
+                            SCALE_TYPE_FIT_HEIGHT -> height.toFloat() / sHeight
+                            SCALE_TYPE_ORIGINAL_SIZE -> 1f
+                            else -> minOf(width.toFloat() / sWidth, height.toFloat() / sHeight)
+                        }
+                        setupZoom(config, effectiveScale = normalScale)
+                    } else {
+                        setupZoom(config)
+                    }
                     if (isVisibleOnScreen()) landscapeZoom(true)
                     this@ReaderPageImageView.onImageLoaded()
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -48,7 +48,7 @@ class PagerConfig(
     var landscapeZoom = false
         private set
 
-    var edgeWidth = 100
+    var edgeWidth = 400
         private set
 
     var coverMode = false

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -51,6 +51,9 @@ class PagerConfig(
     var edgeWidth = 100
         private set
 
+    var coverMode = false
+        private set
+
     init {
         readerPreferences.readerTheme
             .register(
@@ -112,6 +115,9 @@ class PagerConfig(
 
         readerPreferences.pagerEdgeWidth
             .register({ edgeWidth = it }, { imagePropertyChangedListener?.invoke() })
+
+        readerPreferences.pagerCoverMode
+            .register({ coverMode = it }, { imagePropertyChangedListener?.invoke() })
     }
 
     private fun zoomTypeFromPreference(value: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -69,6 +69,7 @@ class PagerPageHolder(
     }
 
     private fun applyEdgeWidth() {
+        if (viewer.config.edgeWidth >= 100) return
         val screenWidth = Resources.getSystem().displayMetrics.widthPixels
         val rightPadding = (screenWidth * (1f - viewer.config.edgeWidth / 100f)).toInt()
         setPadding(0, paddingTop, rightPadding, paddingBottom)
@@ -178,6 +179,7 @@ class PagerPageHolder(
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,
+                        coverMode = viewer.config.coverMode,
                     ),
                 )
                 if (!isAnimated) {
@@ -261,16 +263,19 @@ class PagerPageHolder(
     override fun onImageLoaded() {
         super.onImageLoaded()
         progressIndicator?.hide()
+        if (viewer.config.edgeWidth >= 100) return
         // After the image decodes inside the manually-constrained container,
         // sWidth * minScale = min(natural dynamic width, manual edge width) in pixels.
         // Adjust right padding to that exact rendered width so portrait images
         // (narrower than the manual limit) are not over-padded.
+        // Skip when rendered content overflows the container (e.g. CENTER_CROP / cover mode)
+        // to preserve the manual edge width padding.
         val screenWidth = Resources.getSystem().displayMetrics.widthPixels
-        val renderedWidth = getRenderedContentWidth()
-        if (renderedWidth != null) {
-            val rightPadding = (screenWidth - renderedWidth).coerceAtLeast(0)
-            setPadding(0, paddingTop, rightPadding, paddingBottom)
-        }
+        val renderedWidth = getRenderedContentWidth() ?: return
+        val containerWidth = screenWidth - paddingRight
+        if (renderedWidth > containerWidth) return
+        val rightPadding = (screenWidth - renderedWidth).coerceAtLeast(0)
+        setPadding(0, paddingTop, rightPadding, paddingBottom)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -69,9 +69,10 @@ class PagerPageHolder(
     }
 
     private fun applyEdgeWidth() {
-        if (viewer.config.edgeWidth >= 100) return
+        if (viewer.config.edgeWidth >= 400) return
         val screenWidth = Resources.getSystem().displayMetrics.widthPixels
-        val rightPadding = (screenWidth * (1f - viewer.config.edgeWidth / 100f)).toInt()
+        // edgeWidth is stored in quarter-percent units (280 = 70%, 400 = 100%)
+        val rightPadding = (screenWidth * (1f - viewer.config.edgeWidth / 400f)).toInt()
         setPadding(0, paddingTop, rightPadding, paddingBottom)
     }
 
@@ -263,7 +264,7 @@ class PagerPageHolder(
     override fun onImageLoaded() {
         super.onImageLoaded()
         progressIndicator?.hide()
-        if (viewer.config.edgeWidth >= 100) return
+        if (viewer.config.edgeWidth >= 400) return
         // After the image decodes inside the manually-constrained container,
         // sWidth * minScale = min(natural dynamic width, manual edge width) in pixels.
         // Adjust right padding to that exact rendered width so portrait images

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -492,6 +492,7 @@
     <string name="pref_category_reading">Reading</string>
     <string name="pref_webtoon_side_padding">Side padding</string>
     <string name="pref_pager_edge_width">Edge width</string>
+    <string name="pref_pager_cover_mode">Cover mode (fill &amp; crop)</string>
     <string name="pref_hide_threshold">Sensitivity for hiding menu on scroll</string>
     <string name="pref_highest">Highest</string>
     <string name="pref_high">High</string>


### PR DESCRIPTION
### 📝 Description
This PR introduces two new display adjustments to improve the reading experience on foldable devices and screens with unconventional camera cutouts.

**Key Changes:**
1. **Sidebar Offset Slider:** Added a manual slider to adjust the visible area from the right side. When the edge width is set to less than 100%, the content automatically shifts to the left. This is specifically designed to prevent content from being obscured by physical camera cutouts (which are often not captured in system screenshots).

2.  **Cover mode Checkbox:** Added a toggle to scale content (similar to `object-fit: cover`) when the height doesn't fill the screen, providing better reading experience.

> [!IMPORTANT]  
> **Note on Visuals:** Please check the visual changes in the screenshots below. Note that the **physical camera cutout/hole-punch** is not captured by the Android OS screen recording/screenshot system, but the offset slider successfully moves the content to clear that "invisible" area.

> [!NOTE]  
> As I am not a Kotlin developer, these features were implemented with the assistance of GitHub Copilot. I have tested the basic functionality but welcome a thorough code review.


### 🖼️ Images

| Offset Slider and Cover Checkbox |  |
| :---: | :---: |
| ![](https://github.com/user-attachments/assets/52ba7a7b-4d76-440c-94e1-d7656dfd6a48) | ![](https://github.com/user-attachments/assets/ae7ef045-4f98-4cb1-8e49-89364c28e4b7) |

