### PR TITLE
Add Gemini translation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -252,6 +252,13 @@ dependencies {
     }
     implementation(libs.image.decoder)
 
+    // Translation OCR
+    implementation(libs.mlkit.text.recognition)
+    implementation(libs.mlkit.text.recognition.chinese)
+    implementation(libs.mlkit.text.recognition.devanagari)
+    implementation(libs.mlkit.text.recognition.japanese)
+    implementation(libs.mlkit.text.recognition.korean)
+
     // UI libraries
     implementation(libs.material)
     implementation(libs.flexibleAdapter)

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -88,6 +88,7 @@ fun MangaScreen(
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
+    onTranslateChapter: ((List<ChapterList.Item>) -> Unit)?,
     onAddToLibraryClicked: () -> Unit,
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
@@ -107,6 +108,7 @@ fun MangaScreen(
     // For top action menu
     onShareClicked: (() -> Unit)?,
     onDownloadActionClicked: ((DownloadAction) -> Unit)?,
+    onTranslateAllClicked: (() -> Unit)?,
     onEditCategoryClicked: (() -> Unit)?,
     onEditFetchIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
@@ -143,6 +145,7 @@ fun MangaScreen(
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
             onDownloadChapter = onDownloadChapter,
+            onTranslateChapter = onTranslateChapter,
             onAddToLibraryClicked = onAddToLibraryClicked,
             onWebViewClicked = onWebViewClicked,
             onWebViewLongClicked = onWebViewLongClicked,
@@ -156,6 +159,7 @@ fun MangaScreen(
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
             onDownloadActionClicked = onDownloadActionClicked,
+            onTranslateAllClicked = onTranslateAllClicked,
             onEditCategoryClicked = onEditCategoryClicked,
             onEditIntervalClicked = onEditFetchIntervalClicked,
             onMigrateClicked = onMigrateClicked,
@@ -179,6 +183,7 @@ fun MangaScreen(
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
             onDownloadChapter = onDownloadChapter,
+            onTranslateChapter = onTranslateChapter,
             onAddToLibraryClicked = onAddToLibraryClicked,
             onWebViewClicked = onWebViewClicked,
             onWebViewLongClicked = onWebViewLongClicked,
@@ -192,6 +197,7 @@ fun MangaScreen(
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
             onDownloadActionClicked = onDownloadActionClicked,
+            onTranslateAllClicked = onTranslateAllClicked,
             onEditCategoryClicked = onEditCategoryClicked,
             onEditIntervalClicked = onEditFetchIntervalClicked,
             onMigrateClicked = onMigrateClicked,
@@ -218,6 +224,7 @@ private fun MangaScreenSmallImpl(
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
+    onTranslateChapter: ((List<ChapterList.Item>) -> Unit)?,
     onAddToLibraryClicked: () -> Unit,
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
@@ -238,6 +245,7 @@ private fun MangaScreenSmallImpl(
     // For top action menu
     onShareClicked: (() -> Unit)?,
     onDownloadActionClicked: ((DownloadAction) -> Unit)?,
+    onTranslateAllClicked: (() -> Unit)?,
     onEditCategoryClicked: (() -> Unit)?,
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
@@ -297,6 +305,7 @@ private fun MangaScreenSmallImpl(
                 onClickFilter = onFilterClicked,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,
+                onClickTranslateAll = onTranslateAllClicked,
                 onClickEditCategory = onEditCategoryClicked,
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
@@ -319,6 +328,7 @@ private fun MangaScreenSmallImpl(
                 onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
                 onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
                 onDownloadChapter = onDownloadChapter,
+                onTranslateChapter = onTranslateChapter,
                 onMultiDeleteClicked = onMultiDeleteClicked,
                 fillFraction = 1f,
             )
@@ -441,6 +451,7 @@ private fun MangaScreenSmallImpl(
                         chapterSwipeEndAction = chapterSwipeEndAction,
                         onChapterClicked = onChapterClicked,
                         onDownloadChapter = onDownloadChapter,
+                        onTranslateChapter = onTranslateChapter,
                         onChapterSelected = onChapterSelected,
                         onChapterSwipe = onChapterSwipe,
                     )
@@ -460,6 +471,7 @@ fun MangaScreenLargeImpl(
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
+    onTranslateChapter: ((List<ChapterList.Item>) -> Unit)?,
     onAddToLibraryClicked: () -> Unit,
     onWebViewClicked: (() -> Unit)?,
     onWebViewLongClicked: (() -> Unit)?,
@@ -480,6 +492,7 @@ fun MangaScreenLargeImpl(
     // For top action menu
     onShareClicked: (() -> Unit)?,
     onDownloadActionClicked: ((DownloadAction) -> Unit)?,
+    onTranslateAllClicked: (() -> Unit)?,
     onEditCategoryClicked: (() -> Unit)?,
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
@@ -532,6 +545,7 @@ fun MangaScreenLargeImpl(
                 onClickFilter = onFilterButtonClicked,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,
+                onClickTranslateAll = onTranslateAllClicked,
                 onClickEditCategory = onEditCategoryClicked,
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
@@ -558,6 +572,7 @@ fun MangaScreenLargeImpl(
                     onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
                     onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
                     onDownloadChapter = onDownloadChapter,
+                    onTranslateChapter = onTranslateChapter,
                     onMultiDeleteClicked = onMultiDeleteClicked,
                     fillFraction = 0.5f,
                 )
@@ -678,6 +693,7 @@ fun MangaScreenLargeImpl(
                                 chapterSwipeEndAction = chapterSwipeEndAction,
                                 onChapterClicked = onChapterClicked,
                                 onDownloadChapter = onDownloadChapter,
+                                onTranslateChapter = onTranslateChapter,
                                 onChapterSelected = onChapterSelected,
                                 onChapterSwipe = onChapterSwipe,
                             )
@@ -696,6 +712,7 @@ private fun SharedMangaBottomActionMenu(
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
+    onTranslateChapter: ((List<ChapterList.Item>) -> Unit)?,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
     fillFraction: Float,
     modifier: Modifier = Modifier,
@@ -723,6 +740,9 @@ private fun SharedMangaBottomActionMenu(
         }.takeIf {
             onDownloadChapter != null && selected.fastAny { it.downloadState != Download.State.DOWNLOADED }
         },
+        onTranslateClicked = {
+            onTranslateChapter!!(selected.toList())
+        }.takeIf { onTranslateChapter != null },
         onDeleteClicked = {
             onMultiDeleteClicked(selected.fastMap { it.chapter })
         }.takeIf {
@@ -739,6 +759,7 @@ private fun LazyListScope.sharedChapterItems(
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
+    onTranslateChapter: ((List<ChapterList.Item>) -> Unit)?,
     onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
 ) {
@@ -800,6 +821,11 @@ private fun LazyListScope.sharedChapterItems(
                     },
                     onDownloadClick = if (onDownloadChapter != null) {
                         { onDownloadChapter(listOf(item), it) }
+                    } else {
+                        null
+                    },
+                    onTranslateClick = if (onTranslateChapter != null && !isAnyChapterSelected) {
+                        { onTranslateChapter(listOf(item)) }
                     } else {
                         null
                     },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.RemoveDone
 import androidx.compose.material.icons.outlined.SwapCalls
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -76,6 +77,7 @@ fun MangaBottomActionMenu(
     onMarkAsUnreadClicked: (() -> Unit)? = null,
     onMarkPreviousAsReadClicked: (() -> Unit)? = null,
     onDownloadClicked: (() -> Unit)? = null,
+    onTranslateClicked: (() -> Unit)? = null,
     onDeleteClicked: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
@@ -90,7 +92,7 @@ fun MangaBottomActionMenu(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             val haptic = LocalHapticFeedback.current
-            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false) }
+            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false, false) }
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -164,12 +166,21 @@ fun MangaBottomActionMenu(
                         onClick = onDownloadClicked,
                     )
                 }
+                if (onTranslateClicked != null) {
+                    Button(
+                        title = stringResource(MR.strings.action_translate),
+                        icon = Icons.Outlined.Translate,
+                        toConfirm = confirm[6],
+                        onLongClick = { onLongClickItem(6) },
+                        onClick = onTranslateClicked,
+                    )
+                }
                 if (onDeleteClicked != null) {
                     Button(
                         title = stringResource(MR.strings.action_delete),
                         icon = Icons.Outlined.Delete,
-                        toConfirm = confirm[6],
-                        onLongClick = { onLongClickItem(6) },
+                        toConfirm = confirm[7],
+                        onLongClick = { onLongClickItem(7) },
                         onClick = onDeleteClicked,
                     )
                 }
@@ -235,6 +246,7 @@ fun LibraryBottomActionMenu(
     onMarkAsReadClicked: () -> Unit,
     onMarkAsUnreadClicked: () -> Unit,
     onDownloadClicked: ((DownloadAction) -> Unit)?,
+    onTranslateClicked: (() -> Unit)?,
     onDeleteClicked: () -> Unit,
     onMigrateClicked: () -> Unit,
     modifier: Modifier = Modifier,
@@ -251,7 +263,7 @@ fun LibraryBottomActionMenu(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             val haptic = LocalHapticFeedback.current
-            val confirm = remember { mutableStateListOf(false, false, false, false, false, false) }
+            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false) }
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -262,7 +274,7 @@ fun LibraryBottomActionMenu(
                     if (isActive) confirm[toConfirmIndex] = false
                 }
             }
-            val itemOverflow = onDownloadClicked != null
+            val itemOverflow = onDownloadClicked != null || onTranslateClicked != null
             Row(
                 modifier = Modifier
                     .windowInsetsPadding(
@@ -309,19 +321,28 @@ fun LibraryBottomActionMenu(
                         )
                     }
                 }
+                if (onTranslateClicked != null) {
+                    Button(
+                        title = stringResource(MR.strings.action_translate),
+                        icon = Icons.Outlined.Translate,
+                        toConfirm = confirm[4],
+                        onLongClick = { onLongClickItem(4) },
+                        onClick = onTranslateClicked,
+                    )
+                }
                 if (!itemOverflow) {
                     Button(
                         title = stringResource(MR.strings.migrate),
                         icon = Icons.Outlined.SwapCalls,
-                        toConfirm = confirm[4],
-                        onLongClick = { onLongClickItem(4) },
+                        toConfirm = confirm[5],
+                        onLongClick = { onLongClickItem(5) },
                         onClick = onMigrateClicked,
                     )
                     Button(
                         title = stringResource(MR.strings.action_delete),
                         icon = Icons.Outlined.Delete,
-                        toConfirm = confirm[5],
-                        onLongClick = { onLongClickItem(5) },
+                        toConfirm = confirm[6],
+                        onLongClick = { onLongClickItem(6) },
                         onClick = onDeleteClicked,
                     )
                 } else {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -17,7 +17,9 @@ import androidx.compose.material.icons.outlined.Done
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.FileDownloadOff
 import androidx.compose.material.icons.outlined.RemoveDone
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
@@ -62,6 +64,7 @@ fun MangaChapterListItem(
     onLongClick: () -> Unit,
     onClick: () -> Unit,
     onDownloadClick: ((ChapterDownloadAction) -> Unit)?,
+    onTranslateClick: (() -> Unit)?,
     onChapterSwipe: (LibraryPreferences.ChapterSwipeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -178,6 +181,17 @@ fun MangaChapterListItem(
                 downloadProgressProvider = downloadProgressProvider,
                 onClick = { onDownloadClick?.invoke(it) },
             )
+            if (onTranslateClick != null) {
+                IconButton(
+                    onClick = onTranslateClick,
+                    modifier = Modifier.padding(start = 2.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Translate,
+                        contentDescription = stringResource(MR.strings.action_translate),
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
@@ -34,6 +35,7 @@ fun MangaToolbar(
     onClickFilter: () -> Unit,
     onClickShare: (() -> Unit)?,
     onClickDownload: ((DownloadAction) -> Unit)?,
+    onClickTranslateAll: (() -> Unit)?,
     onClickEditCategory: (() -> Unit)?,
     onClickRefresh: () -> Unit,
     onClickMigrate: (() -> Unit)?,
@@ -100,6 +102,15 @@ fun MangaToolbar(
                                 title = stringResource(MR.strings.manga_download),
                                 icon = Icons.Outlined.Download,
                                 onClick = { downloadExpanded = !downloadExpanded },
+                            ),
+                        )
+                    }
+                    if (onClickTranslateAll != null) {
+                        add(
+                            AppBar.Action(
+                                title = stringResource(MR.strings.action_translate_all),
+                                icon = Icons.Outlined.Translate,
+                                onClick = onClickTranslateAll,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.QueryStats
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -21,6 +22,7 @@ import eu.kanade.presentation.more.settings.widget.SwitchPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.more.DownloadQueueState
+import eu.kanade.tachiyomi.ui.more.TranslationQueueState
 import tachiyomi.core.common.Constants
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
@@ -31,11 +33,13 @@ import tachiyomi.presentation.core.i18n.stringResource
 @Composable
 fun MoreScreen(
     downloadQueueStateProvider: () -> DownloadQueueState,
+    translationQueueStateProvider: () -> TranslationQueueState,
     downloadedOnly: Boolean,
     onDownloadedOnlyChange: (Boolean) -> Unit,
     incognitoMode: Boolean,
     onIncognitoModeChange: (Boolean) -> Unit,
     onClickDownloadQueue: () -> Unit,
+    onClickTranslationQueue: () -> Unit,
     onClickCategories: () -> Unit,
     onClickStats: () -> Unit,
     onClickDataAndStorage: () -> Unit,
@@ -100,6 +104,35 @@ fun MoreScreen(
                     },
                     icon = Icons.Outlined.GetApp,
                     onPreferenceClick = onClickDownloadQueue,
+                )
+            }
+            item {
+                val translationQueueState = translationQueueStateProvider()
+                TextPreferenceWidget(
+                    title = stringResource(MR.strings.label_translation_queue),
+                    subtitle = when (translationQueueState) {
+                        TranslationQueueState.Stopped -> null
+                        is TranslationQueueState.Paused -> {
+                            val pending = translationQueueState.pending
+                            if (pending == 0) {
+                                stringResource(MR.strings.paused)
+                            } else {
+                                "${stringResource(MR.strings.paused)} • ${
+                                    pluralStringResource(
+                                        MR.plurals.download_queue_summary,
+                                        count = pending,
+                                        pending,
+                                    )
+                                }"
+                            }
+                        }
+                        is TranslationQueueState.Running -> {
+                            val pending = translationQueueState.pending
+                            pluralStringResource(MR.plurals.download_queue_summary, count = pending, pending)
+                        }
+                    },
+                    icon = Icons.Outlined.Translate,
+                    onPreferenceClick = onClickTranslationQueue,
                 )
             }
             item {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
@@ -195,6 +196,12 @@ object SettingsMainScreen : Screen() {
             subtitleRes = MR.strings.pref_downloads_summary,
             icon = Icons.Outlined.GetApp,
             screen = SettingsDownloadScreen,
+        ),
+        Item(
+            titleRes = MR.strings.pref_category_translation,
+            subtitleRes = MR.strings.pref_translation_summary,
+            icon = Icons.Outlined.Translate,
+            screen = SettingsTranslationScreen,
         ),
         Item(
             titleRes = MR.strings.pref_category_tracking,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSearchScreen.kt
@@ -290,6 +290,7 @@ private val settingScreens = listOf(
     SettingsLibraryScreen,
     SettingsReaderScreen,
     SettingsDownloadScreen,
+    SettingsTranslationScreen,
     SettingsTrackingScreen,
     SettingsBrowseScreen,
     SettingsDataScreen,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationScreen.kt
@@ -1,0 +1,256 @@
+package eu.kanade.presentation.more.settings.screen
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.launch
+import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import eu.kanade.presentation.more.settings.Preference
+import eu.kanade.tachiyomi.data.translation.DEFAULT_GEMINI_TRANSLATION_MODEL
+import eu.kanade.tachiyomi.data.translation.GeminiTranslationClient
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
+import eu.kanade.tachiyomi.util.system.toast
+import java.io.File
+import kotlin.math.roundToInt
+
+object SettingsTranslationScreen : SearchableSettings {
+
+    @ReadOnlyComposable
+    @Composable
+    override fun getTitleRes() = MR.strings.pref_category_translation
+
+    @Composable
+    override fun getPreferences(): List<Preference> {
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+        val preferences = remember { Injekt.get<TranslationPreferences>() }
+        val client = remember { Injekt.get<GeminiTranslationClient>() }
+        val repository = remember { Injekt.get<TranslationRepository>() }
+
+        val selectedModel by preferences.geminiModel.collectAsState()
+        val selectedInpaintModel by preferences.geminiInpaintModel.collectAsState()
+        val temperature by preferences.temperature.collectAsState()
+        val topP by preferences.topP.collectAsState()
+        val topK by preferences.topK.collectAsState()
+        val maxOutputTokens by preferences.maxOutputTokens.collectAsState()
+        val thinkingBudget by preferences.thinkingBudget.collectAsState()
+        val concurrency by preferences.concurrency.collectAsState()
+
+        var models by remember(selectedModel, selectedInpaintModel) {
+            mutableStateOf(listOf(DEFAULT_GEMINI_TRANSLATION_MODEL, selectedModel, selectedInpaintModel).distinct())
+        }
+        var modelStatus by remember { mutableStateOf<String?>(null) }
+
+        fun refreshModels(showReadyToast: Boolean) {
+            scope.launch {
+                val apiKey = preferences.geminiApiKey.get().trim()
+                if (apiKey.isBlank()) {
+                    context.toast(MR.strings.pref_translation_gemini_api_key_summary)
+                    return@launch
+                }
+                runCatching {
+                    client.listModels(apiKey).map { it.id }.distinct().sorted()
+                }.onSuccess { fetchedModels ->
+                    models = (fetchedModels + selectedModel + selectedInpaintModel)
+                        .filter { it.isNotBlank() }
+                        .distinct()
+                    modelStatus = "${models.size} models"
+                    if (DEFAULT_GEMINI_TRANSLATION_MODEL !in fetchedModels) {
+                        context.toast(MR.strings.translation_model_unavailable)
+                    } else if (showReadyToast) {
+                        context.toast(MR.strings.translation_model_ready)
+                    }
+                }.onFailure { error ->
+                    modelStatus = error.message
+                    context.toast(error.message ?: "Gemini model refresh failed")
+                }
+            }
+        }
+
+        val modelEntries = models.associateWith { it }.toImmutableMap()
+
+        return listOf(
+            Preference.PreferenceItem.InfoPreference(
+                stringResource(MR.strings.pref_translation_privacy_notice),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_translation),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = preferences.geminiApiKey,
+                        title = stringResource(MR.strings.pref_translation_gemini_api_key),
+                        subtitle = stringResource(MR.strings.pref_translation_gemini_api_key_summary),
+                    ),
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(MR.strings.translation_model_refresh),
+                        subtitle = modelStatus ?: stringResource(MR.strings.translation_model_refresh_summary),
+                        onClick = { refreshModels(showReadyToast = false) },
+                    ),
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(MR.strings.translation_model_test),
+                        subtitle = selectedModel,
+                        onClick = { refreshModels(showReadyToast = true) },
+                    ),
+                    Preference.PreferenceItem.BasicListPreference(
+                        value = selectedModel,
+                        entries = modelEntries,
+                        title = stringResource(MR.strings.pref_translation_model),
+                        onValueChanged = { preferences.geminiModel.set(it) },
+                    ),
+                    Preference.PreferenceItem.BasicListPreference(
+                        value = selectedInpaintModel,
+                        entries = modelEntries,
+                        title = stringResource(MR.strings.pref_translation_inpaint_model),
+                        onValueChanged = { preferences.geminiInpaintModel.set(it) },
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = preferences.targetLanguage,
+                        title = stringResource(MR.strings.pref_translation_target_language),
+                        subtitle = "%s",
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = preferences.sourceLanguage,
+                        title = stringResource(MR.strings.pref_translation_source_language),
+                        subtitle = "%s",
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_translation_pipeline),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.ListPreference(
+                        preference = preferences.pipeline,
+                        entries = mapOf(
+                            "gemini_vision" to stringResource(MR.strings.pref_translation_pipeline_gemini_vision),
+                            "local_ocr_gemini" to stringResource(MR.strings.pref_translation_pipeline_local_ocr_gemini),
+                        ).toImmutableMap(),
+                        title = stringResource(MR.strings.pref_translation_pipeline),
+                    ),
+                    Preference.PreferenceItem.ListPreference(
+                        preference = preferences.ocrScript,
+                        entries = mapOf(
+                            "auto" to stringResource(MR.strings.label_auto),
+                            "latin" to "Latin",
+                            "japanese" to "Japanese",
+                            "chinese" to "Chinese",
+                            "korean" to "Korean",
+                            "devanagari" to "Devanagari",
+                        ).toImmutableMap(),
+                        title = stringResource(MR.strings.pref_translation_ocr_script),
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = preferences.skipExistingOverlays,
+                        title = stringResource(MR.strings.pref_translation_skip_existing),
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = preferences.autoShowOverlay,
+                        title = stringResource(MR.strings.pref_translation_show_overlays),
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = preferences.rawDebugLogging,
+                        title = stringResource(MR.strings.pref_translation_raw_debug_logs),
+                        subtitle = stringResource(MR.strings.pref_translation_raw_debug_logs_summary),
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = preferences.enableInpaint,
+                        title = stringResource(MR.strings.pref_translation_enable_inpaint),
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_translation_generation),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.SliderPreference(
+                        value = (temperature * 100).roundToInt(),
+                        valueRange = 0..200,
+                        title = stringResource(MR.strings.pref_translation_temperature),
+                        valueString = "%.2f".format(temperature),
+                        onValueChanged = { preferences.temperature.set(it / 100f) },
+                    ),
+                    Preference.PreferenceItem.SliderPreference(
+                        value = (topP * 100).roundToInt(),
+                        valueRange = 0..100,
+                        title = stringResource(MR.strings.pref_translation_top_p),
+                        valueString = "%.2f".format(topP),
+                        onValueChanged = { preferences.topP.set(it / 100f) },
+                    ),
+                    Preference.PreferenceItem.SliderPreference(
+                        value = topK,
+                        valueRange = 1..100,
+                        title = stringResource(MR.strings.pref_translation_top_k),
+                        onValueChanged = { preferences.topK.set(it) },
+                    ),
+                    Preference.PreferenceItem.SliderPreference(
+                        value = maxOutputTokens,
+                        valueRange = 512..8192 step 256,
+                        title = stringResource(MR.strings.pref_translation_max_tokens),
+                        onValueChanged = { preferences.maxOutputTokens.set(it) },
+                    ),
+                    Preference.PreferenceItem.SliderPreference(
+                        value = thinkingBudget,
+                        valueRange = -1..4096 step 128,
+                        title = stringResource(MR.strings.pref_translation_thinking_budget),
+                        onValueChanged = { preferences.thinkingBudget.set(it) },
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = preferences.rawJsonOverride,
+                        title = stringResource(MR.strings.pref_translation_raw_json_override),
+                        subtitle = "%s",
+                    ),
+                    Preference.PreferenceItem.EditTextPreference(
+                        preference = preferences.globalInstructions,
+                        title = stringResource(MR.strings.pref_translation_global_instructions),
+                        subtitle = "%s",
+                    ),
+                ),
+            ),
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_translation_queue),
+                preferenceItems = persistentListOf(
+                    Preference.PreferenceItem.SliderPreference(
+                        value = concurrency,
+                        valueRange = 1..4,
+                        title = stringResource(MR.strings.pref_translation_concurrency),
+                        onValueChanged = { preferences.concurrency.set(it) },
+                    ),
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(MR.strings.pref_translation_clear_logs),
+                        onClick = {
+                            scope.launch {
+                                repository.clearLogs()
+                                context.toast(MR.strings.pref_translation_clear_logs)
+                            }
+                        },
+                    ),
+                    Preference.PreferenceItem.TextPreference(
+                        title = stringResource(MR.strings.pref_translation_clear_storage),
+                        onClick = {
+                            scope.launch {
+                                repository.clearPages()
+                                clearTranslationFiles(context)
+                                context.toast(MR.strings.pref_translation_clear_storage)
+                            }
+                        },
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+private fun clearTranslationFiles(context: Context) {
+    File(context.filesDir, "translations").deleteRecursively()
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/ReaderPageActionsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReaderPageActionsDialog.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Photo
 import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,6 +33,8 @@ fun ReaderPageActionsDialog(
     onSetAsCover: () -> Unit,
     onShare: (Boolean) -> Unit,
     onSave: () -> Unit,
+    onTranslate: () -> Unit,
+    onEditTranslation: () -> Unit,
 ) {
     var showSetCoverDialog by remember { mutableStateOf(false) }
 
@@ -71,6 +75,21 @@ fun ReaderPageActionsDialog(
                     onSave()
                     onDismissRequest()
                 },
+            )
+            ActionButton(
+                modifier = Modifier.weight(1f),
+                title = stringResource(MR.strings.action_translate),
+                icon = Icons.Outlined.Translate,
+                onClick = {
+                    onTranslate()
+                    onDismissRequest()
+                },
+            )
+            ActionButton(
+                modifier = Modifier.weight(1f),
+                title = stringResource(MR.strings.action_edit_translation),
+                icon = Icons.Outlined.Edit,
+                onClick = onEditTranslation,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/reader/TranslationOverlayEditorDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/TranslationOverlayEditorDialog.kt
@@ -1,0 +1,309 @@
+package eu.kanade.presentation.reader
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.components.AdaptiveSheet
+import eu.kanade.tachiyomi.data.translation.SavedTranslationPage
+import eu.kanade.tachiyomi.data.translation.TranslationBoxEdit
+import tachiyomi.data.Translation_boxes
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import java.util.Locale
+
+@Composable
+fun TranslationOverlayEditorDialog(
+    savedPage: SavedTranslationPage?,
+    onDismissRequest: () -> Unit,
+    onSave: (List<TranslationBoxEdit>) -> Unit,
+) {
+    var nextLocalId by remember(savedPage?.page?._id) { mutableIntStateOf(savedPage?.boxes?.size ?: 0) }
+    var boxes by remember(savedPage?.page?._id, savedPage?.boxes) {
+        mutableStateOf(
+            savedPage?.boxes
+                ?.map { box -> box.toEditableBox() }
+                .orEmpty(),
+        )
+    }
+
+    AdaptiveSheet(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(MaterialTheme.padding.medium),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(MR.strings.translation_overlay_editor),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                TextButton(
+                    onClick = {
+                        boxes = boxes + EditableTranslationBox(
+                            localId = "new-${nextLocalId++}",
+                            x = 0.1f,
+                            y = 0.1f,
+                            width = 0.55f,
+                            height = 0.12f,
+                            originalText = "",
+                            translatedText = "",
+                            textType = "dialogue",
+                        )
+                    },
+                ) {
+                    Icon(Icons.Outlined.Add, contentDescription = null)
+                    Text(stringResource(MR.strings.action_add))
+                }
+            }
+
+            if (boxes.isEmpty()) {
+                Text(
+                    text = stringResource(MR.strings.translation_overlay_no_boxes),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 560.dp),
+                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.medium),
+                ) {
+                    itemsIndexed(
+                        items = boxes,
+                        key = { _, box -> box.localId },
+                    ) { index, box ->
+                        TranslationBoxEditor(
+                            index = index,
+                            box = box,
+                            onChange = { updated ->
+                                boxes = boxes.toMutableList().also { it[index] = updated.constrained() }
+                            },
+                            onDelete = {
+                                boxes = boxes.toMutableList().also { it.removeAt(index) }
+                            },
+                        )
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismissRequest) {
+                    Text(stringResource(MR.strings.action_cancel))
+                }
+                Button(
+                    onClick = {
+                        onSave(boxes.map { it.constrained().toEdit() })
+                    },
+                ) {
+                    Text(stringResource(MR.strings.action_save))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TranslationBoxEditor(
+    index: Int,
+    box: EditableTranslationBox,
+    onChange: (EditableTranslationBox) -> Unit,
+    onDelete: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(MR.strings.translation_overlay_box_label, index + 1),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = stringResource(MR.strings.action_delete),
+                )
+            }
+        }
+
+        OutlinedTextField(
+            value = box.translatedText,
+            onValueChange = { onChange(box.copy(translatedText = it)) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(MR.strings.translation_overlay_translated_text)) },
+            minLines = 2,
+        )
+        OutlinedTextField(
+            value = box.originalText,
+            onValueChange = { onChange(box.copy(originalText = it)) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(MR.strings.translation_overlay_original_text)) },
+            minLines = 1,
+        )
+        OutlinedTextField(
+            value = box.textType,
+            onValueChange = { onChange(box.copy(textType = it.ifBlank { "dialogue" })) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text(stringResource(MR.strings.translation_overlay_text_type)) },
+            singleLine = true,
+        )
+
+        CoordinateSlider(
+            label = stringResource(MR.strings.translation_overlay_x),
+            value = box.x,
+            valueRange = 0f..(1f - box.width).coerceAtLeast(0f),
+            onValueChange = { onChange(box.copy(x = it)) },
+        )
+        CoordinateSlider(
+            label = stringResource(MR.strings.translation_overlay_y),
+            value = box.y,
+            valueRange = 0f..(1f - box.height).coerceAtLeast(0f),
+            onValueChange = { onChange(box.copy(y = it)) },
+        )
+        CoordinateSlider(
+            label = stringResource(MR.strings.translation_overlay_width),
+            value = box.width,
+            valueRange = 0.01f..(1f - box.x).coerceAtLeast(0.01f),
+            onValueChange = { onChange(box.copy(width = it)) },
+        )
+        CoordinateSlider(
+            label = stringResource(MR.strings.translation_overlay_height),
+            value = box.height,
+            valueRange = 0.01f..(1f - box.y).coerceAtLeast(0.01f),
+            onValueChange = { onChange(box.copy(height = it)) },
+        )
+
+        Spacer(modifier = Modifier.fillMaxWidth())
+        HorizontalDivider()
+    }
+}
+
+@Composable
+private fun CoordinateSlider(
+    label: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    onValueChange: (Float) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = String.format(Locale.ROOT, "%.2f", value),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+        Slider(
+            value = value.coerceIn(valueRange.start, valueRange.endInclusive),
+            onValueChange = onValueChange,
+            valueRange = valueRange,
+        )
+    }
+}
+
+private data class EditableTranslationBox(
+    val localId: String,
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+    val originalText: String,
+    val translatedText: String,
+    val textType: String,
+    val confidence: Double? = null,
+    val styleJson: String? = null,
+) {
+    fun constrained(): EditableTranslationBox {
+        val safeX = x.coerceIn(0f, 0.99f)
+        val safeY = y.coerceIn(0f, 0.99f)
+        return copy(
+            x = safeX,
+            y = safeY,
+            width = width.coerceIn(0.01f, 1f - safeX),
+            height = height.coerceIn(0.01f, 1f - safeY),
+        )
+    }
+
+    fun toEdit(): TranslationBoxEdit {
+        return TranslationBoxEdit(
+            x = x.toDouble(),
+            y = y.toDouble(),
+            width = width.toDouble(),
+            height = height.toDouble(),
+            originalText = originalText,
+            translatedText = translatedText,
+            textType = textType.ifBlank { "dialogue" },
+            confidence = confidence,
+            styleJson = styleJson,
+        )
+    }
+}
+
+private fun Translation_boxes.toEditableBox(): EditableTranslationBox {
+    return EditableTranslationBox(
+        localId = _id.toString(),
+        x = x.toFloat(),
+        y = y.toFloat(),
+        width = width.toFloat(),
+        height = height.toFloat(),
+        originalText = original_text,
+        translatedText = translated_text,
+        textType = text_type,
+        confidence = confidence,
+        styleJson = style_json,
+    ).constrained()
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -47,6 +47,8 @@ fun ReaderAppBars(
     onOpenInWebView: (() -> Unit)?,
     onOpenInBrowser: (() -> Unit)?,
     onShare: (() -> Unit)?,
+    onTranslateChapter: (() -> Unit)?,
+    onToggleTranslationOverlay: (() -> Unit)?,
 
     viewer: Viewer?,
     onNextChapter: () -> Unit,
@@ -90,6 +92,8 @@ fun ReaderAppBars(
                 onOpenInWebView = onOpenInWebView,
                 onOpenInBrowser = onOpenInBrowser,
                 onShare = onShare,
+                onTranslateChapter = onTranslateChapter,
+                onToggleTranslationOverlay = onToggleTranslationOverlay,
             )
         }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderTopBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderTopBar.kt
@@ -22,6 +22,8 @@ fun ReaderTopBar(
     onOpenInWebView: (() -> Unit)?,
     onOpenInBrowser: (() -> Unit)?,
     onShare: (() -> Unit)?,
+    onTranslateChapter: (() -> Unit)?,
+    onToggleTranslationOverlay: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     AppBar(
@@ -71,6 +73,22 @@ fun ReaderTopBar(
                             add(
                                 AppBar.OverflowAction(
                                     title = stringResource(MR.strings.action_share),
+                                    onClick = it,
+                                ),
+                            )
+                        }
+                        onTranslateChapter?.let {
+                            add(
+                                AppBar.OverflowAction(
+                                    title = stringResource(MR.strings.action_translate),
+                                    onClick = it,
+                                ),
+                            )
+                        }
+                        onToggleTranslationOverlay?.let {
+                            add(
+                                AppBar.OverflowAction(
+                                    title = stringResource(MR.strings.action_translation_overlay),
                                     onClick = it,
                                 ),
                             )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -41,6 +41,13 @@ object Notifications {
     const val ID_DOWNLOAD_CHAPTER_ERROR = -202
 
     /**
+     * Notification channel and ids used by the translator.
+     */
+    private const val GROUP_TRANSLATION = "group_translation"
+    const val CHANNEL_TRANSLATION_PROGRESS = "translation_progress_channel"
+    const val ID_TRANSLATION_PROGRESS = -251
+
+    /**
      * Notification channel and ids used by the library updater.
      */
     const val CHANNEL_NEW_CHAPTERS = "new_chapters_channel"
@@ -108,6 +115,9 @@ object Notifications {
                 buildNotificationChannelGroup(GROUP_DOWNLOADER) {
                     setName(context.stringResource(MR.strings.download_notifier_downloader_title))
                 },
+                buildNotificationChannelGroup(GROUP_TRANSLATION) {
+                    setName(context.stringResource(MR.strings.pref_translation))
+                },
                 buildNotificationChannelGroup(GROUP_LIBRARY) {
                     setName(context.stringResource(MR.strings.label_library))
                 },
@@ -143,6 +153,11 @@ object Notifications {
                 buildNotificationChannel(CHANNEL_DOWNLOADER_ERROR, IMPORTANCE_LOW) {
                     setName(context.stringResource(MR.strings.channel_errors))
                     setGroup(GROUP_DOWNLOADER)
+                    setShowBadge(false)
+                },
+                buildNotificationChannel(CHANNEL_TRANSLATION_PROGRESS, IMPORTANCE_LOW) {
+                    setName(context.stringResource(MR.strings.channel_progress))
+                    setGroup(GROUP_TRANSLATION)
                     setShowBadge(false)
                 },
                 buildNotificationChannel(CHANNEL_BACKUP_RESTORE_PROGRESS, IMPORTANCE_LOW) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/GeminiTranslationClient.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/GeminiTranslationClient.kt
@@ -1,0 +1,345 @@
+package eu.kanade.tachiyomi.data.translation
+
+import android.util.Base64
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.await
+import eu.kanade.tachiyomi.network.jsonMime
+import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import okhttp3.Headers.Companion.headersOf
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class GeminiTranslationClient(
+    private val network: NetworkHelper = Injekt.get(),
+    private val json: Json = Injekt.get(),
+) {
+    suspend fun listModels(apiKey: String): List<GeminiModel> {
+        val response = executeGemini(
+            GET(
+                "$BASE_URL/models?pageSize=1000",
+                headers = apiHeaders(apiKey),
+            ),
+        )
+        return with(json) {
+            response.parseAs<GeminiListModelsResponse>()
+        }.models.generateContentModels()
+    }
+
+    suspend fun translatePageImage(
+        apiKey: String,
+        model: String,
+        imageBytes: ByteArray,
+        mimeType: String,
+        targetLanguage: String,
+        sourceLanguage: String?,
+        generationConfig: TranslationGenerationConfig,
+        extraInstructions: String,
+    ): TranslationOverlayResult {
+        val request = GeminiGenerateContentRequest(
+            contents = listOf(
+                GeminiContent(
+                    parts = listOf(
+                        GeminiPart(text = pageTranslationPrompt(targetLanguage, sourceLanguage, extraInstructions)),
+                        GeminiPart(
+                            inlineData = GeminiInlineData(
+                                mimeType = mimeType,
+                                data = Base64.encodeToString(imageBytes, Base64.NO_WRAP),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            generationConfig = generationConfig
+                .copy(rawJsonOverride = generationConfig.rawJsonOverride)
+                .toGeminiJson(json)
+                .withStructuredOverlaySchema(),
+        )
+        return generateOverlay(apiKey, model, request)
+    }
+
+    suspend fun translateOcrBlocks(
+        apiKey: String,
+        model: String,
+        blocks: List<OcrTextBlock>,
+        targetLanguage: String,
+        sourceLanguage: String?,
+        generationConfig: TranslationGenerationConfig,
+        extraInstructions: String,
+    ): TranslationOverlayResult {
+        val prompt = buildString {
+            appendLine(pageTranslationPrompt(targetLanguage, sourceLanguage, extraInstructions))
+            appendLine("Translate these OCR blocks and preserve each id and box:")
+            blocks.forEach { block ->
+                appendLine(
+                    "${block.id}: [${block.x},${block.y},${block.width},${block.height}] ${block.text}",
+                )
+            }
+        }
+        val request = GeminiGenerateContentRequest(
+            contents = listOf(GeminiContent(parts = listOf(GeminiPart(text = prompt)))),
+            generationConfig = generationConfig.toGeminiJson(json).withStructuredOverlaySchema(),
+        )
+        return generateOverlay(apiKey, model, request)
+    }
+
+    suspend fun generateInpaintImage(
+        apiKey: String,
+        model: String,
+        imageBytes: ByteArray,
+        mimeType: String,
+        overlay: TranslationOverlayResult,
+        targetLanguage: String,
+    ): ByteArray? {
+        val prompt = buildString {
+            appendLine("Edit this manga page by replacing original text with the translated text.")
+            appendLine("Target language: $targetLanguage.")
+            appendLine("Preserve art, panel layout, tone, and reading order.")
+            overlay.boxes.forEachIndexed { index, box ->
+                appendLine("${index + 1}. ${box.translatedText}")
+            }
+        }
+        val request = GeminiGenerateContentRequest(
+            contents = listOf(
+                GeminiContent(
+                    parts = listOf(
+                        GeminiPart(text = prompt),
+                        GeminiPart(
+                            inlineData = GeminiInlineData(
+                                mimeType = mimeType,
+                                data = Base64.encodeToString(imageBytes, Base64.NO_WRAP),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val response = generateContent(apiKey, model, request)
+        val imageData = response.candidates
+            .firstOrNull()
+            ?.content
+            ?.parts
+            ?.firstNotNullOfOrNull { it.inlineData?.data }
+            ?: return null
+        return Base64.decode(imageData, Base64.DEFAULT)
+    }
+
+    private suspend fun generateOverlay(
+        apiKey: String,
+        model: String,
+        request: GeminiGenerateContentRequest,
+    ): TranslationOverlayResult {
+        val response = generateContent(apiKey, model, request)
+        val text = response.candidates
+            .firstOrNull()
+            ?.content
+            ?.parts
+            ?.firstNotNullOfOrNull { it.text }
+            ?: error("Gemini response did not include text")
+        return json.decodeFromString<TranslationOverlayResult>(text)
+    }
+
+    private suspend fun generateContent(
+        apiKey: String,
+        model: String,
+        request: GeminiGenerateContentRequest,
+    ): GeminiGenerateContentResponse {
+        val modelId = model.removePrefix("models/")
+        val response = executeGemini(
+            POST(
+                "$BASE_URL/models/$modelId:generateContent",
+                headers = apiHeaders(apiKey),
+                body = json.encodeToString(request).toRequestBody(jsonMime),
+            ),
+        )
+        return with(json) {
+            response.parseAs<GeminiGenerateContentResponse>()
+        }
+    }
+
+    private suspend fun executeGemini(request: Request): Response {
+        val response = network.client.newCall(request).await()
+        if (response.isSuccessful) {
+            return response
+        }
+        val errorBody = response.body.string()
+        response.close()
+        throw GeminiApiException(
+            code = response.code,
+            errorBody = TranslationLogRedactor.redact(errorBody),
+        )
+    }
+
+    private fun apiHeaders(apiKey: String) = headersOf(
+        "x-goog-api-key",
+        apiKey,
+        "Content-Type",
+        "application/json",
+    )
+
+    private fun pageTranslationPrompt(
+        targetLanguage: String,
+        sourceLanguage: String?,
+        extraInstructions: String,
+    ): String {
+        return buildString {
+            appendLine("Translate all visible manga text into ${targetLanguage.ifBlank { "the app language" }}.")
+            appendLine("Source language: ${sourceLanguage?.takeIf { it.isNotBlank() } ?: "auto-detect"}.")
+            appendLine("Include dialogue, captions, signs, and sound effects.")
+            appendLine("Return only JSON matching the schema. Coordinates must be normalized 0.0 to 1.0.")
+            appendLine("Each box needs x, y, width, height, originalText, translatedText, textType, confidence.")
+            if (extraInstructions.isNotBlank()) {
+                appendLine("User glossary/instructions:")
+                appendLine(extraInstructions)
+            }
+        }
+    }
+
+    companion object {
+        private const val BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+    }
+}
+
+class GeminiApiException(
+    val code: Int,
+    val errorBody: String,
+) : IllegalStateException("Gemini API error $code")
+
+private fun JsonElement.withStructuredOverlaySchema(): JsonElement {
+    val base = jsonObject
+    return buildJsonObject {
+        base.forEach { (key, value) -> put(key, value) }
+        put("responseMimeType", "application/json")
+        put(
+            "responseJsonSchema",
+            buildJsonObject {
+                put("type", "object")
+                put(
+                    "properties",
+                    buildJsonObject {
+                        put("sourceLanguage", buildJsonObject { put("type", "string") })
+                        put("targetLanguage", buildJsonObject { put("type", "string") })
+                        put(
+                            "boxes",
+                            buildJsonObject {
+                                put("type", "array")
+                                put(
+                                    "items",
+                                    buildJsonObject {
+                                        put("type", "object")
+                                        put(
+                                            "properties",
+                                            buildJsonObject {
+                                                listOf("x", "y", "width", "height", "confidence").forEach {
+                                                    put(it, buildJsonObject { put("type", "number") })
+                                                }
+                                                listOf("originalText", "translatedText", "textType").forEach {
+                                                    put(it, buildJsonObject { put("type", "string") })
+                                                }
+                                            },
+                                        )
+                                        put(
+                                            "required",
+                                            kotlinx.serialization.json.buildJsonArray {
+                                                listOf(
+                                                    "x",
+                                                    "y",
+                                                    "width",
+                                                    "height",
+                                                    "originalText",
+                                                    "translatedText",
+                                                    "textType",
+                                                ).forEach { add(kotlinx.serialization.json.JsonPrimitive(it)) }
+                                            },
+                                        )
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+                put("required", kotlinx.serialization.json.buildJsonArray { add(kotlinx.serialization.json.JsonPrimitive("boxes")) })
+            },
+        )
+    }
+}
+
+@Serializable
+private data class GeminiListModelsResponse(
+    val models: List<GeminiModel> = emptyList(),
+)
+
+@Serializable
+private data class GeminiGenerateContentRequest(
+    val contents: List<GeminiContent>,
+    val generationConfig: JsonElement? = null,
+)
+
+@Serializable
+private data class GeminiContent(
+    val parts: List<GeminiPart>,
+)
+
+@Serializable
+private data class GeminiPart(
+    val text: String? = null,
+    @SerialName("inline_data")
+    val inlineData: GeminiInlineData? = null,
+)
+
+@Serializable
+private data class GeminiInlineData(
+    @SerialName("mime_type")
+    val mimeType: String,
+    val data: String,
+)
+
+@Serializable
+private data class GeminiGenerateContentResponse(
+    val candidates: List<GeminiCandidate> = emptyList(),
+)
+
+@Serializable
+private data class GeminiCandidate(
+    val content: GeminiContent? = null,
+)
+
+@Serializable
+data class TranslationOverlayResult(
+    val sourceLanguage: String? = null,
+    val targetLanguage: String? = null,
+    val boxes: List<TranslationOverlayBox> = emptyList(),
+)
+
+@Serializable
+data class TranslationOverlayBox(
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+    val originalText: String = "",
+    val translatedText: String,
+    val textType: String = "dialogue",
+    val confidence: Float? = null,
+)
+
+data class OcrTextBlock(
+    val id: String,
+    val text: String,
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/LocalOcrClient.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/LocalOcrClient.kt
@@ -1,0 +1,86 @@
+package eu.kanade.tachiyomi.data.translation
+
+import android.graphics.Bitmap
+import com.google.android.gms.tasks.Task
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.Text
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
+import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
+import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions
+import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
+import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class LocalOcrClient {
+
+    suspend fun recognize(
+        bitmap: Bitmap,
+        script: OcrScript = OcrScript.Auto,
+    ): List<OcrTextBlock> {
+        val scripts = if (script == OcrScript.Auto) {
+            listOf(OcrScript.Latin, OcrScript.Japanese, OcrScript.Chinese, OcrScript.Korean, OcrScript.Devanagari)
+        } else {
+            listOf(script)
+        }
+        val image = InputImage.fromBitmap(bitmap, 0)
+        val blocks = mutableListOf<Text.TextBlock>()
+        scripts.forEach { scriptToRun ->
+            blocks += recognizerFor(scriptToRun).process(image).await().textBlocks
+        }
+        return blocks
+            .mapIndexedNotNull { index, block -> block.toOcrTextBlock(index, bitmap.width, bitmap.height) }
+            .distinctBy { "${it.text}:${it.x}:${it.y}:${it.width}:${it.height}" }
+    }
+
+    private fun recognizerFor(script: OcrScript): TextRecognizer {
+        return when (script) {
+            OcrScript.Auto,
+            OcrScript.Latin -> TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+            OcrScript.Chinese -> TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+            OcrScript.Devanagari -> TextRecognition.getClient(DevanagariTextRecognizerOptions.Builder().build())
+            OcrScript.Japanese -> TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
+            OcrScript.Korean -> TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
+        }
+    }
+}
+
+enum class OcrScript(val preferenceValue: String) {
+    Auto("auto"),
+    Latin("latin"),
+    Chinese("chinese"),
+    Devanagari("devanagari"),
+    Japanese("japanese"),
+    Korean("korean"),
+    ;
+
+    companion object {
+        fun fromPreference(value: String): OcrScript {
+            return entries.firstOrNull { it.preferenceValue == value } ?: Auto
+        }
+    }
+}
+
+private fun Text.TextBlock.toOcrTextBlock(index: Int, imageWidth: Int, imageHeight: Int): OcrTextBlock? {
+    val box = boundingBox ?: return null
+    if (text.isBlank() || imageWidth <= 0 || imageHeight <= 0) return null
+    return OcrTextBlock(
+        id = "ocr-$index",
+        text = text,
+        x = box.left.toFloat() / imageWidth,
+        y = box.top.toFloat() / imageHeight,
+        width = box.width().toFloat() / imageWidth,
+        height = box.height().toFloat() / imageHeight,
+    )
+}
+
+private suspend fun <T> Task<T>.await(): T {
+    return suspendCancellableCoroutine { continuation ->
+        addOnSuccessListener { continuation.resume(it) }
+        addOnFailureListener { continuation.resumeWithException(it) }
+        addOnCanceledListener { continuation.cancel() }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationCore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationCore.kt
@@ -1,0 +1,115 @@
+package eu.kanade.tachiyomi.data.translation
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+
+const val DEFAULT_GEMINI_TRANSLATION_MODEL = "gemini-3-flash-preview"
+
+@Serializable
+data class GeminiModel(
+    val name: String,
+    val baseModelId: String? = null,
+    val displayName: String? = null,
+    val description: String? = null,
+    val inputTokenLimit: Int? = null,
+    val outputTokenLimit: Int? = null,
+    val supportedGenerationMethods: List<String> = emptyList(),
+    val version: String? = null,
+    val thinking: Boolean? = null,
+    val temperature: Float? = null,
+    val maxTemperature: Float? = null,
+    val topP: Float? = null,
+    val topK: Int? = null,
+) {
+    val id: String
+        get() = name.removePrefix("models/")
+}
+
+fun List<GeminiModel>.generateContentModels(): List<GeminiModel> {
+    return filter { model ->
+        model.supportedGenerationMethods.any { it.equals("generateContent", ignoreCase = true) }
+    }
+}
+
+object TranslationLogRedactor {
+    private val apiKeyRegex = Regex("""([?&]key=)[^"&\s]+""")
+    private val inlineDataRegex = Regex(
+        """"(inlineData|inline_data)"\s*:\s*\{\s*"(mimeType|mime_type)"\s*:\s*"([^"]+)"\s*,\s*"data"\s*:\s*"[^"]*"\s*}""",
+    )
+
+    fun redact(value: String): String {
+        return value
+            .replace(apiKeyRegex) { match -> match.groupValues[1] + "<redacted>" }
+            .replace(inlineDataRegex) { match ->
+                """"${match.groupValues[1]}": {"${match.groupValues[2]}": "${match.groupValues[3]}", "data": "<redacted-image>"}"""
+            }
+    }
+}
+
+data class TranslationGenerationConfig(
+    val temperature: Float? = null,
+    val topP: Float? = null,
+    val topK: Int? = null,
+    val maxOutputTokens: Int? = null,
+    val thinkingBudget: Int? = null,
+    val rawJsonOverride: String = "",
+) {
+    fun toGeminiJson(json: Json): JsonElement {
+        val base = buildJsonObject {
+            temperature?.let { put("temperature", it) }
+            topP?.let { put("topP", it) }
+            topK?.let { put("topK", it) }
+            maxOutputTokens?.let { put("maxOutputTokens", it) }
+            thinkingBudget?.let {
+                put(
+                    "thinkingConfig",
+                    buildJsonObject {
+                        put("thinkingBudget", it)
+                    },
+                )
+            }
+        }
+        val override = rawJsonOverride.trim()
+            .takeIf { it.isNotEmpty() }
+            ?.let { json.parseToJsonElement(it).jsonObject }
+            ?: JsonObject(emptyMap())
+        return JsonObject(base + override)
+    }
+}
+
+data class TranslationPageCandidate(
+    val chapterId: Long,
+    val pageIndex: Int,
+    val hasOverlay: Boolean,
+)
+
+data class TranslationBoxEdit(
+    val x: Double,
+    val y: Double,
+    val width: Double,
+    val height: Double,
+    val originalText: String,
+    val translatedText: String,
+    val textType: String,
+    val confidence: Double? = null,
+    val styleJson: String? = null,
+)
+
+object TranslationEnqueuePlanner {
+    fun pagesToQueue(
+        pages: List<TranslationPageCandidate>,
+        overwrite: Boolean,
+    ): List<TranslationPageCandidate> {
+        return if (overwrite) {
+            pages
+        } else {
+            pages.filterNot { it.hasOverlay }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationImageResolver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationImageResolver.kt
@@ -1,0 +1,98 @@
+package eu.kanade.tachiyomi.data.translation
+
+import android.app.Application
+import android.graphics.BitmapFactory
+import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import tachiyomi.core.common.util.system.ImageUtil
+import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.source.model.StubSource
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.ByteArrayInputStream
+
+class TranslationImageResolver(
+    private val context: Application = Injekt.get(),
+    private val downloadManager: DownloadManager = Injekt.get(),
+    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val getManga: GetManga = Injekt.get(),
+    private val getChapter: GetChapter = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+) {
+    suspend fun getPageCount(mangaId: Long, chapterId: Long): Int {
+        return withLoadedChapter(mangaId, chapterId) { chapter, _ ->
+            chapter.pages.orEmpty().size
+        }
+    }
+
+    suspend fun resolvePage(mangaId: Long, chapterId: Long, pageIndex: Int): TranslationPageImage {
+        return withLoadedChapter(mangaId, chapterId) { chapter, source ->
+            val pages = chapter.pages.orEmpty()
+            val page = pages.getOrNull(pageIndex)
+                ?: error("Page $pageIndex is outside loaded chapter page range (${pages.size})")
+            val bytes = page.stream?.invoke()?.use { it.readBytes() }
+                ?: when (source) {
+                    is HttpSource -> {
+                        if (page.imageUrl.isNullOrBlank()) {
+                            page.imageUrl = source.getImageUrl(page)
+                        }
+                        source.getImage(page).use { response ->
+                            response.body.bytes()
+                        }
+                    }
+                    else -> error("Page $pageIndex did not expose an image stream")
+                }
+
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
+
+            TranslationPageImage(
+                bytes = bytes,
+                mimeType = ImageUtil.findImageType { ByteArrayInputStream(bytes) }?.mime ?: "image/jpeg",
+                sourceImageKey = page.imageUrl ?: page.url.takeIf { it.isNotBlank() } ?: "$chapterId/$pageIndex",
+                width = options.outWidth.takeIf { it > 0 },
+                height = options.outHeight.takeIf { it > 0 },
+            )
+        }
+    }
+
+    private suspend fun <T> withLoadedChapter(
+        mangaId: Long,
+        chapterId: Long,
+        block: suspend (ReaderChapter, Source) -> T,
+    ): T {
+        val manga = getManga.await(mangaId) ?: error("Manga $mangaId not found")
+        val chapter = getChapter.await(chapterId) ?: error("Chapter $chapterId not found")
+        val source = sourceManager.getOrStub(manga.source)
+        if (source is StubSource) {
+            error("Source ${manga.source} is not installed")
+        }
+        val readerChapter = ReaderChapter(chapter).also { it.ref() }
+        return try {
+            ChapterLoader(
+                context = context,
+                downloadManager = downloadManager,
+                downloadProvider = downloadProvider,
+                manga = manga,
+                source = source,
+            ).loadChapter(readerChapter)
+            block(readerChapter, source)
+        } finally {
+            readerChapter.unref()
+        }
+    }
+}
+
+data class TranslationPageImage(
+    val bytes: ByteArray,
+    val mimeType: String,
+    val sourceImageKey: String,
+    val width: Int?,
+    val height: Int?,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationJob.kt
@@ -1,0 +1,121 @@
+package eu.kanade.tachiyomi.data.translation
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.lifecycle.asFlow
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.domain.translation.service.TranslationPreferences
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class TranslationJob(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
+
+    private val processor: TranslationQueueProcessor = Injekt.get()
+    private val repository: TranslationRepository = Injekt.get()
+    private val preferences: TranslationPreferences = Injekt.get()
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val notification = applicationContext.notificationBuilder(Notifications.CHANNEL_TRANSLATION_PROGRESS) {
+            setContentTitle(applicationContext.stringResource(MR.strings.label_translation_queue))
+            setSmallIcon(android.R.drawable.stat_sys_upload)
+            setOngoing(true)
+        }.build()
+        return ForegroundInfo(
+            Notifications.ID_TRANSLATION_PROGRESS,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    override suspend fun doWork(): Result {
+        if (repository.getPendingJobs().isEmpty()) {
+            return Result.success()
+        }
+        if (preferences.geminiApiKey.get().isBlank()) {
+            repository.getPendingJobs().forEach { job ->
+                repository.updateJobStatus(
+                    job = job,
+                    status = TranslationJobStatus.PausedAuth,
+                    errorMessage = "Gemini API key is empty",
+                )
+                repository.insertLog(
+                    jobId = job._id,
+                    pageId = null,
+                    level = TranslationLogLevel.Error,
+                    tag = "queue",
+                    message = "Paused translation queue",
+                    details = "Gemini API key is empty",
+                )
+            }
+            return Result.success()
+        }
+
+        setForegroundSafely()
+
+        return when (processor.processPending()) {
+            TranslationProcessResult.RetryLater -> Result.retry()
+            TranslationProcessResult.Idle,
+            TranslationProcessResult.Completed,
+            TranslationProcessResult.Paused,
+            -> Result.success()
+        }
+    }
+
+    companion object {
+        private const val TAG = "TranslationQueue"
+
+        fun start(context: Context) {
+            val request = OneTimeWorkRequestBuilder<TranslationJob>()
+                .addTag(TAG)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build(),
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(TAG, ExistingWorkPolicy.KEEP, request)
+        }
+
+        fun stop(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(TAG)
+        }
+
+        fun isRunning(context: Context): Boolean {
+            return WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWork(TAG)
+                .get()
+                .any { it.state == WorkInfo.State.RUNNING || it.state == WorkInfo.State.ENQUEUED }
+        }
+
+        fun isRunningFlow(context: Context): Flow<Boolean> {
+            return WorkManager.getInstance(context)
+                .getWorkInfosForUniqueWorkLiveData(TAG)
+                .asFlow()
+                .map { list -> list.any { it.state == WorkInfo.State.RUNNING || it.state == WorkInfo.State.ENQUEUED } }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationQueueProcessor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationQueueProcessor.kt
@@ -1,0 +1,312 @@
+package eu.kanade.tachiyomi.data.translation
+
+import android.app.Application
+import android.graphics.BitmapFactory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import tachiyomi.data.Translation_jobs
+import tachiyomi.domain.translation.service.TranslationPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.util.Locale
+import kotlin.math.max
+import kotlin.time.TimeSource
+import tachiyomi.core.common.util.system.ImageUtil
+
+class TranslationQueueProcessor(
+    private val context: Application = Injekt.get(),
+    private val repository: TranslationRepository = Injekt.get(),
+    private val preferences: TranslationPreferences = Injekt.get(),
+    private val gemini: GeminiTranslationClient = Injekt.get(),
+    private val ocrClient: LocalOcrClient = Injekt.get(),
+    private val imageResolver: TranslationImageResolver = Injekt.get(),
+    private val json: Json = Injekt.get(),
+) {
+    suspend fun processPending(): TranslationProcessResult = coroutineScope {
+        val pendingJobs = repository.getPendingJobs()
+        if (pendingJobs.isEmpty()) {
+            return@coroutineScope TranslationProcessResult.Idle
+        }
+
+        val concurrency = preferences.concurrency.get().coerceIn(1, 4)
+        var retryLater = false
+        pendingJobs.chunked(concurrency).forEach { batch ->
+            val results = batch.map { job -> async { processJob(job) } }.awaitAll()
+            when {
+                TranslationProcessResult.Paused in results -> return@coroutineScope TranslationProcessResult.Paused
+                TranslationProcessResult.RetryLater in results -> retryLater = true
+            }
+        }
+        if (retryLater) TranslationProcessResult.RetryLater else TranslationProcessResult.Completed
+    }
+
+    private suspend fun processJob(job: Translation_jobs): TranslationProcessResult {
+        val attempt = job.attempts + 1
+        val runningJob = job.copy(attempts = attempt, status = TranslationJobStatus.Running.value)
+        repository.updateJobStatus(job, TranslationJobStatus.Running, attempts = attempt)
+        repository.insertLog(
+            jobId = job._id,
+            pageId = null,
+            level = TranslationLogLevel.Info,
+            tag = "queue",
+            message = "Started ${job.scope} translation",
+            details = "model=${job.model}, pipeline=${job.pipeline}, mode=${job.mode}, attempt=$attempt",
+        )
+
+        return try {
+            when (job.scope) {
+                TranslationScope.Image.value -> {
+                    val chapterId = requireNotNull(job.chapter_id) { "Image job missing chapter id" }
+                    val pageIndex = requireNotNull(job.page_index) { "Image job missing page index" }.toInt()
+                    processPage(runningJob, chapterId, pageIndex, current = 0, total = 1)
+                    repository.updateJobProgress(runningJob, current = 1, total = 1)
+                }
+                TranslationScope.Chapter.value -> {
+                    val chapterId = requireNotNull(job.chapter_id) { "Chapter job missing chapter id" }
+                    val pageCount = imageResolver.getPageCount(job.manga_id, chapterId)
+                    repository.updateJobProgress(runningJob, current = 0, total = pageCount.toLong())
+                    for (pageIndex in 0 until pageCount) {
+                        processPage(runningJob, chapterId, pageIndex, current = pageIndex.toLong(), total = pageCount.toLong())
+                        repository.updateJobProgress(runningJob, current = pageIndex + 1L, total = pageCount.toLong())
+                    }
+                }
+                else -> error("Unsupported translation scope: ${job.scope}")
+            }
+            repository.updateJobStatus(runningJob, TranslationJobStatus.Completed, attempts = attempt)
+            repository.insertLog(
+                jobId = job._id,
+                pageId = null,
+                level = TranslationLogLevel.Info,
+                tag = "queue",
+                message = "Completed ${job.scope} translation",
+            )
+            TranslationProcessResult.Completed
+        } catch (e: Throwable) {
+            handleFailure(runningJob, e, attempt)
+        }
+    }
+
+    private suspend fun processPage(
+        job: Translation_jobs,
+        chapterId: Long,
+        pageIndex: Int,
+        current: Long,
+        total: Long,
+    ) {
+        val targetLanguage = job.target_language.ifBlank { Locale.getDefault().displayLanguage.ifBlank { "English" } }
+        if (!job.overwrite && repository.getPage(chapterId, pageIndex.toLong(), targetLanguage) != null) {
+            repository.insertLog(
+                jobId = job._id,
+                pageId = null,
+                level = TranslationLogLevel.Info,
+                tag = "queue",
+                message = "Skipped existing overlay",
+                details = "chapter=$chapterId, page=$pageIndex, progress=${current + 1}/$total",
+            )
+            return
+        }
+
+        val mark = TimeSource.Monotonic.markNow()
+        val image = imageResolver.resolvePage(job.manga_id, chapterId, pageIndex)
+        val generationConfig = preferences.toGenerationConfig()
+        repository.insertLog(
+            jobId = job._id,
+            pageId = null,
+            level = TranslationLogLevel.Debug,
+            tag = "request",
+            message = "Prepared page translation",
+            details = buildString {
+                append("chapter=$chapterId, page=$pageIndex, mime=${image.mimeType}, ")
+                append("size=${image.width}x${image.height}, config=${generationConfig.toGeminiJson(json)}")
+            }.takeIf { preferences.rawDebugLogging.get() },
+        )
+
+        val overlay = when (job.pipeline) {
+            "local_ocr_gemini" -> translateWithLocalOcr(job, image, targetLanguage)
+            else -> gemini.translatePageImage(
+                apiKey = preferences.geminiApiKey.get(),
+                model = job.model,
+                imageBytes = image.bytes,
+                mimeType = image.mimeType,
+                targetLanguage = targetLanguage,
+                sourceLanguage = job.source_language,
+                generationConfig = generationConfig,
+                extraInstructions = preferences.globalInstructions.get(),
+            )
+        }
+
+        val inpaintUri = if (job.wantsInpaint()) {
+            generateInpaint(job, pageIndex, image, overlay, targetLanguage)
+        } else {
+            null
+        }
+
+        val savedPage = repository.saveOverlay(
+            mangaId = job.manga_id,
+            chapterId = chapterId,
+            pageIndex = pageIndex.toLong(),
+            sourceImageKey = image.sourceImageKey,
+            model = job.model,
+            targetLanguage = targetLanguage,
+            sourceLanguage = job.source_language,
+            pipeline = job.pipeline,
+            imageWidth = image.width,
+            imageHeight = image.height,
+            inpaintImageUri = inpaintUri,
+            overlay = overlay,
+        )
+
+        repository.insertLog(
+            jobId = job._id,
+            pageId = savedPage._id,
+            level = TranslationLogLevel.Info,
+            tag = "page",
+            message = "Saved translation overlay",
+            details = buildString {
+                appendLine("chapter=$chapterId, page=$pageIndex, boxes=${overlay.boxes.size}")
+                appendLine("elapsed_ms=${mark.elapsedNow().inWholeMilliseconds}")
+                appendLine("source_language=${overlay.sourceLanguage ?: job.source_language ?: "auto"}")
+                appendLine("target_language=${overlay.targetLanguage ?: targetLanguage}")
+                overlay.boxes.forEachIndexed { index, box ->
+                    appendLine("${index + 1}. ${box.originalText} => ${box.translatedText}")
+                }
+            },
+        )
+    }
+
+    private suspend fun translateWithLocalOcr(
+        job: Translation_jobs,
+        image: TranslationPageImage,
+        targetLanguage: String,
+    ): TranslationOverlayResult {
+        val bitmap = BitmapFactory.decodeByteArray(image.bytes, 0, image.bytes.size)
+            ?: error("Unable to decode page image for OCR")
+        val blocks = ocrClient.recognize(
+            bitmap = bitmap,
+            script = OcrScript.fromPreference(preferences.ocrScript.get()),
+        )
+        repository.insertLog(
+            jobId = job._id,
+            pageId = null,
+            level = TranslationLogLevel.Debug,
+            tag = "ocr",
+            message = "Local OCR completed",
+            details = buildString {
+                appendLine("blocks=${blocks.size}")
+                blocks.forEach { block -> appendLine("${block.id}: ${block.text}") }
+            },
+        )
+        return gemini.translateOcrBlocks(
+            apiKey = preferences.geminiApiKey.get(),
+            model = job.model,
+            blocks = blocks,
+            targetLanguage = targetLanguage,
+            sourceLanguage = job.source_language,
+            generationConfig = preferences.toGenerationConfig(),
+            extraInstructions = preferences.globalInstructions.get(),
+        )
+    }
+
+    private suspend fun generateInpaint(
+        job: Translation_jobs,
+        pageIndex: Int,
+        image: TranslationPageImage,
+        overlay: TranslationOverlayResult,
+        targetLanguage: String,
+    ): String? {
+        return try {
+            val bytes = gemini.generateInpaintImage(
+                apiKey = preferences.geminiApiKey.get(),
+                model = preferences.geminiInpaintModel.get(),
+                imageBytes = image.bytes,
+                mimeType = image.mimeType,
+                overlay = overlay,
+                targetLanguage = targetLanguage,
+            ) ?: return null
+            val mime = ImageUtil.findImageType { ByteArrayInputStream(bytes) } ?: ImageUtil.ImageType.JPEG
+            val dir = File(context.filesDir, "translations/inpaint").also { it.mkdirs() }
+            val file = File(dir, "${job.chapter_id}-$pageIndex-${targetLanguage.hashCode()}.${mime.extension}")
+            file.writeBytes(bytes)
+            file.absolutePath
+        } catch (e: Throwable) {
+            repository.insertLog(
+                jobId = job._id,
+                pageId = null,
+                level = TranslationLogLevel.Warning,
+                tag = "inpaint",
+                message = "Inpaint failed; overlay remains available",
+                details = e.message,
+            )
+            null
+        }
+    }
+
+    private suspend fun handleFailure(
+        job: Translation_jobs,
+        error: Throwable,
+        attempt: Long,
+    ): TranslationProcessResult {
+        val errorBody = (error as? GeminiApiException)?.errorBody
+        val message = errorBody ?: error.message ?: error::class.simpleName.orEmpty()
+        val status = when ((error as? GeminiApiException)?.code) {
+            401, 403 -> TranslationJobStatus.PausedAuth
+            429 -> TranslationJobStatus.PausedQuota
+            else -> null
+        }
+        if (status != null) {
+            repository.updateJobStatus(job, status, errorMessage = message, attempts = attempt)
+            repository.insertLog(job._id, null, TranslationLogLevel.Error, "queue", "Paused translation queue", message)
+            return TranslationProcessResult.Paused
+        }
+
+        val transient = error is IOException || (error as? GeminiApiException)?.code in TRANSIENT_HTTP_CODES
+        val canRetry = transient && attempt < MAX_ATTEMPTS
+        repository.updateJobStatus(
+            job = job,
+            status = if (canRetry) TranslationJobStatus.Retrying else TranslationJobStatus.Failed,
+            errorMessage = message,
+            attempts = attempt,
+        )
+        repository.insertLog(
+            jobId = job._id,
+            pageId = null,
+            level = TranslationLogLevel.Error,
+            tag = "queue",
+            message = if (canRetry) "Translation failed; retry scheduled" else "Translation failed",
+            details = "attempt=$attempt, transient=$transient, error=$message",
+        )
+        return if (canRetry) TranslationProcessResult.RetryLater else TranslationProcessResult.Completed
+    }
+
+    private fun TranslationPreferences.toGenerationConfig(): TranslationGenerationConfig {
+        return TranslationGenerationConfig(
+            temperature = temperature.get(),
+            topP = topP.get(),
+            topK = topK.get(),
+            maxOutputTokens = max(1, maxOutputTokens.get()),
+            thinkingBudget = thinkingBudget.get().takeIf { it >= 0 },
+            rawJsonOverride = rawJsonOverride.get(),
+        )
+    }
+
+    private fun Translation_jobs.wantsInpaint(): Boolean {
+        return mode == TranslationMode.Inpaint.value || mode == TranslationMode.OverlayAndInpaint.value
+    }
+
+    companion object {
+        private const val MAX_ATTEMPTS = 3L
+        private val TRANSIENT_HTTP_CODES = setOf(408, 409, 425, 500, 502, 503, 504)
+    }
+}
+
+enum class TranslationProcessResult {
+    Idle,
+    Completed,
+    RetryLater,
+    Paused,
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationRepository.kt
@@ -1,0 +1,304 @@
+package eu.kanade.tachiyomi.data.translation
+
+import app.cash.sqldelight.async.coroutines.awaitAsList
+import app.cash.sqldelight.async.coroutines.awaitAsOne
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.data.Database
+import tachiyomi.data.Translation_boxes
+import tachiyomi.data.Translation_jobs
+import tachiyomi.data.Translation_logs
+import tachiyomi.data.Translation_pages
+import tachiyomi.data.subscribeToList
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class TranslationRepository(
+    private val database: Database = Injekt.get(),
+) {
+    fun observeJobs(): Flow<List<Translation_jobs>> {
+        return database.translationsQueries.getJobs().subscribeToList()
+    }
+
+    fun observeLogs(): Flow<List<Translation_logs>> {
+        return database.translationsQueries.getLogs().subscribeToList()
+    }
+
+    suspend fun getPendingJobs(): List<Translation_jobs> {
+        return database.translationsQueries.getPendingJobs().awaitAsList()
+    }
+
+    suspend fun getPage(
+        chapterId: Long,
+        pageIndex: Long,
+        targetLanguage: String,
+    ): Translation_pages? {
+        return database.translationsQueries
+            .getPage(chapterId, pageIndex, targetLanguage)
+            .awaitAsOneOrNull()
+    }
+
+    suspend fun getPagesByChapter(chapterId: Long, targetLanguage: String): List<SavedTranslationPage> {
+        return database.translationsQueries
+            .getPagesByChapter(chapterId, targetLanguage)
+            .awaitAsList()
+            .map { page ->
+                SavedTranslationPage(
+                    page = page,
+                    boxes = database.translationsQueries.getBoxesForPage(page._id).awaitAsList(),
+                )
+            }
+    }
+
+    suspend fun getSavedPage(
+        chapterId: Long,
+        pageIndex: Long,
+        targetLanguage: String,
+    ): SavedTranslationPage? {
+        val page = getPage(chapterId, pageIndex, targetLanguage) ?: return null
+        return SavedTranslationPage(
+            page = page,
+            boxes = database.translationsQueries.getBoxesForPage(page._id).awaitAsList(),
+        )
+    }
+
+    suspend fun enqueueJob(
+        mangaId: Long,
+        chapterId: Long?,
+        pageIndex: Long?,
+        scope: TranslationScope,
+        pipeline: String,
+        mode: TranslationMode,
+        model: String,
+        targetLanguage: String,
+        sourceLanguage: String?,
+        overwrite: Boolean,
+        progressTotal: Long = 1,
+    ): Long {
+        val now = System.currentTimeMillis()
+        database.translationsQueries.insertJob(
+            mangaId = mangaId,
+            chapterId = chapterId,
+            pageIndex = pageIndex,
+            scope = scope.value,
+            pipeline = pipeline,
+            mode = mode.value,
+            model = model,
+            targetLanguage = targetLanguage,
+            sourceLanguage = sourceLanguage,
+            overwrite = overwrite,
+            status = TranslationJobStatus.Queued.value,
+            progressTotal = progressTotal,
+            createdAt = now,
+        )
+        return database.translationsQueries.lastInsertedJobId().awaitAsOne()
+    }
+
+    suspend fun updateJobStatus(
+        job: Translation_jobs,
+        status: TranslationJobStatus,
+        errorMessage: String? = null,
+        attempts: Long = job.attempts,
+    ) {
+        database.translationsQueries.updateJobStatus(
+            status = status.value,
+            attempts = attempts,
+            errorMessage = errorMessage?.take(MAX_ERROR_LENGTH),
+            updatedAt = System.currentTimeMillis(),
+            id = job._id,
+        )
+    }
+
+    suspend fun updateJobProgress(job: Translation_jobs, current: Long, total: Long) {
+        database.translationsQueries.updateJobProgress(
+            progressCurrent = current,
+            progressTotal = total,
+            updatedAt = System.currentTimeMillis(),
+            id = job._id,
+        )
+    }
+
+    suspend fun deleteJob(id: Long) {
+        database.translationsQueries.deleteJob(id)
+    }
+
+    suspend fun clearFinishedJobs() {
+        database.translationsQueries.clearFinishedJobs()
+    }
+
+    suspend fun clearLogs() {
+        database.translationsQueries.clearLogs()
+    }
+
+    suspend fun clearPages() {
+        database.translationsQueries.clearPages()
+    }
+
+    suspend fun saveOverlay(
+        mangaId: Long,
+        chapterId: Long,
+        pageIndex: Long,
+        sourceImageKey: String,
+        model: String,
+        targetLanguage: String,
+        sourceLanguage: String?,
+        pipeline: String,
+        imageWidth: Int?,
+        imageHeight: Int?,
+        inpaintImageUri: String?,
+        overlay: TranslationOverlayResult,
+    ): Translation_pages {
+        val now = System.currentTimeMillis()
+        database.transaction {
+            database.translationsQueries.upsertPage(
+                mangaId = mangaId,
+                chapterId = chapterId,
+                pageIndex = pageIndex,
+                sourceImageKey = sourceImageKey,
+                model = model,
+                targetLanguage = targetLanguage,
+                sourceLanguage = sourceLanguage ?: overlay.sourceLanguage,
+                pipeline = pipeline,
+                imageWidth = imageWidth?.toLong(),
+                imageHeight = imageHeight?.toLong(),
+                inpaintImageUri = inpaintImageUri,
+                createdAt = now,
+            )
+            val page = database.translationsQueries
+                .getPage(chapterId, pageIndex, targetLanguage)
+                .awaitAsOne()
+            database.translationsQueries.deleteBoxesForPage(page._id)
+            overlay.boxes.forEachIndexed { index, box ->
+                database.translationsQueries.insertBox(
+                    pageId = page._id,
+                    x = box.x.toDouble().coerceIn(0.0, 1.0),
+                    y = box.y.toDouble().coerceIn(0.0, 1.0),
+                    width = box.width.toDouble().coerceIn(0.0, 1.0),
+                    height = box.height.toDouble().coerceIn(0.0, 1.0),
+                    originalText = box.originalText,
+                    translatedText = box.translatedText,
+                    textType = box.textType,
+                    confidence = box.confidence?.toDouble(),
+                    styleJson = null,
+                    sortOrder = index.toLong(),
+                )
+            }
+        }
+        return database.translationsQueries
+            .getPage(chapterId, pageIndex, targetLanguage)
+            .awaitAsOne()
+    }
+
+    suspend fun ensurePage(
+        mangaId: Long,
+        chapterId: Long,
+        pageIndex: Long,
+        sourceImageKey: String,
+        model: String,
+        targetLanguage: String,
+        sourceLanguage: String?,
+        pipeline: String,
+    ): Translation_pages {
+        val now = System.currentTimeMillis()
+        database.translationsQueries.upsertPage(
+            mangaId = mangaId,
+            chapterId = chapterId,
+            pageIndex = pageIndex,
+            sourceImageKey = sourceImageKey,
+            model = model,
+            targetLanguage = targetLanguage,
+            sourceLanguage = sourceLanguage,
+            pipeline = pipeline,
+            imageWidth = null,
+            imageHeight = null,
+            inpaintImageUri = null,
+            createdAt = now,
+        )
+        return database.translationsQueries
+            .getPage(chapterId, pageIndex, targetLanguage)
+            .awaitAsOne()
+    }
+
+    suspend fun replaceBoxes(pageId: Long, boxes: List<TranslationBoxEdit>) {
+        database.transaction {
+            database.translationsQueries.deleteBoxesForPage(pageId)
+            boxes.forEachIndexed { index, box ->
+                database.translationsQueries.insertBox(
+                    pageId = pageId,
+                    x = box.x.coerceIn(0.0, 1.0),
+                    y = box.y.coerceIn(0.0, 1.0),
+                    width = box.width.coerceIn(0.0, 1.0),
+                    height = box.height.coerceIn(0.0, 1.0),
+                    originalText = box.originalText,
+                    translatedText = box.translatedText,
+                    textType = box.textType,
+                    confidence = box.confidence,
+                    styleJson = box.styleJson,
+                    sortOrder = index.toLong(),
+                )
+            }
+            database.translationsQueries.touchPage(
+                updatedAt = System.currentTimeMillis(),
+                id = pageId,
+            )
+        }
+    }
+
+    suspend fun insertLog(
+        jobId: Long?,
+        pageId: Long?,
+        level: TranslationLogLevel,
+        tag: String,
+        message: String,
+        details: String? = null,
+    ) {
+        database.translationsQueries.insertLog(
+            jobId = jobId,
+            pageId = pageId,
+            createdAt = System.currentTimeMillis(),
+            level = level.value,
+            tag = tag,
+            message = message,
+            details = details?.let(TranslationLogRedactor::redact),
+        )
+    }
+
+    companion object {
+        private const val MAX_ERROR_LENGTH = 4_000
+    }
+}
+
+data class SavedTranslationPage(
+    val page: Translation_pages,
+    val boxes: List<Translation_boxes>,
+)
+
+enum class TranslationScope(val value: String) {
+    Image("image"),
+    Chapter("chapter"),
+    Manga("manga"),
+}
+
+enum class TranslationMode(val value: String) {
+    Overlay("overlay"),
+    Inpaint("inpaint"),
+    OverlayAndInpaint("overlay_inpaint"),
+}
+
+enum class TranslationJobStatus(val value: String) {
+    Queued("queued"),
+    Running("running"),
+    Retrying("retrying"),
+    Completed("completed"),
+    Failed("failed"),
+    Cancelled("cancelled"),
+    PausedAuth("paused_auth"),
+    PausedQuota("paused_quota"),
+}
+
+enum class TranslationLogLevel(val value: String) {
+    Debug("debug"),
+    Info("info"),
+    Warning("warning"),
+    Error("error"),
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -16,6 +16,11 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.translation.GeminiTranslationClient
+import eu.kanade.tachiyomi.data.translation.LocalOcrClient
+import eu.kanade.tachiyomi.data.translation.TranslationImageResolver
+import eu.kanade.tachiyomi.data.translation.TranslationQueueProcessor
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.network.JavaScriptEngine
 import eu.kanade.tachiyomi.network.NetworkHelper
@@ -114,6 +119,12 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { DownloadManager(app) }
         addSingletonFactory { DownloadCache(app) }
 
+        addSingletonFactory { TranslationRepository() }
+        addSingletonFactory { GeminiTranslationClient() }
+        addSingletonFactory { LocalOcrClient() }
+        addSingletonFactory { TranslationImageResolver() }
+        addSingletonFactory { TranslationQueueProcessor(app) }
+
         addSingletonFactory { TrackerManager() }
         addSingletonFactory { DelayedTrackingStore(app) }
 
@@ -133,6 +144,8 @@ class AppModule(val app: Application) : InjektModule {
             get<Database>()
 
             get<DownloadManager>()
+
+            get<TranslationQueueProcessor>()
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -17,6 +17,7 @@ import tachiyomi.domain.backup.service.BackupPreferences
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.storage.service.StoragePreferences
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.domain.updates.service.UpdatesPreferences
 import uy.kohesive.injekt.api.InjektModule
 import uy.kohesive.injekt.api.InjektRegistrar
@@ -58,6 +59,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             DownloadPreferences(get())
+        }
+        addSingletonFactory {
+            TranslationPreferences(get())
         }
         addSingletonFactory {
             BackupPreferences(get())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.library
 
+import android.app.Application
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastFilter
@@ -19,6 +20,10 @@ import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.translation.TranslationJob
+import eu.kanade.tachiyomi.data.translation.TranslationMode
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
+import eu.kanade.tachiyomi.data.translation.TranslationScope
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
@@ -63,6 +68,7 @@ import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.track.interactor.GetTracksPerManga
 import tachiyomi.domain.track.model.Track
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -85,6 +91,9 @@ class LibraryScreenModel(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val downloadCache: DownloadCache = Injekt.get(),
     private val trackerManager: TrackerManager = Injekt.get(),
+    private val translationRepository: TranslationRepository = Injekt.get(),
+    private val translationPreferences: TranslationPreferences = Injekt.get(),
+    private val application: Application = Injekt.get(),
 ) : StateScreenModel<LibraryScreenModel.State>(State()) {
 
     init {
@@ -518,6 +527,36 @@ class LibraryScreenModel(
                 downloadManager.downloadChapters(manga, chapters)
             }
         }
+    }
+
+    fun performTranslateSelection() {
+        val mangas = state.value.selectedManga
+        screenModelScope.launchNonCancellable {
+            val mode = if (translationPreferences.enableInpaint.get()) {
+                TranslationMode.OverlayAndInpaint
+            } else {
+                TranslationMode.Overlay
+            }
+            mangas.forEach { manga ->
+                getChaptersByMangaId.await(manga.id)
+                    .forEach { chapter ->
+                        translationRepository.enqueueJob(
+                            mangaId = manga.id,
+                            chapterId = chapter.id,
+                            pageIndex = null,
+                            scope = TranslationScope.Chapter,
+                            pipeline = translationPreferences.pipeline.get(),
+                            mode = mode,
+                            model = translationPreferences.geminiModel.get(),
+                            targetLanguage = translationPreferences.targetLanguage.get(),
+                            sourceLanguage = translationPreferences.sourceLanguage.get().ifBlank { null },
+                            overwrite = !translationPreferences.skipExistingOverlays.get(),
+                        )
+                    }
+            }
+            TranslationJob.start(application)
+        }
+        clearSelection()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -149,6 +149,7 @@ data object LibraryTab : Tab {
                     onMarkAsUnreadClicked = { screenModel.markReadSelection(false) },
                     onDownloadClicked = screenModel::performDownloadAction
                         .takeIf { state.selectedManga.fastAll { !it.isLocal() } },
+                    onTranslateClicked = screenModel::performTranslateSelection,
                     onDeleteClicked = screenModel::openDeleteMangaDialog,
                     onMigrateClicked = {
                         val selection = state.selection

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -121,6 +121,7 @@ class MangaScreen(
             navigateUp = navigator::pop,
             onChapterClicked = { openChapter(context, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
+            onTranslateChapter = screenModel::runChapterTranslationActions,
             onAddToLibraryClicked = {
                 screenModel.toggleFavorite()
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -154,6 +155,7 @@ class MangaScreen(
             onCoverClicked = screenModel::showCoverDialog,
             onShareClicked = { shareManga(context, screenModel.manga, screenModel.source) }.takeIf { isHttpSource },
             onDownloadActionClicked = screenModel::runDownloadAction.takeIf { !successState.source.isLocalOrStub() },
+            onTranslateAllClicked = screenModel::runTranslateAllAction,
             onEditCategoryClicked = screenModel::showChangeCategoryDialog.takeIf { successState.manga.favorite },
             onEditFetchIntervalClicked = screenModel::showSetFetchIntervalDialog.takeIf {
                 successState.manga.favorite

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -36,6 +36,10 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.translation.TranslationJob
+import eu.kanade.tachiyomi.data.translation.TranslationMode
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
+import eu.kanade.tachiyomi.data.translation.TranslationScope
 import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
@@ -85,6 +89,7 @@ import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.track.interactor.GetTracks
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -120,6 +125,8 @@ class MangaScreenModel(
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val mangaRepository: MangaRepository = Injekt.get(),
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get(),
+    private val translationRepository: TranslationRepository = Injekt.get(),
+    private val translationPreferences: TranslationPreferences = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -723,6 +730,48 @@ class MangaScreenModel(
         }
         if (chaptersToDownload.isNotEmpty()) {
             startDownload(chaptersToDownload, false)
+        }
+    }
+
+    fun runChapterTranslationActions(items: List<ChapterList.Item>) {
+        enqueueChapterTranslations(items)
+    }
+
+    fun runTranslateAllAction() {
+        enqueueChapterTranslations(filteredChapters.orEmpty())
+    }
+
+    private fun enqueueChapterTranslations(items: List<ChapterList.Item>) {
+        val manga = manga ?: return
+        val chapters = items
+            .map { it.chapter }
+            .distinctBy { it.id }
+        if (chapters.isEmpty()) return
+
+        screenModelScope.launchIO {
+            val mode = if (translationPreferences.enableInpaint.get()) {
+                TranslationMode.OverlayAndInpaint
+            } else {
+                TranslationMode.Overlay
+            }
+            chapters.forEach { chapter ->
+                translationRepository.enqueueJob(
+                    mangaId = manga.id,
+                    chapterId = chapter.id,
+                    pageIndex = null,
+                    scope = TranslationScope.Chapter,
+                    pipeline = translationPreferences.pipeline.get(),
+                    mode = mode,
+                    model = translationPreferences.geminiModel.get(),
+                    targetLanguage = translationPreferences.targetLanguage.get(),
+                    sourceLanguage = translationPreferences.sourceLanguage.get().ifBlank { null },
+                    overwrite = !translationPreferences.skipExistingOverlays.get(),
+                )
+            }
+            TranslationJob.start(context)
+            withUIContext {
+                context.toast("Queued translation for ${chapters.size} chapter(s)")
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.more
 
+import android.app.Application
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
@@ -21,8 +22,11 @@ import eu.kanade.presentation.more.MoreScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.translation.TranslationJob
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
+import eu.kanade.tachiyomi.ui.translation.TranslationQueueScreen
 import eu.kanade.tachiyomi.ui.setting.SettingsScreen
 import eu.kanade.tachiyomi.ui.stats.StatsScreen
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -60,13 +64,16 @@ data object MoreTab : Tab {
         val navigator = LocalNavigator.currentOrThrow
         val screenModel = rememberScreenModel { MoreScreenModel() }
         val downloadQueueState by screenModel.downloadQueueState.collectAsState()
+        val translationQueueState by screenModel.translationQueueState.collectAsState()
         MoreScreen(
             downloadQueueStateProvider = { downloadQueueState },
+            translationQueueStateProvider = { translationQueueState },
             downloadedOnly = screenModel.downloadedOnly,
             onDownloadedOnlyChange = { screenModel.downloadedOnly = it },
             incognitoMode = screenModel.incognitoMode,
             onIncognitoModeChange = { screenModel.incognitoMode = it },
             onClickDownloadQueue = { navigator.push(DownloadQueueScreen) },
+            onClickTranslationQueue = { navigator.push(TranslationQueueScreen) },
             onClickCategories = { navigator.push(CategoryScreen()) },
             onClickStats = { navigator.push(StatsScreen()) },
             onClickDataAndStorage = { navigator.push(SettingsScreen(SettingsScreen.Destination.DataAndStorage)) },
@@ -79,6 +86,8 @@ data object MoreTab : Tab {
 
 private class MoreScreenModel(
     private val downloadManager: DownloadManager = Injekt.get(),
+    private val translationRepository: TranslationRepository = Injekt.get(),
+    private val application: Application = Injekt.get(),
     preferences: BasePreferences = Injekt.get(),
 ) : ScreenModel {
 
@@ -87,6 +96,10 @@ private class MoreScreenModel(
 
     private var _downloadQueueState: MutableStateFlow<DownloadQueueState> = MutableStateFlow(DownloadQueueState.Stopped)
     val downloadQueueState: StateFlow<DownloadQueueState> = _downloadQueueState.asStateFlow()
+
+    private var _translationQueueState: MutableStateFlow<TranslationQueueState> =
+        MutableStateFlow(TranslationQueueState.Stopped)
+    val translationQueueState: StateFlow<TranslationQueueState> = _translationQueueState.asStateFlow()
 
     init {
         // Handle running/paused status change and queue progress updating
@@ -104,6 +117,23 @@ private class MoreScreenModel(
                     }
                 }
         }
+        screenModelScope.launchIO {
+            combine(
+                TranslationJob.isRunningFlow(application),
+                translationRepository.observeJobs(),
+            ) { isRunning, jobs -> Pair(isRunning, jobs.count { it.status !in TRANSLATION_FINISHED_STATUSES }) }
+                .collectLatest { (isRunning, pendingJobCount) ->
+                    _translationQueueState.value = when {
+                        pendingJobCount == 0 -> TranslationQueueState.Stopped
+                        !isRunning -> TranslationQueueState.Paused(pendingJobCount)
+                        else -> TranslationQueueState.Running(pendingJobCount)
+                    }
+                }
+        }
+    }
+
+    companion object {
+        private val TRANSLATION_FINISHED_STATUSES = setOf("completed", "failed", "cancelled")
     }
 }
 
@@ -111,4 +141,10 @@ sealed interface DownloadQueueState {
     data object Stopped : DownloadQueueState
     data class Paused(val pending: Int) : DownloadQueueState
     data class Downloading(val pending: Int) : DownloadQueueState
+}
+
+sealed interface TranslationQueueState {
+    data object Stopped : TranslationQueueState
+    data class Paused(val pending: Int) : TranslationQueueState
+    data class Running(val pending: Int) : TranslationQueueState
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -55,6 +55,7 @@ import eu.kanade.presentation.reader.ReaderContentOverlay
 import eu.kanade.presentation.reader.ReaderPageActionsDialog
 import eu.kanade.presentation.reader.ReaderPageIndicator
 import eu.kanade.presentation.reader.ReadingModeSelectDialog
+import eu.kanade.presentation.reader.TranslationOverlayEditorDialog
 import eu.kanade.presentation.reader.appbars.ReaderAppBars
 import eu.kanade.presentation.reader.settings.ReaderSettingsDialog
 import eu.kanade.tachiyomi.R
@@ -241,6 +242,12 @@ class ReaderActivity : BaseActivity() {
                     is ReaderViewModel.Event.SetCoverResult -> {
                         onSetAsCoverResult(event.result)
                     }
+                    ReaderViewModel.Event.TranslationOverlaySaved -> {
+                        toast(MR.strings.translation_overlay_saved)
+                    }
+                    is ReaderViewModel.Event.TranslationOverlaySaveFailed -> {
+                        toast(stringResource(MR.strings.translation_overlay_save_failed, event.message))
+                    }
                 }
             }
             .launchIn(lifecycleScope)
@@ -274,7 +281,8 @@ class ReaderActivity : BaseActivity() {
         }
 
         val onDismissRequest = viewModel::closeDialog
-        when (state.dialog) {
+        val dialog = state.dialog
+        when (dialog) {
             is ReaderViewModel.Dialog.Loading -> {
                 AlertDialog(
                     onDismissRequest = {},
@@ -321,11 +329,21 @@ class ReaderActivity : BaseActivity() {
                 )
             }
             is ReaderViewModel.Dialog.PageActions -> {
+                val page = dialog.page
                 ReaderPageActionsDialog(
                     onDismissRequest = onDismissRequest,
                     onSetAsCover = viewModel::setAsCover,
                     onShare = viewModel::shareImage,
                     onSave = viewModel::saveImage,
+                    onTranslate = { viewModel.translatePageImage(page) },
+                    onEditTranslation = { viewModel.openTranslationOverlayEditor(page) },
+                )
+            }
+            is ReaderViewModel.Dialog.TranslationOverlayEditor -> {
+                TranslationOverlayEditorDialog(
+                    savedPage = dialog.savedPage,
+                    onDismissRequest = onDismissRequest,
+                    onSave = { boxes -> viewModel.saveTranslationOverlayEdits(dialog.page, boxes) },
                 )
             }
             null -> {}
@@ -470,6 +488,12 @@ class ReaderActivity : BaseActivity() {
             onOpenInWebView = ::openChapterInWebView.takeIf { isHttpSource },
             onOpenInBrowser = ::openChapterInBrowser.takeIf { isHttpSource },
             onShare = ::shareChapter.takeIf { isHttpSource },
+            onTranslateChapter = viewModel::translateCurrentChapter,
+            onToggleTranslationOverlay = {
+                val enabled = viewModel.toggleTranslationOverlay()
+                menuToggleToast?.cancel()
+                menuToggleToast = toast(if (enabled) MR.strings.on else MR.strings.off)
+            },
 
             viewer = state.viewer,
             onNextChapter = ::loadNextChapter,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -22,6 +22,13 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.saver.Image
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.saver.Location
+import eu.kanade.tachiyomi.data.translation.SavedTranslationPage
+import eu.kanade.tachiyomi.data.translation.TranslationBoxEdit
+import eu.kanade.tachiyomi.data.translation.TranslationJob
+import eu.kanade.tachiyomi.data.translation.TranslationLogLevel
+import eu.kanade.tachiyomi.data.translation.TranslationMode
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
+import eu.kanade.tachiyomi.data.translation.TranslationScope
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
@@ -73,11 +80,13 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.time.Instant
 import java.util.Date
+import java.util.Locale
 
 /**
  * Presenter used by the activity to perform background operations.
@@ -101,6 +110,9 @@ class ReaderViewModel @JvmOverloads constructor(
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
     private val getIncognitoState: GetIncognitoState = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
+    private val translationRepository: TranslationRepository = Injekt.get(),
+    private val translationPreferences: TranslationPreferences = Injekt.get(),
+    private val application: Application = Injekt.get(),
 ) : ViewModel() {
 
     private val mutableState = MutableStateFlow(State())
@@ -461,6 +473,126 @@ class ReaderViewModel @JvmOverloads constructor(
         }
 
         eventChannel.trySend(Event.PageChanged)
+    }
+
+    fun translatePageImage(page: ReaderPage) {
+        val chapterId = page.chapter.chapter.id ?: return
+        enqueueTranslationJob(
+            chapterId = chapterId,
+            pageIndex = page.index.toLong(),
+            scope = TranslationScope.Image,
+        )
+    }
+
+    fun translateCurrentChapter() {
+        val chapterId = state.value.currentChapter?.chapter?.id ?: return
+        enqueueTranslationJob(
+            chapterId = chapterId,
+            pageIndex = null,
+            scope = TranslationScope.Chapter,
+        )
+    }
+
+    fun toggleTranslationOverlay(): Boolean {
+        val enabled = translationPreferences.autoShowOverlay.toggle()
+        eventChannel.trySend(Event.ReloadViewerChapters)
+        return enabled
+    }
+
+    fun openTranslationOverlayEditor(page: ReaderPage) {
+        val chapterId = page.chapter.chapter.id ?: return
+        mutableState.update { it.copy(dialog = Dialog.Loading) }
+        viewModelScope.launchIO {
+            val targetLanguage = translationTargetLanguage()
+            val savedPage = translationRepository.getSavedPage(
+                chapterId = chapterId,
+                pageIndex = page.index.toLong(),
+                targetLanguage = targetLanguage,
+            )
+            withUIContext {
+                mutableState.update {
+                    it.copy(dialog = Dialog.TranslationOverlayEditor(page, savedPage))
+                }
+            }
+        }
+    }
+
+    fun saveTranslationOverlayEdits(page: ReaderPage, boxes: List<TranslationBoxEdit>) {
+        val manga = manga ?: return
+        val chapterId = page.chapter.chapter.id ?: return
+        mutableState.update { it.copy(dialog = Dialog.Loading) }
+        viewModelScope.launchIO {
+            try {
+                val targetLanguage = translationTargetLanguage()
+                val savedPage = translationRepository.getSavedPage(
+                    chapterId = chapterId,
+                    pageIndex = page.index.toLong(),
+                    targetLanguage = targetLanguage,
+                )?.page ?: translationRepository.ensurePage(
+                    mangaId = manga.id,
+                    chapterId = chapterId,
+                    pageIndex = page.index.toLong(),
+                    sourceImageKey = page.imageUrl ?: "${page.chapter.chapter.url}#${page.index}",
+                    model = translationPreferences.geminiModel.get(),
+                    targetLanguage = targetLanguage,
+                    sourceLanguage = translationPreferences.sourceLanguage.get().ifBlank { null },
+                    pipeline = translationPreferences.pipeline.get(),
+                )
+                translationRepository.replaceBoxes(savedPage._id, boxes)
+                translationRepository.insertLog(
+                    jobId = null,
+                    pageId = savedPage._id,
+                    level = TranslationLogLevel.Info,
+                    tag = "editor",
+                    message = "Saved translation overlay edits",
+                    details = "boxes=${boxes.size}",
+                )
+                withUIContext {
+                    mutableState.update { it.copy(dialog = null) }
+                    eventChannel.send(Event.ReloadViewerChapters)
+                    eventChannel.send(Event.TranslationOverlaySaved)
+                }
+            } catch (e: Throwable) {
+                logcat(LogPriority.ERROR, e)
+                withUIContext {
+                    mutableState.update { it.copy(dialog = Dialog.TranslationOverlayEditor(page, null)) }
+                    eventChannel.send(Event.TranslationOverlaySaveFailed(e.message ?: e::class.simpleName.orEmpty()))
+                }
+            }
+        }
+    }
+
+    private fun translationTargetLanguage(): String {
+        return translationPreferences.targetLanguage.get()
+            .ifBlank { Locale.getDefault().displayLanguage.ifBlank { "English" } }
+    }
+
+    private fun enqueueTranslationJob(
+        chapterId: Long,
+        pageIndex: Long?,
+        scope: TranslationScope,
+    ) {
+        val manga = manga ?: return
+        viewModelScope.launchIO {
+            val mode = if (translationPreferences.enableInpaint.get()) {
+                TranslationMode.OverlayAndInpaint
+            } else {
+                TranslationMode.Overlay
+            }
+            translationRepository.enqueueJob(
+                mangaId = manga.id,
+                chapterId = chapterId,
+                pageIndex = pageIndex,
+                scope = scope,
+                pipeline = translationPreferences.pipeline.get(),
+                mode = mode,
+                model = translationPreferences.geminiModel.get(),
+                targetLanguage = translationPreferences.targetLanguage.get(),
+                sourceLanguage = translationPreferences.sourceLanguage.get().ifBlank { null },
+                overwrite = !translationPreferences.skipExistingOverlays.get(),
+            )
+            TranslationJob.start(application)
+        }
     }
 
     private fun downloadNextChapters() {
@@ -973,6 +1105,10 @@ class ReaderViewModel @JvmOverloads constructor(
         data object ReadingModeSelect : Dialog
         data object OrientationModeSelect : Dialog
         data class PageActions(val page: ReaderPage) : Dialog
+        data class TranslationOverlayEditor(
+            val page: ReaderPage,
+            val savedPage: SavedTranslationPage?,
+        ) : Dialog
     }
 
     sealed interface Event {
@@ -984,5 +1120,7 @@ class ReaderViewModel @JvmOverloads constructor(
         data class SavedImage(val result: SaveImageResult) : Event
         data class ShareImage(val uri: Uri, val page: ReaderPage) : Event
         data class CopyImage(val uri: Uri) : Event
+        data object TranslationOverlaySaved : Event
+        data class TranslationOverlaySaveFailed(val message: String) : Event
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -1,8 +1,15 @@
 package eu.kanade.tachiyomi.ui.reader.viewer
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
 import android.graphics.PointF
 import android.graphics.RectF
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.text.TextUtils
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
@@ -40,6 +47,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonSubsamplingImageView
 import eu.kanade.tachiyomi.util.system.animatorDurationScale
 import eu.kanade.tachiyomi.util.view.isVisibleOnScreen
 import okio.BufferedSource
+import tachiyomi.data.Translation_boxes
 import tachiyomi.core.common.util.system.ImageUtil
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -65,6 +73,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     }
 
     private var pageView: View? = null
+    private var translationOverlayView: TranslationOverlayView? = null
 
     private var config: Config? = null
 
@@ -91,6 +100,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
 
     @CallSuper
     open fun onScaleChanged(newScale: Float) {
+        translationOverlayView?.invalidate()
         onScaleChanged?.invoke(newScale)
     }
 
@@ -174,7 +184,31 @@ open class ReaderPageImageView @JvmOverloads constructor(
             is SubsamplingScaleImageView -> it.recycle()
             is AppCompatImageView -> it.dispose()
         }
+        clearTranslationOverlay()
         it.isVisible = false
+    }
+
+    fun setTranslationOverlay(boxes: List<Translation_boxes>) {
+        if (boxes.isEmpty()) {
+            clearTranslationOverlay()
+            return
+        }
+        val overlay = translationOverlayView ?: TranslationOverlayView(context) { pageView }.also {
+            translationOverlayView = it
+            addView(it, MATCH_PARENT, MATCH_PARENT)
+        }
+        overlay.boxes = boxes
+        overlay.isVisible = true
+        overlay.bringToFront()
+        overlay.invalidate()
+    }
+
+    fun clearTranslationOverlay() {
+        translationOverlayView?.let {
+            it.boxes = emptyList()
+            it.isVisible = false
+            it.invalidate()
+        }
     }
 
     /**
@@ -251,13 +285,14 @@ open class ReaderPageImageView @JvmOverloads constructor(
                     }
 
                     override fun onCenterChanged(newCenter: PointF?, origin: Int) {
-                        // Not used
+                        translationOverlayView?.invalidate()
                     }
                 },
             )
             setOnClickListener { this@ReaderPageImageView.onViewClicked() }
         }
         addView(pageView, MATCH_PARENT, MATCH_PARENT)
+        translationOverlayView?.bringToFront()
     }
 
     private fun SubsamplingScaleImageView.setupZoom(config: Config?) {
@@ -375,6 +410,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
             }
         }
         addView(pageView, MATCH_PARENT, MATCH_PARENT)
+        translationOverlayView?.bringToFront()
     }
 
     private fun setAnimatedImage(
@@ -427,6 +463,118 @@ open class ReaderPageImageView @JvmOverloads constructor(
         LEFT,
         CENTER,
         RIGHT,
+    }
+
+    private class TranslationOverlayView(
+        context: Context,
+        private val pageViewProvider: () -> View?,
+    ) : View(context) {
+
+        var boxes: List<Translation_boxes> = emptyList()
+
+        private val density = resources.displayMetrics.density
+        private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.argb(210, 255, 255, 255)
+            style = Paint.Style.FILL
+        }
+        private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.argb(230, 32, 32, 32)
+            style = Paint.Style.STROKE
+            strokeWidth = 1.5f * density
+        }
+        private val baseTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            if (boxes.isEmpty()) return
+
+            boxes.forEach { box ->
+                val rect = box.toViewRect() ?: return@forEach
+                if (rect.width() <= 1f || rect.height() <= 1f) return@forEach
+
+                val radius = 4f * density
+                canvas.drawRoundRect(rect, radius, radius, fillPaint)
+                canvas.drawRoundRect(rect, radius, radius, strokePaint)
+                drawText(canvas, rect, box.translated_text)
+            }
+        }
+
+        private fun drawText(canvas: Canvas, rect: RectF, text: String) {
+            if (text.isBlank()) return
+            val padding = (4f * density).coerceAtMost(rect.width() / 5f).coerceAtMost(rect.height() / 5f)
+            val width = (rect.width() - padding * 2).toInt().coerceAtLeast(1)
+            val textPaint = TextPaint(baseTextPaint).apply {
+                textSize = (rect.height() / 3.2f).coerceIn(10f * density, 20f * density)
+            }
+            val maxLines = ((rect.height() - padding * 2) / textPaint.fontSpacing).toInt().coerceAtLeast(1)
+            val layout = StaticLayout.Builder
+                .obtain(text, 0, text.length, textPaint, width)
+                .setAlignment(Layout.Alignment.ALIGN_CENTER)
+                .setEllipsize(TextUtils.TruncateAt.END)
+                .setMaxLines(maxLines)
+                .build()
+
+            canvas.save()
+            canvas.clipRect(rect)
+            canvas.translate(rect.left + padding, rect.top + padding)
+            layout.draw(canvas)
+            canvas.restore()
+        }
+
+        private fun Translation_boxes.toViewRect(): RectF? {
+            val view = pageViewProvider() ?: return null
+            return when (view) {
+                is SubsamplingScaleImageView -> toSubsamplingRect(view)
+                is AppCompatImageView -> toImageViewRect(view)
+                else -> null
+            }
+        }
+
+        private fun Translation_boxes.toSubsamplingRect(view: SubsamplingScaleImageView): RectF? {
+            if (!view.isReady || view.sWidth <= 0 || view.sHeight <= 0) return null
+            val start = view.sourceToViewCoord((x * view.sWidth).toFloat(), (y * view.sHeight).toFloat())
+                ?: return null
+            val end = view.sourceToViewCoord(
+                ((x + width) * view.sWidth).toFloat(),
+                ((y + height) * view.sHeight).toFloat(),
+            ) ?: return null
+            return RectF(
+                view.left + start.x,
+                view.top + start.y,
+                view.left + end.x,
+                view.top + end.y,
+            ).normalize()
+        }
+
+        private fun Translation_boxes.toImageViewRect(view: AppCompatImageView): RectF? {
+            val drawable = view.drawable ?: return null
+            val imageRect = RectF(
+                0f,
+                0f,
+                drawable.intrinsicWidth.toFloat(),
+                drawable.intrinsicHeight.toFloat(),
+            )
+            view.imageMatrix.mapRect(imageRect)
+            imageRect.offset(view.left.toFloat(), view.top.toFloat())
+            return RectF(
+                imageRect.left + (x * imageRect.width()).toFloat(),
+                imageRect.top + (y * imageRect.height()).toFloat(),
+                imageRect.left + ((x + width) * imageRect.width()).toFloat(),
+                imageRect.top + ((y + height) * imageRect.height()).toFloat(),
+            ).normalize()
+        }
+
+        private fun RectF.normalize(): RectF {
+            if (left <= right && top <= bottom) return this
+            return RectF(
+                minOf(left, right),
+                minOf(top, bottom),
+                maxOf(left, right),
+                maxOf(top, bottom),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import androidx.core.view.isVisible
 import eu.kanade.presentation.util.formattedMessage
 import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
@@ -27,7 +28,11 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.Locale
 
 /**
  * View of the ViewPager that contains a page of a chapter.
@@ -56,6 +61,8 @@ class PagerPageHolder(
     private var errorLayout: ReaderErrorBinding? = null
 
     private val scope = MainScope()
+    private val translationRepository: TranslationRepository = Injekt.get()
+    private val translationPreferences: TranslationPreferences = Injekt.get()
 
     /**
      * Job for loading the page and processing changes to the page's status.
@@ -120,6 +127,7 @@ class PagerPageHolder(
     private fun setQueued() {
         initProgressIndicator()
         progressIndicator?.show()
+        clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -129,6 +137,7 @@ class PagerPageHolder(
     private fun setLoading() {
         initProgressIndicator()
         progressIndicator?.show()
+        clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -138,6 +147,7 @@ class PagerPageHolder(
     private fun setDownloading() {
         initProgressIndicator()
         progressIndicator?.show()
+        clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -177,6 +187,7 @@ class PagerPageHolder(
                 }
                 removeErrorLayout()
             }
+            setTranslationOverlay()
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e)
             withUIContext {
@@ -247,7 +258,28 @@ class PagerPageHolder(
      */
     private fun setError(error: Throwable?) {
         progressIndicator?.hide()
+        clearTranslationOverlay()
         showErrorLayout(error)
+    }
+
+    private suspend fun setTranslationOverlay() {
+        if (!translationPreferences.autoShowOverlay.get()) {
+            withUIContext { clearTranslationOverlay() }
+            return
+        }
+        val chapterId = page.chapter.chapter.id ?: return
+        val targetLanguage = translationPreferences.targetLanguage.get()
+            .ifBlank { Locale.getDefault().displayLanguage.ifBlank { "English" } }
+        val savedPage = withIOContext {
+            translationRepository.getSavedPage(
+                chapterId = chapterId,
+                pageIndex = page.index.toLong(),
+                targetLanguage = targetLanguage,
+            )
+        }
+        withUIContext {
+            setTranslationOverlay(savedPage?.boxes.orEmpty())
+        }
     }
 
     override fun onImageLoaded() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -12,6 +12,7 @@ import androidx.core.view.updateMargins
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import eu.kanade.presentation.util.formattedMessage
 import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
@@ -32,7 +33,11 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.translation.service.TranslationPreferences
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.Locale
 
 /**
  * Holder of the webtoon reader for a single page of a chapter.
@@ -74,6 +79,8 @@ class WebtoonPageHolder(
     private var page: ReaderPage? = null
 
     private val scope = MainScope()
+    private val translationRepository: TranslationRepository = Injekt.get()
+    private val translationPreferences: TranslationPreferences = Injekt.get()
 
     /**
      * Job for loading the page.
@@ -119,6 +126,7 @@ class WebtoonPageHolder(
 
         removeErrorLayout()
         frame.recycle()
+        frame.clearTranslationOverlay()
         progressIndicator.setProgress(0)
         progressContainer.isVisible = true
     }
@@ -160,6 +168,7 @@ class WebtoonPageHolder(
     private fun setQueued() {
         progressContainer.isVisible = true
         progressIndicator.show()
+        frame.clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -169,6 +178,7 @@ class WebtoonPageHolder(
     private fun setLoading() {
         progressContainer.isVisible = true
         progressIndicator.show()
+        frame.clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -178,6 +188,7 @@ class WebtoonPageHolder(
     private fun setDownloading() {
         progressContainer.isVisible = true
         progressIndicator.show()
+        frame.clearTranslationOverlay()
         removeErrorLayout()
     }
 
@@ -207,6 +218,7 @@ class WebtoonPageHolder(
                 )
                 removeErrorLayout()
             }
+            setTranslationOverlay(page)
         } catch (e: Throwable) {
             logcat(LogPriority.ERROR, e)
             withUIContext {
@@ -246,7 +258,31 @@ class WebtoonPageHolder(
      */
     private fun setError(error: Throwable?) {
         progressContainer.isVisible = false
+        frame.clearTranslationOverlay()
         initErrorLayout(error)
+    }
+
+    private suspend fun setTranslationOverlay(page: ReaderPage?) {
+        if (!translationPreferences.autoShowOverlay.get()) {
+            withUIContext { frame.clearTranslationOverlay() }
+            return
+        }
+        page ?: return
+        val chapterId = page.chapter.chapter.id ?: return
+        val targetLanguage = translationPreferences.targetLanguage.get()
+            .ifBlank { Locale.getDefault().displayLanguage.ifBlank { "English" } }
+        val savedPage = withIOContext {
+            translationRepository.getSavedPage(
+                chapterId = chapterId,
+                pageIndex = page.index.toLong(),
+                targetLanguage = targetLanguage,
+            )
+        }
+        withUIContext {
+            if (this@WebtoonPageHolder.page == page) {
+                frame.setTranslationOverlay(savedPage?.boxes.orEmpty())
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/translation/TranslationQueueScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/translation/TranslationQueueScreen.kt
@@ -1,0 +1,351 @@
+package eu.kanade.tachiyomi.ui.translation
+
+import android.content.Context
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.Pause
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cafe.adriel.voyager.core.model.ScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.translation.TranslationJob
+import eu.kanade.tachiyomi.data.translation.TranslationJobStatus
+import eu.kanade.tachiyomi.data.translation.TranslationLogLevel
+import eu.kanade.tachiyomi.data.translation.TranslationRepository
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.data.Translation_jobs
+import tachiyomi.data.Translation_logs
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.Pill
+import tachiyomi.presentation.core.components.ScrollbarLazyColumn
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+object TranslationQueueScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val context = LocalContext.current
+        val navigator = LocalNavigator.currentOrThrow
+        val screenModel = rememberScreenModel { TranslationQueueScreenModel() }
+        val jobs by screenModel.jobs.collectAsState()
+        val logs by screenModel.logs.collectAsState()
+        val isRunning by TranslationJob.isRunningFlow(context).collectAsState(false)
+        val activeJobCount by remember(jobs) {
+            derivedStateOf { jobs.count { it.status !in FINISHED_STATUSES } }
+        }
+
+        val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+        Scaffold(
+            topBar = {
+                AppBar(
+                    titleContent = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = stringResource(MR.strings.label_translation_queue),
+                                maxLines = 1,
+                                modifier = Modifier.weight(1f, false),
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            if (activeJobCount > 0) {
+                                Pill(
+                                    text = "$activeJobCount",
+                                    modifier = Modifier.padding(start = 4.dp),
+                                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.08f),
+                                    fontSize = 14.sp,
+                                )
+                            }
+                        }
+                    },
+                    navigateUp = navigator::pop,
+                    actions = {
+                        if (jobs.isNotEmpty() || logs.isNotEmpty()) {
+                            AppBarActions(
+                                persistentListOf(
+                                    AppBar.OverflowAction(
+                                        title = stringResource(MR.strings.action_cancel_all),
+                                        onClick = { screenModel.cancelAll(context) },
+                                    ),
+                                    AppBar.OverflowAction(
+                                        title = stringResource(MR.strings.pref_translation_clear_logs),
+                                        onClick = { screenModel.clearLogs() },
+                                    ),
+                                    AppBar.OverflowAction(
+                                        title = stringResource(MR.strings.pref_translation_clear_finished),
+                                        onClick = { screenModel.clearFinished() },
+                                    ),
+                                ),
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+            floatingActionButton = {
+                SmallExtendedFloatingActionButton(
+                    text = {
+                        Text(
+                            text = stringResource(
+                                if (isRunning) MR.strings.action_pause else MR.strings.action_resume,
+                            ),
+                        )
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = if (isRunning) Icons.Outlined.Pause else Icons.Filled.PlayArrow,
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        if (isRunning) {
+                            TranslationJob.stop(context)
+                        } else {
+                            TranslationJob.start(context)
+                        }
+                    },
+                    modifier = Modifier.animateFloatingActionButton(
+                        visible = activeJobCount > 0,
+                        alignment = Alignment.BottomEnd,
+                    ),
+                )
+            },
+        ) { contentPadding ->
+            if (jobs.isEmpty() && logs.isEmpty()) {
+                EmptyScreen(
+                    stringRes = MR.strings.information_no_translation_jobs,
+                    modifier = Modifier.padding(contentPadding),
+                )
+                return@Scaffold
+            }
+
+            ScrollbarLazyColumn(contentPadding = contentPadding) {
+                items(
+                    count = jobs.size,
+                    key = { index -> jobs[index]._id },
+                ) { index ->
+                    TranslationJobItem(
+                        job = jobs[index],
+                        onRetry = { screenModel.retry(context, jobs[index]) },
+                        onCancel = { screenModel.cancel(jobs[index]) },
+                    )
+                    HorizontalDivider()
+                }
+                if (logs.isNotEmpty()) {
+                    item {
+                        ListItem(
+                            headlineContent = { Text(text = stringResource(MR.strings.pref_translation_logs)) },
+                        )
+                    }
+                }
+                items(
+                    count = logs.take(LOG_LIMIT).size,
+                    key = { index -> "log-${logs[index]._id}" },
+                ) { index ->
+                    TranslationLogItem(log = logs[index])
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    private const val LOG_LIMIT = 100
+}
+
+private val FINISHED_STATUSES = setOf(
+    TranslationJobStatus.Completed.value,
+    TranslationJobStatus.Failed.value,
+    TranslationJobStatus.Cancelled.value,
+)
+
+@Composable
+private fun TranslationJobItem(
+    job: Translation_jobs,
+    onRetry: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val isFinished = job.status in FINISHED_STATUSES
+    ListItem(
+        headlineContent = {
+            Text(
+                text = buildString {
+                    append("#")
+                    append(job._id)
+                    append(" ")
+                    append(job.scope)
+                    job.chapter_id?.let {
+                        append(" · ch ")
+                        append(it)
+                    }
+                    job.page_index?.let {
+                        append(" · p ")
+                        append(it + 1)
+                    }
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        supportingContent = {
+            Text(
+                text = buildString {
+                    append(job.status)
+                    append(" · ")
+                    append(job.progress_current)
+                    append("/")
+                    append(job.progress_total)
+                    append(" · ")
+                    append(job.target_language.ifBlank { "app language" })
+                    append(" · ")
+                    append(job.model)
+                    job.error_message?.let {
+                        append("\n")
+                        append(it)
+                    }
+                },
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        trailingContent = {
+            if (isFinished) {
+                Text(
+                    text = stringResource(MR.strings.action_retry),
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp),
+                )
+            } else {
+                Text(
+                    text = stringResource(MR.strings.action_cancel),
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp),
+                )
+            }
+        },
+        modifier = Modifier.then(
+            if (isFinished) {
+                Modifier.clickable(onClick = onRetry)
+            } else {
+                Modifier.clickable(onClick = onCancel)
+            },
+        ),
+    )
+}
+
+@Composable
+private fun TranslationLogItem(log: Translation_logs) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = "${log.level} · ${log.tag} · ${log.message}",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = when (log.level) {
+                    TranslationLogLevel.Error.value -> MaterialTheme.colorScheme.error
+                    TranslationLogLevel.Warning.value -> MaterialTheme.colorScheme.tertiary
+                    else -> MaterialTheme.colorScheme.onSurface
+                },
+            )
+        },
+        supportingContent = log.details?.let {
+            {
+                Text(
+                    text = it,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+    )
+}
+
+private class TranslationQueueScreenModel(
+    private val repository: TranslationRepository = Injekt.get(),
+) : ScreenModel {
+
+    val jobs = repository.observeJobs()
+        .stateIn(screenModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val logs = repository.observeLogs()
+        .stateIn(screenModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun retry(context: Context, job: Translation_jobs) {
+        screenModelScope.launchIO {
+            repository.updateJobStatus(
+                job = job,
+                status = TranslationJobStatus.Queued,
+                errorMessage = null,
+            )
+            TranslationJob.start(context)
+        }
+    }
+
+    fun cancel(job: Translation_jobs) {
+        screenModelScope.launchIO {
+            repository.updateJobStatus(
+                job = job,
+                status = TranslationJobStatus.Cancelled,
+                errorMessage = null,
+            )
+        }
+    }
+
+    fun cancelAll(context: Context) {
+        screenModelScope.launchIO {
+            jobs.value
+                .filter { it.status !in FINISHED_STATUSES }
+                .forEach {
+                    repository.updateJobStatus(
+                        job = it,
+                        status = TranslationJobStatus.Cancelled,
+                        errorMessage = null,
+                    )
+                }
+            TranslationJob.stop(context)
+        }
+    }
+
+    fun clearFinished() {
+        screenModelScope.launchIO {
+            repository.clearFinishedJobs()
+        }
+    }
+
+    fun clearLogs() {
+        screenModelScope.launchIO {
+            repository.clearLogs()
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/translation/TranslationCoreTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/translation/TranslationCoreTest.kt
@@ -1,0 +1,82 @@
+package eu.kanade.tachiyomi.data.translation
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+
+class TranslationCoreTest {
+
+    @Test
+    fun `model list keeps only generateContent models`() {
+        val models = listOf(
+            GeminiModel(
+                name = "models/gemini-3-flash-preview",
+                baseModelId = "gemini-3-flash-preview",
+                displayName = "Gemini 3 Flash Preview",
+                supportedGenerationMethods = listOf("generateContent"),
+            ),
+            GeminiModel(
+                name = "models/text-embedding",
+                baseModelId = "text-embedding",
+                displayName = "Embedding",
+                supportedGenerationMethods = listOf("embedContent"),
+            ),
+        )
+
+        models.generateContentModels().map { it.id } shouldContainExactly listOf("gemini-3-flash-preview")
+    }
+
+    @Test
+    fun `redaction removes api key and image payloads but keeps text`() {
+        val raw = """
+            {
+              "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent?key=secret-key",
+              "inlineData": {"mimeType": "image/png", "data": "base64-image"},
+              "text": "translated line"
+            }
+        """.trimIndent()
+
+        TranslationLogRedactor.redact(raw) shouldBe """
+            {
+              "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini:generateContent?key=<redacted>",
+              "inlineData": {"mimeType": "image/png", "data": "<redacted-image>"},
+              "text": "translated line"
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `generation config applies raw json override last`() {
+        val prefs = TranslationGenerationConfig(
+            temperature = 0.2f,
+            topP = 0.9f,
+            topK = 40,
+            maxOutputTokens = 4096,
+            thinkingBudget = 1024,
+            rawJsonOverride = """{"temperature":0.7,"candidateCount":1}""",
+        )
+
+        val obj = prefs.toGeminiJson(Json).jsonObject
+
+        obj["temperature"].toString() shouldBe "0.7"
+        obj["topP"].toString() shouldBe "0.9"
+        obj["topK"].toString() shouldBe "40"
+        obj["maxOutputTokens"].toString() shouldBe "4096"
+        obj["candidateCount"].toString() shouldBe "1"
+        obj["thinkingConfig"]!!.jsonObject shouldContain ("thinkingBudget" to Json.parseToJsonElement("1024"))
+    }
+
+    @Test
+    fun `enqueue plan skips existing overlays unless overwrite requested`() {
+        val pages = listOf(
+            TranslationPageCandidate(chapterId = 1, pageIndex = 0, hasOverlay = true),
+            TranslationPageCandidate(chapterId = 1, pageIndex = 1, hasOverlay = false),
+        )
+
+        TranslationEnqueuePlanner.pagesToQueue(pages, overwrite = false) shouldContainExactly listOf(pages[1])
+        TranslationEnqueuePlanner.pagesToQueue(pages, overwrite = true) shouldContainExactly pages
+    }
+}

--- a/data/src/main/sqldelight/tachiyomi/data/translations.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/translations.sq
@@ -1,0 +1,313 @@
+import kotlin.Boolean;
+
+CREATE TABLE translation_jobs(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    chapter_id INTEGER,
+    page_index INTEGER,
+    scope TEXT NOT NULL,
+    pipeline TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    model TEXT NOT NULL,
+    target_language TEXT NOT NULL,
+    source_language TEXT,
+    overwrite INTEGER AS Boolean NOT NULL,
+    status TEXT NOT NULL,
+    progress_current INTEGER NOT NULL,
+    progress_total INTEGER NOT NULL,
+    attempts INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    error_message TEXT,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX translation_jobs_status_index ON translation_jobs(status, created_at);
+CREATE INDEX translation_jobs_manga_index ON translation_jobs(manga_id);
+CREATE INDEX translation_jobs_chapter_index ON translation_jobs(chapter_id);
+
+CREATE TABLE translation_pages(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    chapter_id INTEGER NOT NULL,
+    page_index INTEGER NOT NULL,
+    source_image_key TEXT NOT NULL,
+    model TEXT NOT NULL,
+    target_language TEXT NOT NULL,
+    source_language TEXT,
+    pipeline TEXT NOT NULL,
+    image_width INTEGER,
+    image_height INTEGER,
+    inpaint_image_uri TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE,
+    UNIQUE(chapter_id, page_index, target_language)
+);
+
+CREATE INDEX translation_pages_manga_index ON translation_pages(manga_id);
+CREATE INDEX translation_pages_chapter_index ON translation_pages(chapter_id, page_index);
+
+CREATE TABLE translation_boxes(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL,
+    x REAL NOT NULL,
+    y REAL NOT NULL,
+    width REAL NOT NULL,
+    height REAL NOT NULL,
+    original_text TEXT NOT NULL,
+    translated_text TEXT NOT NULL,
+    text_type TEXT NOT NULL,
+    confidence REAL,
+    style_json TEXT,
+    sort_order INTEGER NOT NULL,
+    FOREIGN KEY(page_id) REFERENCES translation_pages (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX translation_boxes_page_index ON translation_boxes(page_id, sort_order);
+
+CREATE TABLE translation_logs(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER,
+    page_id INTEGER,
+    created_at INTEGER NOT NULL,
+    level TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    message TEXT NOT NULL,
+    details TEXT,
+    FOREIGN KEY(job_id) REFERENCES translation_jobs (_id) ON DELETE SET NULL,
+    FOREIGN KEY(page_id) REFERENCES translation_pages (_id) ON DELETE SET NULL
+);
+
+CREATE INDEX translation_logs_created_index ON translation_logs(created_at);
+CREATE INDEX translation_logs_job_index ON translation_logs(job_id);
+
+insertJob:
+INSERT INTO translation_jobs(
+    manga_id,
+    chapter_id,
+    page_index,
+    scope,
+    pipeline,
+    mode,
+    model,
+    target_language,
+    source_language,
+    overwrite,
+    status,
+    progress_current,
+    progress_total,
+    attempts,
+    created_at,
+    updated_at,
+    error_message
+)
+VALUES (
+    :mangaId,
+    :chapterId,
+    :pageIndex,
+    :scope,
+    :pipeline,
+    :mode,
+    :model,
+    :targetLanguage,
+    :sourceLanguage,
+    :overwrite,
+    :status,
+    0,
+    :progressTotal,
+    0,
+    :createdAt,
+    :createdAt,
+    NULL
+);
+
+lastInsertedJobId:
+SELECT last_insert_rowid();
+
+getJob:
+SELECT *
+FROM translation_jobs
+WHERE _id = :id;
+
+getJobs:
+SELECT *
+FROM translation_jobs
+ORDER BY created_at DESC;
+
+getPendingJobs:
+SELECT *
+FROM translation_jobs
+WHERE status IN ('queued', 'retrying')
+ORDER BY created_at ASC;
+
+updateJobStatus:
+UPDATE translation_jobs
+SET status = :status,
+    attempts = :attempts,
+    error_message = :errorMessage,
+    updated_at = :updatedAt
+WHERE _id = :id;
+
+updateJobProgress:
+UPDATE translation_jobs
+SET progress_current = :progressCurrent,
+    progress_total = :progressTotal,
+    updated_at = :updatedAt
+WHERE _id = :id;
+
+deleteJob:
+DELETE FROM translation_jobs
+WHERE _id = :id;
+
+clearFinishedJobs:
+DELETE FROM translation_jobs
+WHERE status IN ('completed', 'failed', 'cancelled');
+
+upsertPage:
+INSERT INTO translation_pages(
+    manga_id,
+    chapter_id,
+    page_index,
+    source_image_key,
+    model,
+    target_language,
+    source_language,
+    pipeline,
+    image_width,
+    image_height,
+    inpaint_image_uri,
+    created_at,
+    updated_at
+)
+VALUES (
+    :mangaId,
+    :chapterId,
+    :pageIndex,
+    :sourceImageKey,
+    :model,
+    :targetLanguage,
+    :sourceLanguage,
+    :pipeline,
+    :imageWidth,
+    :imageHeight,
+    :inpaintImageUri,
+    :createdAt,
+    :createdAt
+)
+ON CONFLICT(chapter_id, page_index, target_language)
+DO UPDATE SET
+    source_image_key = excluded.source_image_key,
+    model = excluded.model,
+    source_language = excluded.source_language,
+    pipeline = excluded.pipeline,
+    image_width = excluded.image_width,
+    image_height = excluded.image_height,
+    inpaint_image_uri = excluded.inpaint_image_uri,
+    updated_at = excluded.updated_at;
+
+getPage:
+SELECT *
+FROM translation_pages
+WHERE chapter_id = :chapterId
+AND page_index = :pageIndex
+AND target_language = :targetLanguage;
+
+getPagesByChapter:
+SELECT *
+FROM translation_pages
+WHERE chapter_id = :chapterId
+AND target_language = :targetLanguage
+ORDER BY page_index ASC;
+
+clearPages:
+DELETE FROM translation_pages;
+
+deleteBoxesForPage:
+DELETE FROM translation_boxes
+WHERE page_id = :pageId;
+
+insertBox:
+INSERT INTO translation_boxes(
+    page_id,
+    x,
+    y,
+    width,
+    height,
+    original_text,
+    translated_text,
+    text_type,
+    confidence,
+    style_json,
+    sort_order
+)
+VALUES (
+    :pageId,
+    :x,
+    :y,
+    :width,
+    :height,
+    :originalText,
+    :translatedText,
+    :textType,
+    :confidence,
+    :styleJson,
+    :sortOrder
+);
+
+getBoxesForPage:
+SELECT *
+FROM translation_boxes
+WHERE page_id = :pageId
+ORDER BY sort_order ASC;
+
+touchPage:
+UPDATE translation_pages
+SET updated_at = :updatedAt
+WHERE _id = :id;
+
+updateBox:
+UPDATE translation_boxes
+SET x = :x,
+    y = :y,
+    width = :width,
+    height = :height,
+    translated_text = :translatedText,
+    text_type = :textType,
+    style_json = :styleJson,
+    sort_order = :sortOrder
+WHERE _id = :id;
+
+deleteBox:
+DELETE FROM translation_boxes
+WHERE _id = :id;
+
+insertLog:
+INSERT INTO translation_logs(
+    job_id,
+    page_id,
+    created_at,
+    level,
+    tag,
+    message,
+    details
+)
+VALUES (
+    :jobId,
+    :pageId,
+    :createdAt,
+    :level,
+    :tag,
+    :message,
+    :details
+);
+
+getLogs:
+SELECT *
+FROM translation_logs
+ORDER BY created_at DESC;
+
+clearLogs:
+DELETE FROM translation_logs;

--- a/data/src/main/sqldelight/tachiyomi/migrations/11.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/11.sqm
@@ -1,0 +1,83 @@
+CREATE TABLE translation_jobs(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    chapter_id INTEGER,
+    page_index INTEGER,
+    scope TEXT NOT NULL,
+    pipeline TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    model TEXT NOT NULL,
+    target_language TEXT NOT NULL,
+    source_language TEXT,
+    overwrite INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    progress_current INTEGER NOT NULL,
+    progress_total INTEGER NOT NULL,
+    attempts INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    error_message TEXT,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX translation_jobs_status_index ON translation_jobs(status, created_at);
+CREATE INDEX translation_jobs_manga_index ON translation_jobs(manga_id);
+CREATE INDEX translation_jobs_chapter_index ON translation_jobs(chapter_id);
+
+CREATE TABLE translation_pages(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    manga_id INTEGER NOT NULL,
+    chapter_id INTEGER NOT NULL,
+    page_index INTEGER NOT NULL,
+    source_image_key TEXT NOT NULL,
+    model TEXT NOT NULL,
+    target_language TEXT NOT NULL,
+    source_language TEXT,
+    pipeline TEXT NOT NULL,
+    image_width INTEGER,
+    image_height INTEGER,
+    inpaint_image_uri TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE,
+    UNIQUE(chapter_id, page_index, target_language)
+);
+
+CREATE INDEX translation_pages_manga_index ON translation_pages(manga_id);
+CREATE INDEX translation_pages_chapter_index ON translation_pages(chapter_id, page_index);
+
+CREATE TABLE translation_boxes(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    page_id INTEGER NOT NULL,
+    x REAL NOT NULL,
+    y REAL NOT NULL,
+    width REAL NOT NULL,
+    height REAL NOT NULL,
+    original_text TEXT NOT NULL,
+    translated_text TEXT NOT NULL,
+    text_type TEXT NOT NULL,
+    confidence REAL,
+    style_json TEXT,
+    sort_order INTEGER NOT NULL,
+    FOREIGN KEY(page_id) REFERENCES translation_pages (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX translation_boxes_page_index ON translation_boxes(page_id, sort_order);
+
+CREATE TABLE translation_logs(
+    _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER,
+    page_id INTEGER,
+    created_at INTEGER NOT NULL,
+    level TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    message TEXT NOT NULL,
+    details TEXT,
+    FOREIGN KEY(job_id) REFERENCES translation_jobs (_id) ON DELETE SET NULL,
+    FOREIGN KEY(page_id) REFERENCES translation_pages (_id) ON DELETE SET NULL
+);
+
+CREATE INDEX translation_logs_created_index ON translation_logs(created_at);
+CREATE INDEX translation_logs_job_index ON translation_logs(job_id);

--- a/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/translation/service/TranslationPreferences.kt
@@ -1,0 +1,43 @@
+package tachiyomi.domain.translation.service
+
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class TranslationPreferences(
+    preferenceStore: PreferenceStore,
+) {
+    val geminiApiKey: Preference<String> = preferenceStore.getString(
+        Preference.privateKey("translation_gemini_api_key"),
+        "",
+    )
+
+    val geminiModel: Preference<String> = preferenceStore.getString(
+        "translation_gemini_model",
+        "gemini-3-flash-preview",
+    )
+
+    val geminiInpaintModel: Preference<String> = preferenceStore.getString(
+        "translation_gemini_inpaint_model",
+        "gemini-2.5-flash-image",
+    )
+
+    val targetLanguage: Preference<String> = preferenceStore.getString("translation_target_language", "")
+    val sourceLanguage: Preference<String> = preferenceStore.getString("translation_source_language", "")
+    val pipeline: Preference<String> = preferenceStore.getString("translation_pipeline", "gemini_vision")
+    val ocrScript: Preference<String> = preferenceStore.getString("translation_ocr_script", "auto")
+
+    val concurrency: Preference<Int> = preferenceStore.getInt("translation_concurrency", 1)
+    val skipExistingOverlays: Preference<Boolean> = preferenceStore.getBoolean("translation_skip_existing_overlays", true)
+    val autoShowOverlay: Preference<Boolean> = preferenceStore.getBoolean("translation_auto_show_overlay", true)
+    val rawDebugLogging: Preference<Boolean> = preferenceStore.getBoolean("translation_raw_debug_logging", false)
+    val enableInpaint: Preference<Boolean> = preferenceStore.getBoolean("translation_enable_inpaint", false)
+
+    val temperature: Preference<Float> = preferenceStore.getFloat("translation_temperature", 0.2f)
+    val topP: Preference<Float> = preferenceStore.getFloat("translation_top_p", 0.9f)
+    val topK: Preference<Int> = preferenceStore.getInt("translation_top_k", 40)
+    val maxOutputTokens: Preference<Int> = preferenceStore.getInt("translation_max_output_tokens", 4096)
+    val thinkingBudget: Preference<Int> = preferenceStore.getInt("translation_thinking_budget", 1024)
+    val rawJsonOverride: Preference<String> = preferenceStore.getString("translation_raw_json_override", "")
+
+    val globalInstructions: Preference<String> = preferenceStore.getString("translation_global_instructions", "")
+}

--- a/domain/src/test/java/tachiyomi/domain/translation/service/TranslationPreferencesTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/translation/service/TranslationPreferencesTest.kt
@@ -1,0 +1,17 @@
+package tachiyomi.domain.translation.service
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.InMemoryPreferenceStore
+import tachiyomi.core.common.preference.Preference
+
+class TranslationPreferencesTest {
+
+    @Test
+    fun `default model and private api key are configured`() {
+        val preferences = TranslationPreferences(InMemoryPreferenceStore())
+
+        preferences.geminiModel.get() shouldBe "gemini-3-flash-preview"
+        Preference.isPrivate(preferences.geminiApiKey.key()) shouldBe true
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ logcat = "0.4"
 markdown = "0.39.2"
 material = "1.12.0"
 materialKolor = "5.0.0-alpha07"
+mlkit-text = "16.0.1"
 mockk = "1.14.9"
 moko-resources = "0.26.3"
 okhttp = "5.3.2"
@@ -152,6 +153,11 @@ markdown-coil = { module = "com.mikepenz:multiplatform-markdown-renderer-coil3",
 markdown-core = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdown" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit-text" }
+mlkit-text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "mlkit-text" }
+mlkit-text-recognition-devanagari = { module = "com.google.mlkit:text-recognition-devanagari", version.ref = "mlkit-text" }
+mlkit-text-recognition-japanese = { module = "com.google.mlkit:text-recognition-japanese", version.ref = "mlkit-text" }
+mlkit-text-recognition-korean = { module = "com.google.mlkit:text-recognition-korean", version.ref = "mlkit-text" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
 natural-comparator = { module = "com.github.gpanther:java-nat-sort", version = "natural-comparator-1.1" }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -24,6 +24,7 @@
     <string name="label_more">More</string>
     <string name="label_settings">Settings</string>
     <string name="label_download_queue">Download queue</string>
+    <string name="label_translation_queue">Translation queue</string>
     <string name="label_library">Library</string>
     <string name="label_recent_updates">Updates</string>
     <string name="label_upcoming">Upcoming</string>
@@ -108,6 +109,10 @@
     <string name="action_remove_everything">Remove everything</string>
     <string name="action_start">Start</string>
     <string name="action_resume">Resume</string>
+    <string name="action_translate">Translate</string>
+    <string name="action_translate_all">Translate all</string>
+    <string name="action_translation_overlay">Translation overlay</string>
+    <string name="action_edit_translation">Edit translation</string>
     <string name="action_open_in_browser">Open in browser</string>
     <string name="action_show_manga">Show entry</string>
     <string name="action_copy_to_clipboard">Copy to clipboard</string>
@@ -209,6 +214,7 @@
     <string name="pref_category_library">Library</string>
     <string name="pref_category_reader">Reader</string>
     <string name="pref_category_downloads">Downloads</string>
+    <string name="pref_category_translation">Translation</string>
     <string name="pref_category_tracking">Tracking</string>
     <string name="pref_category_advanced">Advanced</string>
     <string name="pref_category_about">About</string>
@@ -217,6 +223,7 @@
     <string name="pref_library_summary">Categories, global update, chapter swipe</string>
     <string name="pref_reader_summary">Reading mode, display, navigation</string>
     <string name="pref_downloads_summary">Automatic download, download ahead</string>
+    <string name="pref_translation_summary">Gemini API, overlays, queue</string>
     <string name="pref_tracking_summary">One-way progress sync, enhanced sync</string>
     <string name="pref_browse_summary">Sources, extensions, global search</string>
     <string name="pref_backup_summary">Manual &amp; automatic backups, storage space</string>
@@ -527,6 +534,56 @@
     <string name="pref_download_concurrent_sources">Concurrent source downloads</string>
     <string name="pref_download_concurrent_pages">Concurrent page downloads</string>
     <string name="pref_download_concurrent_pages_summary">Pages downloaded simultaneously per source</string>
+
+      <!-- Translation section -->
+    <string name="pref_translation">Translation</string>
+    <string name="pref_translation_privacy_notice">Images and OCR text are sent to Gemini when translation jobs run. API keys, image bytes, and base64 images are never written to logs.</string>
+    <string name="pref_translation_gemini_api_key">Gemini API key</string>
+    <string name="pref_translation_gemini_api_key_summary">Stored privately on this device</string>
+    <string name="pref_translation_model">Translation model</string>
+    <string name="pref_translation_inpaint_model">Inpaint image model</string>
+    <string name="pref_translation_source_language">Source language</string>
+    <string name="pref_translation_target_language">Target language</string>
+    <string name="pref_translation_pipeline">Translation pipeline</string>
+    <string name="pref_translation_pipeline_gemini_vision">Gemini vision</string>
+    <string name="pref_translation_pipeline_local_ocr_gemini">Local OCR + Gemini</string>
+    <string name="pref_translation_ocr_script">OCR script</string>
+    <string name="pref_translation_skip_existing">Skip existing overlays</string>
+    <string name="pref_translation_show_overlays">Show saved overlays in reader</string>
+    <string name="pref_translation_raw_debug_logs">Raw debug logs</string>
+    <string name="pref_translation_raw_debug_logs_summary">Stores redacted prompts and Gemini JSON for troubleshooting</string>
+    <string name="pref_translation_enable_inpaint">Enable experimental inpaint</string>
+    <string name="pref_translation_generation">Generation</string>
+    <string name="pref_translation_temperature">Temperature</string>
+    <string name="pref_translation_top_p">Top P</string>
+    <string name="pref_translation_top_k">Top K</string>
+    <string name="pref_translation_max_tokens">Max output tokens</string>
+    <string name="pref_translation_thinking_budget">Thinking budget</string>
+    <string name="pref_translation_raw_json_override">Raw JSON override</string>
+    <string name="pref_translation_global_instructions">Global instructions</string>
+    <string name="pref_translation_queue">Queue</string>
+    <string name="pref_translation_concurrency">Concurrent translation jobs</string>
+    <string name="pref_translation_logs">Logs</string>
+    <string name="pref_translation_clear_logs">Clear translation logs</string>
+    <string name="pref_translation_clear_finished">Clear finished jobs</string>
+    <string name="pref_translation_clear_storage">Clear saved translations</string>
+    <string name="translation_model_refresh">Refresh Gemini models</string>
+    <string name="translation_model_refresh_summary">Fetch available generateContent models using the API key</string>
+    <string name="translation_model_test">Test API key and model</string>
+    <string name="translation_model_ready">Gemini key and model are reachable</string>
+    <string name="translation_model_unavailable">Default model unavailable; choose another generateContent model.</string>
+    <string name="translation_overlay_editor">Translation overlay editor</string>
+    <string name="translation_overlay_saved">Translation overlay saved</string>
+    <string name="translation_overlay_save_failed">Failed to save translation overlay: %s</string>
+    <string name="translation_overlay_no_boxes">No text boxes yet</string>
+    <string name="translation_overlay_box_label">Box %d</string>
+    <string name="translation_overlay_original_text">Original text</string>
+    <string name="translation_overlay_translated_text">Translated text</string>
+    <string name="translation_overlay_text_type">Text type</string>
+    <string name="translation_overlay_x">X</string>
+    <string name="translation_overlay_y">Y</string>
+    <string name="translation_overlay_width">Width</string>
+    <string name="translation_overlay_height">Height</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>
@@ -952,6 +1009,7 @@
 
     <!-- Information Text -->
     <string name="information_no_downloads">No downloads</string>
+    <string name="information_no_translation_jobs">No translation jobs</string>
     <string name="information_no_recent">No recent updates</string>
     <string name="information_no_recent_manga">Nothing read recently</string>
     <string name="information_empty_library">Your library is empty</string>


### PR DESCRIPTION
## Summary
- Add Gemini-backed manga image translation with dedicated settings, model refresh/test, queueing, logs, and saved overlays.
- Add SQLDelight translation storage, WorkManager processing, local OCR option, and experimental inpaint plumbing.
- Add translate actions in manga/library/reader plus reader overlay rendering and editing.

## Test Plan
- [x] ./gradlew :i18n:generateMRcommonMain :i18n:generateMRandroidMain :data:generateDebugDatabaseInterface
- [x] ./gradlew :app:compileDebugKotlin
- [x] ./gradlew :app:testDebugUnitTest --tests eu.kanade.tachiyomi.data.translation.TranslationCoreTest
- [x] ./gradlew :domain:testDebugUnitTest --tests tachiyomi.domain.translation.service.TranslationPreferencesTest

## Not Tested
- Emulator UI smoke
- Live Gemini API model refresh/translation
