### PR TITLE
perf: offload backup, restore, and update tasks to IO thread pool

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
 import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.backup.service.BackupPreferences
 import tachiyomi.domain.storage.service.StorageManager
@@ -50,18 +51,20 @@ class BackupCreateJob(private val context: Context, workerParams: WorkerParamete
         val options = inputData.getBooleanArray(OPTIONS_KEY)?.let { BackupOptions.fromBooleanArray(it) }
             ?: BackupOptions()
 
-        return try {
-            val location = BackupCreator(context, isAutoBackup).backup(uri, options)
-            if (!isAutoBackup) {
-                notifier.showBackupComplete(UniFile.fromUri(context, location.toUri())!!)
+        return withIOContext {
+            try {
+                val location = BackupCreator(context, isAutoBackup).backup(uri, options)
+                if (!isAutoBackup) {
+                    notifier.showBackupComplete(UniFile.fromUri(context, location.toUri())!!)
+                }
+                Result.success()
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR, e)
+                if (!isAutoBackup) notifier.showBackupError(e.message)
+                Result.failure()
+            } finally {
+                context.cancelNotification(Notifications.ID_BACKUP_PROGRESS)
             }
-            Result.success()
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            if (!isAutoBackup) notifier.showBackupError(e.message)
-            Result.failure()
-        } finally {
-            context.cancelNotification(Notifications.ID_BACKUP_PROGRESS)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -23,6 +23,7 @@ import okio.buffer
 import okio.gzip
 import okio.sink
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.backup.service.BackupPreferences
 import tachiyomi.domain.manga.interactor.GetFavorites
@@ -53,7 +54,7 @@ class BackupCreator(
     private val sourcesBackupCreator: SourcesBackupCreator = SourcesBackupCreator(),
 ) {
 
-    suspend fun backup(uri: Uri, options: BackupOptions): String {
+    suspend fun backup(uri: Uri, options: BackupOptions): String = withIOContext {
         var file: UniFile? = null
         try {
             file = if (isAutoBackup) {
@@ -111,7 +112,7 @@ class BackupCreator(
                 backupPreferences.lastAutoBackupTimestamp.set(Instant.now().toEpochMilli())
             }
 
-            return fileUri.toString()
+            fileUri.toString()
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             file?.delete()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestoreJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestoreJob.kt
@@ -20,6 +20,7 @@ import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 
@@ -40,20 +41,22 @@ class BackupRestoreJob(private val context: Context, workerParams: WorkerParamet
 
         setForegroundSafely()
 
-        return try {
-            BackupRestorer(context, notifier, isSync).restore(uri, options)
-            Result.success()
-        } catch (e: Exception) {
-            if (e is CancellationException) {
-                notifier.showRestoreError(context.stringResource(MR.strings.restoring_backup_canceled))
+        return withIOContext {
+            try {
+                BackupRestorer(context, notifier, isSync).restore(uri, options)
                 Result.success()
-            } else {
-                logcat(LogPriority.ERROR, e)
-                notifier.showRestoreError(e.message)
-                Result.failure()
+            } catch (e: Exception) {
+                if (e is CancellationException) {
+                    notifier.showRestoreError(context.stringResource(MR.strings.restoring_backup_canceled))
+                    Result.success()
+                } else {
+                    logcat(LogPriority.ERROR, e)
+                    notifier.showRestoreError(e.message)
+                    Result.failure()
+                }
+            } finally {
+                context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
             }
-        } finally {
-            context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.i18n.MR
 import java.io.File
 import java.text.SimpleDateFormat
@@ -45,7 +46,7 @@ class BackupRestorer(
      */
     private var sourceMapping: Map<Long, String> = emptyMap()
 
-    suspend fun restore(uri: Uri, options: RestoreOptions) {
+    suspend fun restore(uri: Uri, options: RestoreOptions) = withIOContext {
         val startTime = System.currentTimeMillis()
 
         restoreFromFile(uri, options)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -116,9 +116,9 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         libraryPreferences.lastUpdatedTimestamp.set(Instant.now().toEpochMilli())
 
         val categoryId = inputData.getLong(KEY_CATEGORY, -1L)
-        addMangaToQueue(categoryId)
 
         return withIOContext {
+            addMangaToQueue(categoryId)
             try {
                 updateChapterList()
                 Result.success()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/MetadataUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/MetadataUpdateJob.kt
@@ -57,9 +57,8 @@ class MetadataUpdateJob(private val context: Context, workerParams: WorkerParame
     override suspend fun doWork(): Result {
         setForegroundSafely()
 
-        addMangaToQueue()
-
         return withIOContext {
+            addMangaToQueue()
             try {
                 updateMetadata()
                 Result.success()

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionApi.kt
@@ -69,43 +69,45 @@ internal class ExtensionApi {
         context: Context,
         fromAvailableExtensionList: Boolean = false,
     ): List<Extension.Installed>? {
-        // Limit checks to once a day at most
-        if (!fromAvailableExtensionList &&
-            Instant.now().toEpochMilli() < lastExtCheck.get() + 1.days.inWholeMilliseconds
-        ) {
-            return null
-        }
-
-        // Update extension repo details
-        updateExtensionRepo.awaitAll()
-
-        val extensions = if (fromAvailableExtensionList) {
-            extensionManager.availableExtensionsFlow.value
-        } else {
-            findExtensions().also { lastExtCheck.set(Instant.now().toEpochMilli()) }
-        }
-
-        val installedExtensions = ExtensionLoader.loadExtensions(context)
-            .filterIsInstance<LoadResult.Success>()
-            .map { it.extension }
-
-        val extensionsWithUpdate = mutableListOf<Extension.Installed>()
-        for (installedExt in installedExtensions) {
-            val pkgName = installedExt.pkgName
-            val availableExt = extensions.find { it.pkgName == pkgName } ?: continue
-            val hasUpdatedVer = availableExt.versionCode > installedExt.versionCode
-            val hasUpdatedLib = availableExt.libVersion > installedExt.libVersion
-            val hasUpdate = hasUpdatedVer || hasUpdatedLib
-            if (hasUpdate) {
-                extensionsWithUpdate.add(installedExt)
+        return withIOContext {
+            // Limit checks to once a day at most
+            if (!fromAvailableExtensionList &&
+                Instant.now().toEpochMilli() < lastExtCheck.get() + 1.days.inWholeMilliseconds
+            ) {
+                return@withIOContext null
             }
-        }
 
-        if (extensionsWithUpdate.isNotEmpty()) {
-            ExtensionUpdateNotifier(context).promptUpdates(extensionsWithUpdate.map { it.name })
-        }
+            // Update extension repo details
+            updateExtensionRepo.awaitAll()
 
-        return extensionsWithUpdate
+            val extensions = if (fromAvailableExtensionList) {
+                extensionManager.availableExtensionsFlow.value
+            } else {
+                findExtensions().also { lastExtCheck.set(Instant.now().toEpochMilli()) }
+            }
+
+            val installedExtensions = ExtensionLoader.loadExtensions(context)
+                .filterIsInstance<LoadResult.Success>()
+                .map { it.extension }
+
+            val extensionsWithUpdate = mutableListOf<Extension.Installed>()
+            for (installedExt in installedExtensions) {
+                val pkgName = installedExt.pkgName
+                val availableExt = extensions.find { it.pkgName == pkgName } ?: continue
+                val hasUpdatedVer = availableExt.versionCode > installedExt.versionCode
+                val hasUpdatedLib = availableExt.libVersion > installedExt.libVersion
+                val hasUpdate = hasUpdatedVer || hasUpdatedLib
+                if (hasUpdate) {
+                    extensionsWithUpdate.add(installedExt)
+                }
+            }
+
+            if (extensionsWithUpdate.isNotEmpty()) {
+                ExtensionUpdateNotifier(context).promptUpdates(extensionsWithUpdate.map { it.name })
+            }
+
+            extensionsWithUpdate
+        }
     }
 
     private fun List<ExtensionJsonObject>.toExtensions(repoUrl: String): List<Extension.Available> {

--- a/domain/src/main/java/mihon/domain/extensionrepo/interactor/UpdateExtensionRepo.kt
+++ b/domain/src/main/java/mihon/domain/extensionrepo/interactor/UpdateExtensionRepo.kt
@@ -6,20 +6,23 @@ import kotlinx.coroutines.coroutineScope
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import mihon.domain.extensionrepo.repository.ExtensionRepoRepository
 import mihon.domain.extensionrepo.service.ExtensionRepoService
+import tachiyomi.core.common.util.lang.withIOContext
 
 class UpdateExtensionRepo(
     private val repository: ExtensionRepoRepository,
     private val service: ExtensionRepoService,
 ) {
 
-    suspend fun awaitAll() = coroutineScope {
-        repository.getAll()
-            .map { async { await(it) } }
-            .awaitAll()
+    suspend fun awaitAll() = withIOContext {
+        coroutineScope {
+            repository.getAll()
+                .map { async { await(it) } }
+                .awaitAll()
+        }
     }
 
-    suspend fun await(repo: ExtensionRepo) {
-        val newRepo = service.fetchRepoDetails(repo.baseUrl) ?: return
+    suspend fun await(repo: ExtensionRepo) = withIOContext {
+        val newRepo = service.fetchRepoDetails(repo.baseUrl) ?: return@withIOContext
         if (
             repo.signingKeyFingerprint.startsWith("NOFINGERPRINT") ||
             repo.signingKeyFingerprint == newRepo.signingKeyFingerprint


### PR DESCRIPTION
This PR refactors several long-running background tasks to ensure they are executed on the IO thread pool using `withIOContext`. This improves the application's responsiveness by preventing potential blocking of the main thread during heavy IO or database operations.

- **Backup & Restore**: Refactored `BackupCreateJob`, `BackupRestoreJob`, `BackupCreator`, and `BackupRestorer` to execute within the IO context.
- **Library Updates**: Optimized `LibraryUpdateJob` and `MetadataUpdateJob` by moving the manga queueing logic (`addMangaToQueue`) into the IO thread block.
- **Extensions**: Updated `ExtensionApi.checkForUpdates` and `UpdateExtensionRepo` to perform network and database operations on the IO dispatcher.

These optimizations properly offload intensive disk and network tasks, maintaining a smooth user experience even during large library updates or backup restorations.

This doesn't improve backup restoration time and I kept the chunking changes in #3267 separate.
