### PR TITLE
Pinned Categories

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -49,12 +49,14 @@ import tachiyomi.data.updates.UpdatesRepositoryImpl
 import tachiyomi.domain.category.interactor.CreateCategoryWithName
 import tachiyomi.domain.category.interactor.DeleteCategory
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.PinCategory
 import tachiyomi.domain.category.interactor.RenameCategory
 import tachiyomi.domain.category.interactor.ReorderCategory
 import tachiyomi.domain.category.interactor.ResetCategoryFlags
 import tachiyomi.domain.category.interactor.SetDisplayMode
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.interactor.SetSortModeForCategory
+import tachiyomi.domain.category.interactor.UnPinCategory
 import tachiyomi.domain.category.interactor.UpdateCategory
 import tachiyomi.domain.category.repository.CategoryRepository
 import tachiyomi.domain.chapter.interactor.GetBookmarkedChaptersByMangaId
@@ -111,6 +113,8 @@ class DomainModule : InjektModule {
         addFactory { SetDisplayMode(get()) }
         addFactory { SetSortModeForCategory(get(), get()) }
         addFactory { CreateCategoryWithName(get(), get()) }
+        addFactory { PinCategory(get()) }
+        addFactory { UnPinCategory(get()) }
         addFactory { RenameCategory(get()) }
         addFactory { ReorderCategory(get()) }
         addFactory { UpdateCategory(get()) }

--- a/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
@@ -39,6 +39,7 @@ fun CategoryScreen(
     onClickCreate: () -> Unit,
     onClickRename: (Category) -> Unit,
     onClickDelete: (Category) -> Unit,
+    onClickPin: (Category) -> Unit,
     onChangeOrder: (Category, Int) -> Unit,
     navigateUp: () -> Unit,
 ) {
@@ -59,7 +60,7 @@ fun CategoryScreen(
             )
         },
     ) { paddingValues ->
-        if (state.isEmpty && state.isSuperCatsEmpty) {
+        if (state.isEmpty && state.isPinnedEmpty) {
             EmptyScreen(
                 stringRes = MR.strings.information_empty_category,
                 modifier = Modifier.padding(paddingValues),
@@ -74,21 +75,22 @@ fun CategoryScreen(
         ) {
             Text(
                 modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                text = stringResource(MR.strings.categories_super),
+                text = stringResource(MR.strings.categories_pinned),
                 style = MaterialTheme.typography.titleMedium,
             )
-            if (state.isSuperCatsEmpty) {
+            if (state.isPinnedEmpty) {
                 Text(
-                    text = stringResource(MR.strings.information_empty_super_category),
+                    text = stringResource(MR.strings.information_empty_pinned_category),
                     modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
                 )
             } else {
                 CategoryContent(
-                    categories = state.superCategories,
+                    categories = state.pinnedCategories,
                     lazyListState = lazyListStateSuper,
                     paddingValues = paddingValues,
                     onClickRename = onClickRename,
                     onClickDelete = onClickDelete,
+                    onClickPin = onClickPin,
                     onChangeOrder = onChangeOrder,
                 )
             }
@@ -115,6 +117,7 @@ fun CategoryScreen(
                     paddingValues = paddingValues,
                     onClickRename = onClickRename,
                     onClickDelete = onClickDelete,
+                    onClickPin = onClickPin,
                     onChangeOrder = onChangeOrder,
                 )
             }
@@ -130,6 +133,7 @@ private fun CategoryContent(
     paddingValues: PaddingValues,
     onClickRename: (Category) -> Unit,
     onClickDelete: (Category) -> Unit,
+    onClickPin: (Category) -> Unit,
     onChangeOrder: (Category, Int) -> Unit,
 ) {
     val categoriesState = remember { categories.toMutableStateList() }
@@ -163,6 +167,7 @@ private fun CategoryContent(
                     category = category,
                     onRename = { onClickRename(category) },
                     onDelete = { onClickDelete(category) },
+                    onPin = { onClickPin(category) },
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
@@ -43,7 +43,7 @@ fun CategoryScreen(
     onChangeOrder: (Category, Int) -> Unit,
     navigateUp: () -> Unit,
 ) {
-    val lazyListStateSuper = rememberLazyListState()
+    val lazyListStatePinned = rememberLazyListState()
     val lazyListState = rememberLazyListState()
     Scaffold(
         topBar = { scrollBehavior ->
@@ -56,11 +56,11 @@ fun CategoryScreen(
         floatingActionButton = {
             CategoryFloatingActionButton(
                 onCreate = onClickCreate,
-                expanded = lazyListState.shouldExpandFAB() || lazyListStateSuper.shouldExpandFAB(),
+                expanded = lazyListState.shouldExpandFAB() || lazyListStatePinned.shouldExpandFAB(),
             )
         },
     ) { paddingValues ->
-        if (state.isEmpty && state.isPinnedEmpty) {
+        if (state.isEmpty) {
             EmptyScreen(
                 stringRes = MR.strings.information_empty_category,
                 modifier = Modifier.padding(paddingValues),
@@ -68,68 +68,83 @@ fun CategoryScreen(
             return@Scaffold
         }
 
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize(),
-        ) {
-            Text(
-                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                text = stringResource(MR.strings.categories_pinned),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            if (state.isPinnedEmpty) {
-                Text(
-                    text = stringResource(MR.strings.information_empty_pinned_category),
-                    modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                )
-            } else {
-                CategoryContent(
-                    categories = state.pinnedCategories,
-                    lazyListState = lazyListStateSuper,
-                    paddingValues = paddingValues,
-                    onClickRename = onClickRename,
-                    onClickDelete = onClickDelete,
-                    onClickPin = onClickPin,
-                    onChangeOrder = onChangeOrder,
-                )
-            }
-
-            HorizontalDivider(
-                modifier = Modifier.padding(MaterialTheme.padding.medium),
-            )
-
-            Text(
-                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                text = stringResource(MR.strings.categories),
-                style = MaterialTheme.typography.titleSmall,
-            )
-            if (state.isEmpty) {
-                Text(
-                    text = stringResource(MR.strings.information_empty_category),
-                    modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                )
-            } else {
-                CategoryContent(
-                    modifier = Modifier.weight(1f, fill = true),
-                    categories = state.categories,
-                    lazyListState = lazyListState,
-                    paddingValues = paddingValues,
-                    onClickRename = onClickRename,
-                    onClickDelete = onClickDelete,
-                    onClickPin = onClickPin,
-                    onChangeOrder = onChangeOrder,
-                )
-            }
-        }
+        CategoryContent(
+            categories = state.categories,
+            pinnedCategories = state.pinnedCategories,
+            lazyListState = lazyListState,
+            lazyListStatePinned = lazyListStatePinned,
+            paddingValues = paddingValues,
+            onClickRename = onClickRename,
+            onClickDelete = onClickDelete,
+            onClickPin = onClickPin,
+            onChangeOrder = onChangeOrder,
+        )
     }
 }
 
 @Composable
 private fun CategoryContent(
-    modifier: Modifier = Modifier,
+    pinnedCategories: List<Category>,
     categories: List<Category>,
     lazyListState: LazyListState,
+    lazyListStatePinned: LazyListState,
+    paddingValues: PaddingValues,
+    onClickRename: (Category) -> Unit,
+    onClickDelete: (Category) -> Unit,
+    onClickPin: (Category) -> Unit,
+    onChangeOrder: (Category, Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .padding(paddingValues)
+            .fillMaxSize(),
+    ) {
+        if (pinnedCategories.isEmpty()) {
+            Text(
+                text = stringResource(MR.strings.information_empty_pinned_category),
+                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+            )
+        } else {
+            CategoryList(
+                categories = pinnedCategories,
+                lazyListState = lazyListStatePinned,
+                paddingValues = paddingValues,
+                onClickRename = onClickRename,
+                onClickDelete = onClickDelete,
+                onClickPin = onClickPin,
+                onChangeOrder = onChangeOrder,
+            )
+
+            HorizontalDivider(
+                modifier = Modifier.padding(MaterialTheme.padding.medium),
+            )
+        }
+
+        if (categories.isEmpty()) {
+            Text(
+                text = stringResource(MR.strings.information_empty_category),
+                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+            )
+        } else {
+            CategoryList(
+                modifier = Modifier.weight(1f, fill = true),
+                categories = categories,
+                lazyListState = lazyListState,
+                paddingValues = paddingValues,
+                onClickRename = onClickRename,
+                onClickDelete = onClickDelete,
+                onClickPin = onClickPin,
+                onChangeOrder = onChangeOrder,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryList(
+    categories: List<Category>,
+    lazyListState: LazyListState,
+    modifier: Modifier = Modifier,
     paddingValues: PaddingValues,
     onClickRename: (Category) -> Unit,
     onClickDelete: (Category) -> Unit,

--- a/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
@@ -1,6 +1,7 @@
 package eu.kanade.presentation.category
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,7 +9,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -28,6 +31,7 @@ import tachiyomi.presentation.core.components.material.topSmallPaddingValues
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.util.plus
+import tachiyomi.presentation.core.util.shouldExpandFAB
 
 @Composable
 fun CategoryScreen(
@@ -38,6 +42,7 @@ fun CategoryScreen(
     onChangeOrder: (Category, Int) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val lazyListStateSuper = rememberLazyListState()
     val lazyListState = rememberLazyListState()
     Scaffold(
         topBar = { scrollBehavior ->
@@ -49,12 +54,12 @@ fun CategoryScreen(
         },
         floatingActionButton = {
             CategoryFloatingActionButton(
-                lazyListState = lazyListState,
                 onCreate = onClickCreate,
+                expanded = lazyListState.shouldExpandFAB() || lazyListStateSuper.shouldExpandFAB(),
             )
         },
     ) { paddingValues ->
-        if (state.isEmpty) {
+        if (state.isEmpty && state.isSuperCatsEmpty) {
             EmptyScreen(
                 stringRes = MR.strings.information_empty_category,
                 modifier = Modifier.padding(paddingValues),
@@ -62,19 +67,64 @@ fun CategoryScreen(
             return@Scaffold
         }
 
-        CategoryContent(
-            categories = state.categories,
-            lazyListState = lazyListState,
-            paddingValues = paddingValues,
-            onClickRename = onClickRename,
-            onClickDelete = onClickDelete,
-            onChangeOrder = onChangeOrder,
-        )
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize(),
+        ) {
+            Text(
+                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+                text = stringResource(MR.strings.categories_super),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            if (state.isSuperCatsEmpty) {
+                Text(
+                    text = stringResource(MR.strings.information_empty_super_category),
+                    modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+                )
+            } else {
+                CategoryContent(
+                    categories = state.superCategories,
+                    lazyListState = lazyListStateSuper,
+                    paddingValues = paddingValues,
+                    onClickRename = onClickRename,
+                    onClickDelete = onClickDelete,
+                    onChangeOrder = onChangeOrder,
+                )
+            }
+
+            HorizontalDivider(
+                modifier = Modifier.padding(MaterialTheme.padding.medium),
+            )
+
+            Text(
+                modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+                text = stringResource(MR.strings.categories),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            if (state.isEmpty) {
+                Text(
+                    text = stringResource(MR.strings.information_empty_category),
+                    modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+                )
+            } else {
+                CategoryContent(
+                    modifier = Modifier.weight(1f, fill = true),
+                    categories = state.categories,
+                    lazyListState = lazyListState,
+                    paddingValues = paddingValues,
+                    onClickRename = onClickRename,
+                    onClickDelete = onClickDelete,
+                    onChangeOrder = onChangeOrder,
+                )
+            }
+        }
     }
 }
 
 @Composable
 private fun CategoryContent(
+    modifier: Modifier = Modifier,
     categories: List<Category>,
     lazyListState: LazyListState,
     paddingValues: PaddingValues,
@@ -97,10 +147,9 @@ private fun CategoryContent(
     }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier,
         state = lazyListState,
-        contentPadding = paddingValues +
-            topSmallPaddingValues +
+        contentPadding = topSmallPaddingValues +
             PaddingValues(horizontal = MaterialTheme.padding.medium),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
     ) {

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -266,7 +267,10 @@ fun ChangeCategoryDialog(
             Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                selection.forEach { checkbox ->
+                Text(
+                    text = stringResource(MR.strings.categories_super),
+                )
+                selection.filter { it.value.isSuper }.forEach { checkbox ->
                     val onChange: (CheckboxState<Category>) -> Unit = {
                         val index = selection.indexOf(it)
                         if (index != -1) {
@@ -275,34 +279,54 @@ fun ChangeCategoryDialog(
                             selection = mutableList.toList().toImmutableList()
                         }
                     }
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onChange(checkbox) },
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        when (checkbox) {
-                            is CheckboxState.TriState -> {
-                                TriStateCheckbox(
-                                    state = checkbox.asToggleableState(),
-                                    onClick = { onChange(checkbox) },
-                                )
-                            }
-                            is CheckboxState.State -> {
-                                Checkbox(
-                                    checked = checkbox.isChecked,
-                                    onCheckedChange = { onChange(checkbox) },
-                                )
-                            }
+                    CategoryItem(checkbox, onChange)
+                }
+                HorizontalDivider()
+                selection.filterNot { it.value.isSuper }.forEach { checkbox ->
+                    val onChange: (CheckboxState<Category>) -> Unit = {
+                        val index = selection.indexOf(it)
+                        if (index != -1) {
+                            val mutableList = selection.toMutableList()
+                            mutableList[index] = it.next()
+                            selection = mutableList.toList().toImmutableList()
                         }
-
-                        Text(
-                            text = checkbox.value.visualName,
-                            modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-                        )
                     }
+                    CategoryItem(checkbox, onChange)
                 }
             }
         },
     )
+}
+
+@Composable
+fun CategoryItem(
+    checkbox: CheckboxState<Category>,
+    onChange: (CheckboxState<Category>) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onChange(checkbox) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        when (checkbox) {
+            is CheckboxState.TriState -> {
+                TriStateCheckbox(
+                    state = checkbox.asToggleableState(),
+                    onClick = { onChange(checkbox) },
+                )
+            }
+            is CheckboxState.State -> {
+                Checkbox(
+                    checked = checkbox.isChecked,
+                    onCheckedChange = { onChange(checkbox) },
+                )
+            }
+        }
+
+        Text(
+            text = checkbox.value.visualName,
+            modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+        )
+    }
 }

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.delay
 import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.domain.category.model.Category
 import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.time.Duration.Companion.seconds
@@ -40,10 +41,11 @@ import kotlin.time.Duration.Companion.seconds
 @Composable
 fun CategoryCreateDialog(
     onDismissRequest: () -> Unit,
-    onCreate: (String) -> Unit,
+    onCreate: (String, Boolean) -> Unit,
     categories: ImmutableList<String>,
 ) {
     var name by remember { mutableStateOf("") }
+    var isSuper by remember { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
     val nameAlreadyExists = remember(name) { categories.contains(name) }
@@ -54,7 +56,7 @@ fun CategoryCreateDialog(
             TextButton(
                 enabled = name.isNotEmpty() && !nameAlreadyExists,
                 onClick = {
-                    onCreate(name)
+                    onCreate(name, isSuper)
                     onDismissRequest()
                 },
             ) {
@@ -70,25 +72,28 @@ fun CategoryCreateDialog(
             Text(text = stringResource(MR.strings.action_add_category))
         },
         text = {
-            OutlinedTextField(
-                modifier = Modifier
-                    .focusRequester(focusRequester),
-                value = name,
-                onValueChange = { name = it },
-                label = {
-                    Text(text = stringResource(MR.strings.name))
-                },
-                supportingText = {
-                    val msgRes = if (name.isNotEmpty() && nameAlreadyExists) {
-                        MR.strings.error_category_exists
-                    } else {
-                        MR.strings.information_required_plain
-                    }
-                    Text(text = stringResource(msgRes))
-                },
-                isError = name.isNotEmpty() && nameAlreadyExists,
-                singleLine = true,
-            )
+            Column {
+                OutlinedTextField(
+                    modifier = Modifier
+                        .focusRequester(focusRequester),
+                    value = name,
+                    onValueChange = { name = it },
+                    label = {
+                        Text(text = stringResource(MR.strings.name))
+                    },
+                    supportingText = {
+                        val msgRes = if (name.isNotEmpty() && nameAlreadyExists) {
+                            MR.strings.error_category_exists
+                        } else {
+                            MR.strings.information_required_plain
+                        }
+                        Text(text = stringResource(msgRes))
+                    },
+                    isError = name.isNotEmpty() && nameAlreadyExists,
+                    singleLine = true,
+                )
+                CheckboxItem(stringResource(MR.strings.is_category_super), isSuper, onClick = { isSuper = !isSuper })
+            }
         },
     )
 

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
@@ -42,11 +42,10 @@ import kotlin.time.Duration.Companion.seconds
 @Composable
 fun CategoryCreateDialog(
     onDismissRequest: () -> Unit,
-    onCreate: (String, Boolean) -> Unit,
+    onCreate: (String) -> Unit,
     categories: ImmutableList<String>,
 ) {
     var name by remember { mutableStateOf("") }
-    var isSuper by remember { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
     val nameAlreadyExists = remember(name) { categories.contains(name) }
@@ -57,7 +56,7 @@ fun CategoryCreateDialog(
             TextButton(
                 enabled = name.isNotEmpty() && !nameAlreadyExists,
                 onClick = {
-                    onCreate(name, isSuper)
+                    onCreate(name)
                     onDismissRequest()
                 },
             ) {
@@ -73,28 +72,25 @@ fun CategoryCreateDialog(
             Text(text = stringResource(MR.strings.action_add_category))
         },
         text = {
-            Column {
-                OutlinedTextField(
-                    modifier = Modifier
-                        .focusRequester(focusRequester),
-                    value = name,
-                    onValueChange = { name = it },
-                    label = {
-                        Text(text = stringResource(MR.strings.name))
-                    },
-                    supportingText = {
-                        val msgRes = if (name.isNotEmpty() && nameAlreadyExists) {
-                            MR.strings.error_category_exists
-                        } else {
-                            MR.strings.information_required_plain
-                        }
-                        Text(text = stringResource(msgRes))
-                    },
-                    isError = name.isNotEmpty() && nameAlreadyExists,
-                    singleLine = true,
-                )
-                CheckboxItem(stringResource(MR.strings.is_category_super), isSuper, onClick = { isSuper = !isSuper })
-            }
+            OutlinedTextField(
+                modifier = Modifier
+                    .focusRequester(focusRequester),
+                value = name,
+                onValueChange = { name = it },
+                label = {
+                    Text(text = stringResource(MR.strings.name))
+                },
+                supportingText = {
+                    val msgRes = if (name.isNotEmpty() && nameAlreadyExists) {
+                        MR.strings.error_category_exists
+                    } else {
+                        MR.strings.information_required_plain
+                    }
+                    Text(text = stringResource(msgRes))
+                },
+                isError = name.isNotEmpty() && nameAlreadyExists,
+                singleLine = true,
+            )
         },
     )
 
@@ -268,9 +264,9 @@ fun ChangeCategoryDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
                 Text(
-                    text = stringResource(MR.strings.categories_super),
+                    text = stringResource(MR.strings.categories_pinned),
                 )
-                selection.filter { it.value.isSuper }.forEach { checkbox ->
+                selection.filter { it.value.isPinned }.forEach { checkbox ->
                     val onChange: (CheckboxState<Category>) -> Unit = {
                         val index = selection.indexOf(it)
                         if (index != -1) {
@@ -282,7 +278,7 @@ fun ChangeCategoryDialog(
                     CategoryItem(checkbox, onChange)
                 }
                 HorizontalDivider()
-                selection.filterNot { it.value.isSuper }.forEach { checkbox ->
+                selection.filterNot { it.value.isPinned }.forEach { checkbox ->
                     val onChange: (CheckboxState<Category>) -> Unit = {
                         val index = selection.indexOf(it)
                         if (index != -1) {

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryDialogs.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -34,7 +37,6 @@ import kotlinx.coroutines.delay
 import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.domain.category.model.Category
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.time.Duration.Companion.seconds
@@ -263,21 +265,34 @@ fun ChangeCategoryDialog(
             Column(
                 modifier = Modifier.verticalScroll(rememberScrollState()),
             ) {
-                Text(
-                    text = stringResource(MR.strings.categories_pinned),
-                )
-                selection.filter { it.value.isPinned }.forEach { checkbox ->
-                    val onChange: (CheckboxState<Category>) -> Unit = {
-                        val index = selection.indexOf(it)
-                        if (index != -1) {
-                            val mutableList = selection.toMutableList()
-                            mutableList[index] = it.next()
-                            selection = mutableList.toList().toImmutableList()
-                        }
+                if (selection.any { it.value.isPinned }) {
+                    Row(
+                        modifier = Modifier.padding(start = MaterialTheme.padding.small),
+                    )
+                    {
+                        Icon(
+                            imageVector = Icons.Filled.PushPin,
+                            contentDescription = stringResource(MR.strings.pinned_category),
+                        )
+                        Text(
+                            text = stringResource(MR.strings.categories_pinned),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(start = MaterialTheme.padding.medium),
+                        )
                     }
-                    CategoryItem(checkbox, onChange)
+                    selection.filter { it.value.isPinned }.forEach { checkbox ->
+                        val onChange: (CheckboxState<Category>) -> Unit = {
+                            val index = selection.indexOf(it)
+                            if (index != -1) {
+                                val mutableList = selection.toMutableList()
+                                mutableList[index] = it.next()
+                                selection = mutableList.toList().toImmutableList()
+                            }
+                        }
+                        CategoryItem(checkbox, onChange)
+                    }
+                    HorizontalDivider()
                 }
-                HorizontalDivider()
                 selection.filterNot { it.value.isPinned }.forEach { checkbox ->
                     val onChange: (CheckboxState<Category>) -> Unit = {
                         val index = selection.indexOf(it)
@@ -322,7 +337,7 @@ fun CategoryItem(
 
         Text(
             text = checkbox.value.visualName,
-            modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+            modifier = Modifier.padding(start = MaterialTheme.padding.medium),
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryFloatingActionButton.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryFloatingActionButton.kt
@@ -14,7 +14,7 @@ import tachiyomi.presentation.core.util.shouldExpandFAB
 
 @Composable
 fun CategoryFloatingActionButton(
-    lazyListState: LazyListState,
+    expanded: Boolean,
     onCreate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -22,7 +22,7 @@ fun CategoryFloatingActionButton(
         text = { Text(text = stringResource(MR.strings.action_add)) },
         icon = { Icon(imageVector = Icons.Outlined.Add, contentDescription = null) },
         onClick = onCreate,
-        expanded = lazyListState.shouldExpandFAB(),
+        expanded = expanded,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DragHandle
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -27,6 +29,7 @@ fun ReorderableCollectionItemScope.CategoryListItem(
     category: Category,
     onRename: () -> Unit,
     onDelete: () -> Unit,
+    onPin: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ElevatedCard(modifier = modifier) {
@@ -52,6 +55,16 @@ fun ReorderableCollectionItemScope.CategoryListItem(
                 text = category.name,
                 modifier = Modifier.weight(1f),
             )
+            IconButton(onClick = onPin) {
+                Icon(
+                    imageVector = if (category.isPinned) {
+                        Icons.Filled.PushPin
+                    } else {
+                        Icons.Outlined.PushPin
+                    },
+                    contentDescription = stringResource(MR.strings.action_pin_category),
+                )
+            }
             IconButton(onClick = onRename) {
                 Icon(
                     imageVector = Icons.Outlined.Edit,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -53,6 +53,7 @@ fun LibraryContent(
     onRefresh: () -> Boolean,
     onGlobalSearchClicked: () -> Unit,
     getItemCountForCategory: (Category) -> Int?,
+    getItemCountForSuperCategory: (Category) -> Int?,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
     getItemsForCategory: (Category) -> List<LibraryItem>,
@@ -88,7 +89,7 @@ fun LibraryContent(
                             text = {
                                 TabText(
                                     text = category.visualName,
-                                    badgeCount = getItemCountForCategory(category),
+                                    badgeCount = getItemCountForSuperCategory(category),
                                 )
                             },
                             unselectedContentColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,7 +19,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import eu.kanade.core.preference.PreferenceMutableState
+import eu.kanade.presentation.category.visualName
 import eu.kanade.tachiyomi.ui.library.LibraryItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -23,18 +30,22 @@ import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.presentation.core.components.material.PullRefresh
+import tachiyomi.presentation.core.components.material.TabText
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun LibraryContent(
     categories: List<Category>,
+    superCategories: List<Category>,
     searchQuery: String?,
     selection: Set<Long>,
     contentPadding: PaddingValues,
     currentPage: Int,
+    currentSuperPage: Int,
     hasActiveFilters: Boolean,
     showPageTabs: Boolean,
     onChangeCurrentPage: (Int) -> Unit,
+    onChangeCurrentSuperPage: (Int) -> Unit,
     onClickManga: (Long) -> Unit,
     onContinueReadingClicked: ((LibraryManga) -> Unit)?,
     onToggleSelection: (Category, LibraryManga) -> Unit,
@@ -57,6 +68,37 @@ fun LibraryContent(
 
         val scope = rememberCoroutineScope()
         var isRefreshing by remember(pagerState.currentPage) { mutableStateOf(false) }
+
+        if (showPageTabs && superCategories.isNotEmpty() &&
+            (superCategories.size > 1 || !superCategories.first().isSystemCategory)
+        ) {
+            val currentPageIndex = currentSuperPage.coerceAtMost(superCategories.lastIndex)
+            Column(modifier = Modifier.zIndex(2f)) {
+                PrimaryScrollableTabRow(
+                    selectedTabIndex = currentSuperPage,
+                    edgePadding = 0.dp,
+                    // TODO: use default when width is fixed upstream
+                    // https://issuetracker.google.com/issues/242879624
+                    divider = {},
+                ) {
+                    superCategories.forEachIndexed { index, category ->
+                        Tab(
+                            selected = currentPageIndex == index,
+                            onClick = { onChangeCurrentSuperPage(index) },
+                            text = {
+                                TabText(
+                                    text = category.visualName,
+                                    badgeCount = getItemCountForCategory(category),
+                                )
+                            },
+                            unselectedContentColor = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+            }
+        }
 
         if (showPageTabs && categories.isNotEmpty() && (categories.size > 1 || !categories.first().isSystemCategory)) {
             LaunchedEffect(categories) {

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -36,16 +36,16 @@ import kotlin.time.Duration.Companion.seconds
 @Composable
 fun LibraryContent(
     categories: List<Category>,
-    superCategories: List<Category>,
+    pinnedCategories: List<Category>,
     searchQuery: String?,
     selection: Set<Long>,
     contentPadding: PaddingValues,
     currentPage: Int,
-    currentSuperPage: Int,
+    currentPinnedPage: Int,
     hasActiveFilters: Boolean,
     showPageTabs: Boolean,
     onChangeCurrentPage: (Int) -> Unit,
-    onChangeCurrentSuperPage: (Int) -> Unit,
+    onChangeCurrentPinnedPage: (Int) -> Unit,
     onClickManga: (Long) -> Unit,
     onContinueReadingClicked: ((LibraryManga) -> Unit)?,
     onToggleSelection: (Category, LibraryManga) -> Unit,
@@ -53,7 +53,6 @@ fun LibraryContent(
     onRefresh: () -> Boolean,
     onGlobalSearchClicked: () -> Unit,
     getItemCountForCategory: (Category) -> Int?,
-    getItemCountForSuperCategory: (Category) -> Int?,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
     getItemsForCategory: (Category) -> List<LibraryItem>,
@@ -70,26 +69,26 @@ fun LibraryContent(
         val scope = rememberCoroutineScope()
         var isRefreshing by remember(pagerState.currentPage) { mutableStateOf(false) }
 
-        if (showPageTabs && superCategories.isNotEmpty() &&
-            (superCategories.size > 1 || !superCategories.first().isSystemCategory)
+        if (showPageTabs && pinnedCategories.isNotEmpty() &&
+            (pinnedCategories.size > 1 || !pinnedCategories.first().isSystemCategory)
         ) {
-            val currentPageIndex = currentSuperPage.coerceAtMost(superCategories.lastIndex)
+            val currentPageIndex = currentPinnedPage.coerceAtMost(pinnedCategories.lastIndex)
             Column(modifier = Modifier.zIndex(2f)) {
                 PrimaryScrollableTabRow(
-                    selectedTabIndex = currentSuperPage,
+                    selectedTabIndex = currentPinnedPage,
                     edgePadding = 0.dp,
                     // TODO: use default when width is fixed upstream
                     // https://issuetracker.google.com/issues/242879624
                     divider = {},
                 ) {
-                    superCategories.forEachIndexed { index, category ->
+                    pinnedCategories.forEachIndexed { index, category ->
                         Tab(
                             selected = currentPageIndex == index,
-                            onClick = { onChangeCurrentSuperPage(index) },
+                            onClick = { onChangeCurrentPinnedPage(index) },
                             text = {
                                 TabText(
                                     text = category.visualName,
-                                    badgeCount = getItemCountForSuperCategory(category),
+                                    badgeCount = getItemCountForCategory(category),
                                 )
                             },
                             unselectedContentColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -72,12 +72,6 @@ object SettingsLibraryScreen : SearchableSettings {
         val scope = rememberCoroutineScope()
         val userCategoriesCount = allCategories.filterNot(Category::isSystemCategory).size
 
-        // For default category
-        val ids = listOf(libraryPreferences.defaultCategory.defaultValue()) +
-            allCategories.fastMap { it.id.toInt() }
-        val labels = listOf(stringResource(MR.strings.default_category_summary)) +
-            allCategories.fastMap { it.visualName }
-
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.categories),
             preferenceItems = persistentListOf(
@@ -90,10 +84,9 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     onClick = { navigator.push(CategoryScreen()) },
                 ),
-                Preference.PreferenceItem.ListPreference(
-                    preference = libraryPreferences.defaultCategory,
-                    entries = ids.zip(labels).toMap().toImmutableMap(),
-                    title = stringResource(MR.strings.default_category),
+                defaultCategoryPreferences(
+                    allCategories = allCategories,
+                    libraryPreferences = libraryPreferences,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.categorizedDisplaySettings,
@@ -108,6 +101,55 @@ object SettingsLibraryScreen : SearchableSettings {
                     },
                 ),
             ),
+        )
+    }
+
+    @Composable
+    private fun defaultCategoryPreferences(
+        allCategories: List<Category>,
+        libraryPreferences: LibraryPreferences,
+    ): Preference.PreferenceItem<out Any, out Any> {
+        val pinnedCategories = allCategories.filter { it.isPinned }
+        val unpinnedCategories = allCategories.filterNot { it.isPinned }
+
+        return when (pinnedCategories.isEmpty()) {
+            true -> {
+                defaultCategoryPreference(
+                    categories = unpinnedCategories,
+                    defaultCategoryPreference = libraryPreferences.defaultCategory,
+                    title = stringResource(MR.strings.default_category),
+                )
+            }
+            false -> {
+                defaultCategoryPreference(
+                    categories = pinnedCategories,
+                    defaultCategoryPreference = libraryPreferences.defaultPinnedCategory,
+                    title = stringResource(MR.strings.default_pinned_category),
+                )
+                defaultCategoryPreference(
+                    categories = unpinnedCategories,
+                    defaultCategoryPreference = libraryPreferences.defaultCategory,
+                    title = stringResource(MR.strings.default_category),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun defaultCategoryPreference(
+        categories: List<Category>,
+        defaultCategoryPreference: tachiyomi.core.common.preference.Preference<Int>,
+        title: String,
+    ): Preference.PreferenceItem<out Any, out Any> {
+        val ids = listOf<Int>(defaultCategoryPreference.defaultValue()) +
+            categories.fastMap { it.id.toInt() }
+        val labels = listOf(stringResource(MR.strings.default_category_summary)) +
+            categories.fastMap { it.visualName }
+
+        return Preference.PreferenceItem.ListPreference(
+            preference = defaultCategoryPreference,
+            entries = ids.zip(labels).toMap().toImmutableMap(),
+            title = title,
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposScreen.kt
@@ -23,6 +23,7 @@ import tachiyomi.presentation.core.components.material.topSmallPaddingValues
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.util.plus
+import tachiyomi.presentation.core.util.shouldExpandFAB
 
 @Composable
 fun ExtensionReposScreen(
@@ -52,8 +53,8 @@ fun ExtensionReposScreen(
         },
         floatingActionButton = {
             CategoryFloatingActionButton(
-                lazyListState = lazyListState,
                 onCreate = onClickCreate,
+                expanded = lazyListState.shouldExpandFAB(),
             )
         },
     ) { paddingValues ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
@@ -11,12 +11,14 @@ class BackupCategory(
     @ProtoNumber(3) var id: Long = 0,
     // @ProtoNumber(3) val updateInterval: Int = 0, 1.x value not used in 0.x
     @ProtoNumber(100) var flags: Long = 0,
+    @ProtoNumber(4) var isSuper: Boolean = false,
 ) {
     fun toCategory(id: Long) = Category(
         id = id,
         name = this@BackupCategory.name,
         flags = this@BackupCategory.flags,
         order = this@BackupCategory.order,
+        isSuper = this@BackupCategory.isSuper,
     )
 }
 
@@ -26,5 +28,6 @@ val backupCategoryMapper = { category: Category ->
         name = category.name,
         order = category.order,
         flags = category.flags,
+        isSuper = category.isSuper,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
@@ -11,14 +11,14 @@ class BackupCategory(
     @ProtoNumber(3) var id: Long = 0,
     // @ProtoNumber(3) val updateInterval: Int = 0, 1.x value not used in 0.x
     @ProtoNumber(100) var flags: Long = 0,
-    @ProtoNumber(4) var isSuper: Boolean = false,
+    @ProtoNumber(4) var isPinned: Boolean = false,
 ) {
     fun toCategory(id: Long) = Category(
         id = id,
         name = this@BackupCategory.name,
         flags = this@BackupCategory.flags,
         order = this@BackupCategory.order,
-        isSuper = this@BackupCategory.isSuper,
+        isPinned = this@BackupCategory.isPinned,
     )
 }
 
@@ -28,6 +28,6 @@ val backupCategoryMapper = { category: Category ->
         name = category.name,
         order = category.order,
         flags = category.flags,
-        isSuper = category.isSuper,
+        isPinned = category.isPinned,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -27,7 +27,7 @@ class CategoriesRestorer(
                     if (dbCategory != null) return@map dbCategory
                     val order = nextOrder++
                     database.categoriesQueries
-                        .insert(it.name, order, it.flags)
+                        .insert(it.name, order, it.flags, it.isSuper)
                         .awaitAsOne()
                         .let { id -> it.toCategory(id).copy(order = order) }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -27,7 +27,7 @@ class CategoriesRestorer(
                     if (dbCategory != null) return@map dbCategory
                     val order = nextOrder++
                     database.categoriesQueries
-                        .insert(it.name, order, it.flags, it.isSuper)
+                        .insert(it.name, order, it.flags, it.isPinned)
                         .awaitAsOne()
                         .let { id -> it.toCategory(id).copy(order = order) }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
@@ -41,6 +41,7 @@ class CategoryScreen : Screen() {
             onClickCreate = { screenModel.showDialog(CategoryDialog.Create) },
             onClickRename = { screenModel.showDialog(CategoryDialog.Rename(it)) },
             onClickDelete = { screenModel.showDialog(CategoryDialog.Delete(it)) },
+            onClickPin = screenModel::togglePin,
             onChangeOrder = screenModel::changeOrder,
             navigateUp = navigator::pop,
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.launch
 import tachiyomi.domain.category.interactor.CreateCategoryWithName
 import tachiyomi.domain.category.interactor.DeleteCategory
 import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.PinCategory
 import tachiyomi.domain.category.interactor.RenameCategory
 import tachiyomi.domain.category.interactor.ReorderCategory
+import tachiyomi.domain.category.interactor.UnPinCategory
 import tachiyomi.domain.category.model.Category
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
@@ -27,6 +29,8 @@ class CategoryScreenModel(
     private val deleteCategory: DeleteCategory = Injekt.get(),
     private val reorderCategory: ReorderCategory = Injekt.get(),
     private val renameCategory: RenameCategory = Injekt.get(),
+    private val pinCategory: PinCategory = Injekt.get(),
+    private val unPinCategory: UnPinCategory = Injekt.get(),
 ) : StateScreenModel<CategoryScreenState>(CategoryScreenState.Loading) {
 
     private val _events: Channel<CategoryEvent> = Channel()
@@ -40,11 +44,11 @@ class CategoryScreenModel(
                         CategoryScreenState.Success(
                             categories = allCategories
                                 .filterNot(Category::isSystemCategory)
-                                .filterNot { it.isSuper }
+                                .filterNot { it.isPinned }
                                 .toImmutableList(),
-                            superCategories = allCategories
+                            pinnedCategories = allCategories
                                 .filterNot(Category::isSystemCategory)
-                                .filter { it.isSuper }
+                                .filter { it.isPinned }
                                 .toImmutableList(),
                         )
                     }
@@ -52,9 +56,9 @@ class CategoryScreenModel(
         }
     }
 
-    fun createCategory(name: String, isSuper: Boolean) {
+    fun createCategory(name: String) {
         screenModelScope.launch {
-            when (createCategoryWithName.await(name, isSuper)) {
+            when (createCategoryWithName.await(name)) {
                 is CreateCategoryWithName.Result.InternalError -> _events.send(CategoryEvent.InternalError)
                 else -> {}
             }
@@ -84,6 +88,22 @@ class CategoryScreenModel(
             when (renameCategory.await(category, name)) {
                 is RenameCategory.Result.InternalError -> _events.send(CategoryEvent.InternalError)
                 else -> {}
+            }
+        }
+    }
+
+    fun togglePin(category: Category) {
+        screenModelScope.launch {
+            if (category.isPinned) {
+                when (unPinCategory.await(category.id)) {
+                    is UnPinCategory.Result.InternalError -> _events.send(CategoryEvent.InternalError)
+                    else -> {}
+                }
+            } else {
+                when (pinCategory.await(category.id)) {
+                    is PinCategory.Result.InternalError -> _events.send(CategoryEvent.InternalError)
+                    else -> {}
+                }
             }
         }
     }
@@ -126,13 +146,13 @@ sealed interface CategoryScreenState {
     @Immutable
     data class Success(
         val categories: ImmutableList<Category>,
-        val superCategories: ImmutableList<Category>,
+        val pinnedCategories: ImmutableList<Category>,
         val dialog: CategoryDialog? = null,
     ) : CategoryScreenState {
 
         val isEmpty: Boolean
             get() = categories.isEmpty()
-        val isSuperCatsEmpty: Boolean
-            get() = superCategories.isEmpty()
+        val isPinnedEmpty: Boolean
+            get() = pinnedCategories.isEmpty()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
@@ -151,8 +151,6 @@ sealed interface CategoryScreenState {
     ) : CategoryScreenState {
 
         val isEmpty: Boolean
-            get() = categories.isEmpty()
-        val isPinnedEmpty: Boolean
-            get() = pinnedCategories.isEmpty()
+            get() = categories.isEmpty() && pinnedCategories.isEmpty()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
@@ -35,11 +35,16 @@ class CategoryScreenModel(
     init {
         screenModelScope.launch {
             getCategories.subscribe()
-                .collectLatest { categories ->
+                .collectLatest { allCategories ->
                     mutableState.update {
                         CategoryScreenState.Success(
-                            categories = categories
+                            categories = allCategories
                                 .filterNot(Category::isSystemCategory)
+                                .filterNot { it.isSuper }
+                                .toImmutableList(),
+                            superCategories = allCategories
+                                .filterNot(Category::isSystemCategory)
+                                .filter { it.isSuper }
                                 .toImmutableList(),
                         )
                     }
@@ -47,9 +52,9 @@ class CategoryScreenModel(
         }
     }
 
-    fun createCategory(name: String) {
+    fun createCategory(name: String, isSuper: Boolean) {
         screenModelScope.launch {
-            when (createCategoryWithName.await(name)) {
+            when (createCategoryWithName.await(name, isSuper)) {
                 is CreateCategoryWithName.Result.InternalError -> _events.send(CategoryEvent.InternalError)
                 else -> {}
             }
@@ -121,10 +126,11 @@ sealed interface CategoryScreenState {
     @Immutable
     data class Success(
         val categories: ImmutableList<Category>,
+        val superCategories: ImmutableList<Category>,
         val dialog: CategoryDialog? = null,
     ) : CategoryScreenState {
 
         val isEmpty: Boolean
-            get() = categories.isEmpty()
+            get() = categories.isEmpty() && superCategories.isEmpty()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
@@ -131,6 +131,8 @@ sealed interface CategoryScreenState {
     ) : CategoryScreenState {
 
         val isEmpty: Boolean
-            get() = categories.isEmpty() && superCategories.isEmpty()
+            get() = categories.isEmpty()
+        val isSuperCatsEmpty: Boolean
+            get() = superCategories.isEmpty()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -92,7 +92,7 @@ class LibraryScreenModel(
         mutableState.update { state ->
             state.copy(
                 activeCategoryIndex = libraryPreferences.lastUsedCategory.get(),
-                activeSuperCategoryIndex = libraryPreferences.lastUsedSuperCategory.get(),
+                activePinnedCategoryIndex = libraryPreferences.lastUsedPinnedCategory.get(),
             )
         }
         screenModelScope.launchIO {
@@ -262,24 +262,24 @@ class LibraryScreenModel(
     private fun List<LibraryItem>.applyGrouping(
         categories: List<Category>,
         showSystemCategory: Boolean,
-    ): Map</* SuperCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> {
-        val groupCache = mutableMapOf</* SuperCategory */
+    ): Map</* PinnedCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> {
+        val groupCache = mutableMapOf</* PinnedCategory */
             Long,
             MutableMap</* Category */ Long, MutableList</* LibraryItem */ Long>>,
             >()
         forEach { item ->
-            item.libraryManga.superCategories.forEach { superCategoryId ->
+            item.libraryManga.pinnedCategories.forEach { pinnedCategoryId ->
                 item.libraryManga.categories.forEach { categoryId ->
-                    groupCache.getOrPut(superCategoryId) { mutableMapOf() }
+                    groupCache.getOrPut(pinnedCategoryId) { mutableMapOf() }
                         .getOrPut(categoryId) { mutableListOf() }.add(item.id)
                 }
             }
         }
-        val superCats = categories.filter { it.isSuper }
-        val normalCats = categories.filterNot { it.isSuper || (!showSystemCategory && it.isSystemCategory) }
-        return superCats.associateWith { superCat ->
+        val pinnedCats = categories.filter { it.isPinned }
+        val normalCats = categories.filterNot { it.isPinned || (!showSystemCategory && it.isSystemCategory) }
+        return pinnedCats.associateWith { pinnedCat ->
             normalCats.associateWith { cat ->
-                groupCache[superCat.id]?.toMap().orEmpty()[cat.id]?.toList().orEmpty()
+                groupCache[pinnedCat.id]?.toMap().orEmpty()[cat.id]?.toList().orEmpty()
             }
         }
     }
@@ -350,7 +350,7 @@ class LibraryScreenModel(
             }
         }
 
-        return mapValues { (superCategory, categoryMap) ->
+        return mapValues { (_, categoryMap) ->
             categoryMap.mapValues { (key, value) ->
                 if (key.sort.type == LibrarySort.Type.Random) {
                     return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed.get()))
@@ -705,13 +705,13 @@ class LibraryScreenModel(
 
         libraryPreferences.lastUsedCategory.set(newIndex)
     }
-    fun updateActiveSuperCategoryIndex(index: Int) {
+    fun updateActivePinnedCategoryIndex(index: Int) {
         val newIndex = mutableState.updateAndGet { state ->
-            state.copy(activeSuperCategoryIndex = index)
+            state.copy(activePinnedCategoryIndex = index)
         }
-            .coercedActiveSuperCategoryIndex
+            .coercedActivePinnedCategoryIndex
 
-        libraryPreferences.lastUsedSuperCategory.set(newIndex)
+        libraryPreferences.lastUsedPinnedCategory.set(newIndex)
     }
 
     fun openChangeCategoryDialog() {
@@ -797,21 +797,21 @@ class LibraryScreenModel(
         val showMangaContinueButton: Boolean = false,
         val dialog: Dialog? = null,
         val libraryData: LibraryData = LibraryData(),
-        private val activeSuperCategoryIndex: Int = 0,
+        private val activePinnedCategoryIndex: Int = 0,
         private val activeCategoryIndex: Int = 0,
-        private val groupedFavorites: Map</* SuperCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> =
+        private val groupedFavorites: Map</* PinnedCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> =
             emptyMap(),
     ) {
         val nonSystemCategories: List<Category> = libraryData.categories.filterNot { it.isSystemCategory }
-        val displayedSuperCategories: List<Category> = groupedFavorites.keys.toList()
+        val displayedPinnedCategories: List<Category> = groupedFavorites.keys.toList()
 
-        val coercedActiveSuperCategoryIndex = activeSuperCategoryIndex.coerceIn(
+        val coercedActivePinnedCategoryIndex = activePinnedCategoryIndex.coerceIn(
             minimumValue = 0,
-            maximumValue = displayedSuperCategories.lastIndex.coerceAtLeast(0),
+            maximumValue = displayedPinnedCategories.lastIndex.coerceAtLeast(0),
         )
-        val activeSuperCategory: Category? = displayedSuperCategories.getOrNull(coercedActiveSuperCategoryIndex)
+        val activePinnedCategory: Category? = displayedPinnedCategories.getOrNull(coercedActivePinnedCategoryIndex)
 
-        val displayedCategories: List<Category> = groupedFavorites[activeSuperCategory].orEmpty().keys.toList()
+        val displayedCategories: List<Category> = groupedFavorites[activePinnedCategory].orEmpty().keys.toList()
 
         val coercedActiveCategoryIndex = activeCategoryIndex.coerceIn(
             minimumValue = 0,
@@ -833,7 +833,7 @@ class LibraryScreenModel(
         }
 
         fun getItemsForCategory(category: Category): List<LibraryItem> {
-            return groupedFavorites[activeSuperCategory].orEmpty()[category].orEmpty().mapNotNull {
+            return groupedFavorites[activePinnedCategory].orEmpty()[category].orEmpty().mapNotNull {
                 libraryData.favoritesById[it]
             }
         }
@@ -842,16 +842,11 @@ class LibraryScreenModel(
             return if (showMangaCount ||
                 !searchQuery.isNullOrEmpty()
             ) {
-                groupedFavorites[activeSuperCategory].orEmpty()[category]?.size
-            } else {
-                null
-            }
-        }
-        fun getItemCountForSuperCategory(category: Category): Int? {
-            return if (showMangaCount ||
-                !searchQuery.isNullOrEmpty()
-            ) {
-                groupedFavorites[category]?.values?.sumOf { it.size }
+                if (category.isPinned) {
+                    groupedFavorites[category]?.values?.sumOf { it.size }
+                } else {
+                    groupedFavorites[activePinnedCategory].orEmpty()[category]?.size
+                }
             } else {
                 null
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -847,6 +847,15 @@ class LibraryScreenModel(
                 null
             }
         }
+        fun getItemCountForSuperCategory(category: Category): Int? {
+            return if (showMangaCount ||
+                !searchQuery.isNullOrEmpty()
+            ) {
+                groupedFavorites[category]?.values?.sumOf { it.size }
+            } else {
+                null
+            }
+        }
 
         fun getToolbarTitle(
             defaultTitle: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -66,6 +66,7 @@ import tachiyomi.domain.track.model.Track
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.collections.mutableListOf
 import kotlin.random.Random
 
 class LibraryScreenModel(
@@ -89,7 +90,10 @@ class LibraryScreenModel(
 
     init {
         mutableState.update { state ->
-            state.copy(activeCategoryIndex = libraryPreferences.lastUsedCategory.get())
+            state.copy(
+                activeCategoryIndex = libraryPreferences.lastUsedCategory.get(),
+                activeSuperCategoryIndex = libraryPreferences.lastUsedSuperCategory.get(),
+            )
         }
         screenModelScope.launchIO {
             combine(
@@ -258,22 +262,33 @@ class LibraryScreenModel(
     private fun List<LibraryItem>.applyGrouping(
         categories: List<Category>,
         showSystemCategory: Boolean,
-    ): Map<Category, List</* LibraryItem */ Long>> {
-        val groupCache = mutableMapOf</* Category */ Long, MutableList</* LibraryItem */ Long>>()
+    ): Map</* SuperCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> {
+        val groupCache = mutableMapOf</* SuperCategory */
+            Long,
+            MutableMap</* Category */ Long, MutableList</* LibraryItem */ Long>>,
+            >()
         forEach { item ->
-            item.libraryManga.categories.forEach { categoryId ->
-                groupCache.getOrPut(categoryId) { mutableListOf() }.add(item.id)
+            item.libraryManga.superCategories.forEach { superCategoryId ->
+                item.libraryManga.categories.forEach { categoryId ->
+                    groupCache.getOrPut(superCategoryId) { mutableMapOf() }
+                        .getOrPut(categoryId) { mutableListOf() }.add(item.id)
+                }
             }
         }
-        return categories.filter { showSystemCategory || !it.isSystemCategory }
-            .associateWith { groupCache[it.id]?.toList().orEmpty() }
+        val superCats = categories.filter { it.isSuper }
+        val normalCats = categories.filterNot { it.isSuper || (!showSystemCategory && it.isSystemCategory) }
+        return superCats.associateWith { superCat ->
+            normalCats.associateWith { cat ->
+                groupCache[superCat.id]?.toMap().orEmpty()[cat.id]?.toList().orEmpty()
+            }
+        }
     }
 
-    private fun Map<Category, List</* LibraryItem */ Long>>.applySort(
+    private fun Map<Category, Map<Category, List</* LibraryItem */ Long>>>.applySort(
         favoritesById: Map<Long, LibraryItem>,
         trackMap: Map<Long, List<Track>>,
         loggedInTrackerIds: Set<Long>,
-    ): Map<Category, List</* LibraryItem */ Long>> {
+    ): Map<Category, Map<Category, List</* LibraryItem */ Long>>> {
         val sortAlphabetically: (LibraryItem, LibraryItem) -> Int = { manga1, manga2 ->
             val title1 = manga1.libraryManga.manga.title.lowercase()
             val title2 = manga2.libraryManga.manga.title.lowercase()
@@ -335,18 +350,20 @@ class LibraryScreenModel(
             }
         }
 
-        return mapValues { (key, value) ->
-            if (key.sort.type == LibrarySort.Type.Random) {
-                return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed.get()))
+        return mapValues { (superCategory, categoryMap) ->
+            categoryMap.mapValues { (key, value) ->
+                if (key.sort.type == LibrarySort.Type.Random) {
+                    return@mapValues value.shuffled(Random(libraryPreferences.randomSortSeed.get()))
+                }
+
+                val manga = value.mapNotNull { favoritesById[it] }
+
+                val comparator = key.sort.comparator()
+                    .let { if (key.sort.isAscending) it else it.reversed() }
+                    .thenComparator(sortAlphabetically)
+
+                manga.sortedWith(comparator).map { it.id }
             }
-
-            val manga = value.mapNotNull { favoritesById[it] }
-
-            val comparator = key.sort.comparator()
-                .let { if (key.sort.isAscending) it else it.reversed() }
-                .thenComparator(sortAlphabetically)
-
-            manga.sortedWith(comparator).map { it.id }
         }
     }
 
@@ -688,6 +705,14 @@ class LibraryScreenModel(
 
         libraryPreferences.lastUsedCategory.set(newIndex)
     }
+    fun updateActiveSuperCategoryIndex(index: Int) {
+        val newIndex = mutableState.updateAndGet { state ->
+            state.copy(activeSuperCategoryIndex = index)
+        }
+            .coercedActiveSuperCategoryIndex
+
+        libraryPreferences.lastUsedSuperCategory.set(newIndex)
+    }
 
     fun openChangeCategoryDialog() {
         screenModelScope.launchIO {
@@ -695,7 +720,7 @@ class LibraryScreenModel(
             val mangaList = state.value.selectedManga
 
             // Hide the default category because it has a different behavior than the ones from db.
-            val categories = state.value.displayedCategories.filter { it.id != 0L }
+            val categories = state.value.nonSystemCategories
 
             // Get indexes of the common categories to preselect.
             val common = getCommonCategories(mangaList)
@@ -772,10 +797,21 @@ class LibraryScreenModel(
         val showMangaContinueButton: Boolean = false,
         val dialog: Dialog? = null,
         val libraryData: LibraryData = LibraryData(),
+        private val activeSuperCategoryIndex: Int = 0,
         private val activeCategoryIndex: Int = 0,
-        private val groupedFavorites: Map<Category, List</* LibraryItem */ Long>> = emptyMap(),
+        private val groupedFavorites: Map</* SuperCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> =
+            emptyMap(),
     ) {
-        val displayedCategories: List<Category> = groupedFavorites.keys.toList()
+        val nonSystemCategories: List<Category> = libraryData.categories.filterNot { it.isSystemCategory }
+        val displayedSuperCategories: List<Category> = groupedFavorites.keys.toList()
+
+        val coercedActiveSuperCategoryIndex = activeSuperCategoryIndex.coerceIn(
+            minimumValue = 0,
+            maximumValue = displayedSuperCategories.lastIndex.coerceAtLeast(0),
+        )
+        val activeSuperCategory: Category? = displayedSuperCategories.getOrNull(coercedActiveSuperCategoryIndex)
+
+        val displayedCategories: List<Category> = groupedFavorites[activeSuperCategory].orEmpty().keys.toList()
 
         val coercedActiveCategoryIndex = activeCategoryIndex.coerceIn(
             minimumValue = 0,
@@ -797,11 +833,19 @@ class LibraryScreenModel(
         }
 
         fun getItemsForCategory(category: Category): List<LibraryItem> {
-            return groupedFavorites[category].orEmpty().mapNotNull { libraryData.favoritesById[it] }
+            return groupedFavorites[activeSuperCategory].orEmpty()[category].orEmpty().mapNotNull {
+                libraryData.favoritesById[it]
+            }
         }
 
         fun getItemCountForCategory(category: Category): Int? {
-            return if (showMangaCount || !searchQuery.isNullOrEmpty()) groupedFavorites[category]?.size else null
+            return if (showMangaCount ||
+                !searchQuery.isNullOrEmpty()
+            ) {
+                groupedFavorites[activeSuperCategory].orEmpty()[category]?.size
+            } else {
+                null
+            }
         }
 
         fun getToolbarTitle(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -91,6 +91,7 @@ class LibraryScreenModel(
     init {
         mutableState.update { state ->
             state.copy(
+                // TODO active cat index by pinned cat
                 activeCategoryIndex = libraryPreferences.lastUsedCategory.get(),
                 activePinnedCategoryIndex = libraryPreferences.lastUsedPinnedCategory.get(),
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -103,14 +103,12 @@ class LibraryScreenModel(
                 combine(getTracksPerManga.subscribe(), getTrackingFiltersFlow(), ::Pair),
                 getLibraryItemPreferencesFlow(),
             ) { searchQuery, categories, favorites, (tracksMap, trackingFilters), itemPreferences ->
-                val showSystemCategory = favorites.any { it.libraryManga.categories.contains(0) }
                 val filteredFavorites = favorites
                     .applyFilters(tracksMap, trackingFilters, itemPreferences)
                     .let { if (searchQuery == null) it else it.filter { m -> m.matches(searchQuery) } }
 
                 LibraryData(
                     isInitialized = true,
-                    showSystemCategory = showSystemCategory,
                     categories = categories,
                     favorites = filteredFavorites,
                     tracksMap = tracksMap,
@@ -132,7 +130,7 @@ class LibraryScreenModel(
                 .distinctUntilChanged()
                 .map { data ->
                     data.favorites
-                        .applyGrouping(data.categories, data.showSystemCategory)
+                        .applyGrouping(data.categories)
                         .applySort(data.favoritesById, data.tracksMap, data.loggedInTrackerIds)
                 }
                 .collectLatest {
@@ -261,26 +259,35 @@ class LibraryScreenModel(
 
     private fun List<LibraryItem>.applyGrouping(
         categories: List<Category>,
-        showSystemCategory: Boolean,
     ): Map</* PinnedCategory */ Category, Map<Category, List</* LibraryItem */ Long>>> {
         val groupCache = mutableMapOf</* PinnedCategory */
             Long,
             MutableMap</* Category */ Long, MutableList</* LibraryItem */ Long>>,
             >()
+        var showPinnedSystemCategory = false
+        val showSystemCategoryCache = mutableMapOf<Long, Boolean>()
         forEach { item ->
             item.libraryManga.pinnedCategories.forEach { pinnedCategoryId ->
                 item.libraryManga.categories.forEach { categoryId ->
                     groupCache.getOrPut(pinnedCategoryId) { mutableMapOf() }
                         .getOrPut(categoryId) { mutableListOf() }.add(item.id)
+
+                    if (categoryId == 0L) {
+                        showSystemCategoryCache[pinnedCategoryId] = true
+                    }
+                }
+
+                if (pinnedCategoryId == -1L) {
+                    showPinnedSystemCategory = true
                 }
             }
         }
-        val pinnedCats = categories.filter { it.isPinned }
-        val normalCats = categories.filterNot { it.isPinned || (!showSystemCategory && it.isSystemCategory) }
+        val pinnedCats = categories.filter { it.isPinned && (!it.isSystemCategory || showPinnedSystemCategory) }
+        val normalCats = categories.filterNot { it.isPinned }
         return pinnedCats.associateWith { pinnedCat ->
             normalCats.associateWith { cat ->
                 groupCache[pinnedCat.id]?.toMap().orEmpty()[cat.id]?.toList().orEmpty()
-            }
+            }.filter { !it.key.isSystemCategory || showSystemCategoryCache[pinnedCat.id] == true }
         }
     }
 
@@ -776,7 +783,6 @@ class LibraryScreenModel(
     @Immutable
     data class LibraryData(
         val isInitialized: Boolean = false,
-        val showSystemCategory: Boolean = false,
         val categories: List<Category> = emptyList(),
         val favorites: List<LibraryItem> = emptyList(),
         val tracksMap: Map</* Manga */ Long, List<Track>> = emptyMap(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -180,16 +180,16 @@ data object LibraryTab : Tab {
                 else -> {
                     LibraryContent(
                         categories = state.displayedCategories,
-                        superCategories = state.displayedSuperCategories,
+                        pinnedCategories = state.displayedPinnedCategories,
                         searchQuery = state.searchQuery,
                         selection = state.selection,
                         contentPadding = contentPadding,
                         currentPage = state.coercedActiveCategoryIndex,
-                        currentSuperPage = state.coercedActiveSuperCategoryIndex,
+                        currentPinnedPage = state.coercedActivePinnedCategoryIndex,
                         hasActiveFilters = state.hasActiveFilters,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
-                        onChangeCurrentSuperPage = screenModel::updateActiveSuperCategoryIndex,
+                        onChangeCurrentPinnedPage = screenModel::updateActivePinnedCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },
                         onContinueReadingClicked = { it: LibraryManga ->
                             scope.launchIO {
@@ -214,7 +214,6 @@ data object LibraryTab : Tab {
                             navigator.push(GlobalSearchScreen(screenModel.state.value.searchQuery ?: ""))
                         },
                         getItemCountForCategory = { state.getItemCountForCategory(it) },
-                        getItemCountForSuperCategory = { state.getItemCountForSuperCategory(it) },
                         getDisplayMode = { screenModel.getDisplayMode() },
                         getColumnsForOrientation = { screenModel.getColumnsForOrientation(it) },
                         getItemsForCategory = { state.getItemsForCategory(it) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -214,6 +214,7 @@ data object LibraryTab : Tab {
                             navigator.push(GlobalSearchScreen(screenModel.state.value.searchQuery ?: ""))
                         },
                         getItemCountForCategory = { state.getItemCountForCategory(it) },
+                        getItemCountForSuperCategory = { state.getItemCountForSuperCategory(it) },
                         getDisplayMode = { screenModel.getDisplayMode() },
                         getColumnsForOrientation = { screenModel.getColumnsForOrientation(it) },
                         getItemsForCategory = { state.getItemsForCategory(it) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -180,13 +180,16 @@ data object LibraryTab : Tab {
                 else -> {
                     LibraryContent(
                         categories = state.displayedCategories,
+                        superCategories = state.displayedSuperCategories,
                         searchQuery = state.searchQuery,
                         selection = state.selection,
                         contentPadding = contentPadding,
                         currentPage = state.coercedActiveCategoryIndex,
+                        currentSuperPage = state.coercedActiveSuperCategoryIndex,
                         hasActiveFilters = state.hasActiveFilters,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
+                        onChangeCurrentSuperPage = screenModel::updateActiveSuperCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },
                         onContinueReadingClicked = { it: LibraryManga ->
                             scope.launchIO {

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -49,6 +49,7 @@ class CategoryRepositoryImpl(
             name = category.name,
             order = category.order,
             flags = category.flags,
+            isSuper = category.isSuper,
         )
             .awaitAsOne()
     }
@@ -81,12 +82,14 @@ class CategoryRepositoryImpl(
         name: String,
         order: Long,
         flags: Long,
+        isSuper: Boolean,
     ): Category {
         return Category(
             id = id,
             name = name,
             order = order,
             flags = flags,
+            isSuper = isSuper,
         )
     }
 }

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package tachiyomi.data.category
 
 import app.cash.sqldelight.async.coroutines.awaitAsList
+import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import kotlinx.coroutines.flow.Flow
 import tachiyomi.data.Database
@@ -49,6 +50,7 @@ class CategoryRepositoryImpl(
             order = category.order,
             flags = category.flags,
         )
+            .awaitAsOne()
     }
 
     override suspend fun updatePartial(update: CategoryUpdate) {

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -49,7 +49,7 @@ class CategoryRepositoryImpl(
             name = category.name,
             order = category.order,
             flags = category.flags,
-            isSuper = category.isSuper,
+            isPinned = category.isPinned,
         )
             .awaitAsOne()
     }
@@ -60,6 +60,7 @@ class CategoryRepositoryImpl(
             order = update.order,
             flags = update.flags,
             categoryId = update.id,
+            isPinned = update.isPinned,
         )
     }
 
@@ -82,14 +83,14 @@ class CategoryRepositoryImpl(
         name: String,
         order: Long,
         flags: Long,
-        isSuper: Boolean,
+        isPinned: Boolean,
     ): Category {
         return Category(
             id = id,
             name = name,
             order = order,
             flags = flags,
-            isSuper = isSuper,
+            isPinned = isPinned,
         )
     }
 }

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -93,7 +93,7 @@ object MangaMapper {
         lastRead: Long,
         bookmarkCount: Double,
         categories: String,
-        superCategories: String,
+        pinnedCategories: String,
     ): LibraryManga = LibraryManga(
         manga = mapManga(
             id,
@@ -123,7 +123,7 @@ object MangaMapper {
             notes,
         ),
         categories = categories.split(",").map { it.toLong() },
-        superCategories = superCategories.split(",").map { it.toLong() },
+        pinnedCategories = pinnedCategories.split(",").map { it.toLong() },
         totalChapters = totalCount,
         readCount = readCount.toLong(),
         bookmarkCount = bookmarkCount.toLong(),

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -93,6 +93,7 @@ object MangaMapper {
         lastRead: Long,
         bookmarkCount: Double,
         categories: String,
+        superCategories: String,
     ): LibraryManga = LibraryManga(
         manga = mapManga(
             id,
@@ -122,6 +123,7 @@ object MangaMapper {
             notes,
         ),
         categories = categories.split(",").map { it.toLong() },
+        superCategories = superCategories.split(",").map { it.toLong() },
         totalChapters = totalCount,
         readCount = readCount.toLong(),
         bookmarkCount = bookmarkCount.toLong(),

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -10,6 +10,7 @@ CREATE TABLE categories(
 
 -- Insert system category
 INSERT OR IGNORE INTO categories(_id, name, sort, flags) VALUES (0, "", -1, 0);
+INSERT OR IGNORE INTO categories(_id, name, sort, flags, is_super) VALUES (-1, "", -1, 0, 1);
 -- Disallow deletion of default category
 CREATE TRIGGER IF NOT EXISTS system_category_delete_trigger BEFORE DELETE
 ON categories

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -5,12 +5,12 @@ CREATE TABLE categories(
     name TEXT NOT NULL,
     sort INTEGER NOT NULL,
     flags INTEGER NOT NULL,
-    is_super INTEGER AS Boolean DEFAULT 0 NOT NULL
+    is_pinned INTEGER AS Boolean DEFAULT 0 NOT NULL
 );
 
 -- Insert system category
 INSERT OR IGNORE INTO categories(_id, name, sort, flags) VALUES (0, "", -1, 0);
-INSERT OR IGNORE INTO categories(_id, name, sort, flags, is_super) VALUES (-1, "", -1, 0, 1);
+INSERT OR IGNORE INTO categories(_id, name, sort, flags, is_pinned) VALUES (-1, "", -1, 0, 1);
 -- Disallow deletion of default category
 CREATE TRIGGER IF NOT EXISTS system_category_delete_trigger BEFORE DELETE
 ON categories
@@ -32,7 +32,7 @@ _id AS id,
 name,
 sort AS `order`,
 flags,
-is_super
+is_pinned
 FROM categories
 ORDER BY sort;
 
@@ -42,15 +42,15 @@ C._id AS id,
 C.name,
 C.sort AS `order`,
 C.flags,
-C.is_super
+C.is_pinned
 FROM categories C
 JOIN mangas_categories MC
 ON C._id = MC.category_id
 WHERE MC.manga_id = :mangaId;
 
 insert {
-    INSERT INTO categories(name, sort, flags, is_super)
-    VALUES (:name, :order, :flags, :isSuper);
+    INSERT INTO categories(name, sort, flags, is_pinned)
+    VALUES (:name, :order, :flags, :isPinned);
 
     SELECT last_insert_rowid();
 }
@@ -63,7 +63,8 @@ update:
 UPDATE categories
 SET name = coalesce(:name, name),
     sort = coalesce(:order, sort),
-    flags = coalesce(:flags, flags)
+    flags = coalesce(:flags, flags),
+    is_pinned = coalesce(:isPinned, is_pinned)
 WHERE _id = :categoryId;
 
 updateAllFlags:

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -1,8 +1,11 @@
+import kotlin.Boolean;
+
 CREATE TABLE categories(
     _id INTEGER NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
     sort INTEGER NOT NULL,
-    flags INTEGER NOT NULL
+    flags INTEGER NOT NULL,
+    is_super INTEGER AS Boolean DEFAULT 0 NOT NULL
 );
 
 -- Insert system category
@@ -27,7 +30,8 @@ SELECT
 _id AS id,
 name,
 sort AS `order`,
-flags
+flags,
+is_super
 FROM categories
 ORDER BY sort;
 
@@ -36,15 +40,16 @@ SELECT
 C._id AS id,
 C.name,
 C.sort AS `order`,
-C.flags
+C.flags,
+C.is_super
 FROM categories C
 JOIN mangas_categories MC
 ON C._id = MC.category_id
 WHERE MC.manga_id = :mangaId;
 
 insert {
-    INSERT INTO categories(name, sort, flags)
-    VALUES (:name, :order, :flags);
+    INSERT INTO categories(name, sort, flags, is_super)
+    VALUES (:name, :order, :flags, :isSuper);
 
     SELECT last_insert_rowid();
 }

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -8,7 +8,7 @@ SELECT
     coalesce(C.lastRead, 0) AS lastRead,
     coalesce(C.bookmarkCount, 0) AS bookmarkCount,
     coalesce(MC.categories, '0') AS categories,
-    coalesce(MSC.super_categories, '-1') AS superCategories
+    coalesce(MPC.pinned_categories, '-1') AS pinnedCategories
 FROM mangas M
 LEFT JOIN (
     SELECT
@@ -34,19 +34,19 @@ LEFT JOIN (
     FROM mangas_categories
     LEFT JOIN categories
     ON mangas_categories.category_id = categories._id
-    WHERE is_super == 0
+    WHERE is_pinned == 0
     GROUP BY manga_id
 ) AS MC
 ON MC.manga_id = M._id
 LEFT JOIN (
-    SELECT manga_id, group_concat(category_id) AS super_categories
+    SELECT manga_id, group_concat(category_id) AS pinned_categories
     FROM mangas_categories
     LEFT JOIN categories
     ON mangas_categories.category_id = categories._id
-    WHERE is_super == 1
+    WHERE is_pinned == 1
     GROUP BY manga_id
-) AS MSC
-ON MSC.manga_id = M._id
+) AS MPC
+ON MPC.manga_id = M._id
 WHERE M.favorite = 1;
 
 library:

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -7,7 +7,8 @@ SELECT
     coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
     coalesce(C.lastRead, 0) AS lastRead,
     coalesce(C.bookmarkCount, 0) AS bookmarkCount,
-    coalesce(MC.categories, '0') AS categories
+    coalesce(MC.categories, '0') AS categories,
+    coalesce(MSC.super_categories, '-1') AS superCategories
 FROM mangas M
 LEFT JOIN (
     SELECT
@@ -31,9 +32,21 @@ ON M._id = C.manga_id
 LEFT JOIN (
     SELECT manga_id, group_concat(category_id) AS categories
     FROM mangas_categories
+    LEFT JOIN categories
+    ON mangas_categories.category_id = categories._id
+    WHERE is_super == 0
     GROUP BY manga_id
 ) AS MC
 ON MC.manga_id = M._id
+LEFT JOIN (
+    SELECT manga_id, group_concat(category_id) AS super_categories
+    FROM mangas_categories
+    LEFT JOIN categories
+    ON mangas_categories.category_id = categories._id
+    WHERE is_super == 1
+    GROUP BY manga_id
+) AS MSC
+ON MSC.manga_id = M._id
 WHERE M.favorite = 1;
 
 library:

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
@@ -18,7 +18,7 @@ class CreateCategoryWithName(
             return sort.type.flag or sort.direction.flag
         }
 
-    suspend fun await(name: String, isSuper: Boolean): Result = withNonCancellableContext {
+    suspend fun await(name: String): Result = withNonCancellableContext {
         val categories = categoryRepository.getAll()
         val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
         val newCategory = Category(
@@ -26,7 +26,7 @@ class CreateCategoryWithName(
             name = name,
             order = nextOrder,
             flags = initialFlags,
-            isSuper = isSuper,
+            isPinned = false,
         )
 
         try {

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
@@ -26,6 +26,7 @@ class CreateCategoryWithName(
             name = name,
             order = nextOrder,
             flags = initialFlags,
+            isSuper = false,
         )
 
         try {

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
@@ -18,7 +18,7 @@ class CreateCategoryWithName(
             return sort.type.flag or sort.direction.flag
         }
 
-    suspend fun await(name: String): Result = withNonCancellableContext {
+    suspend fun await(name: String, isSuper: Boolean): Result = withNonCancellableContext {
         val categories = categoryRepository.getAll()
         val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
         val newCategory = Category(
@@ -26,7 +26,7 @@ class CreateCategoryWithName(
             name = name,
             order = nextOrder,
             flags = initialFlags,
-            isSuper = false,
+            isSuper = isSuper,
         )
 
         try {

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/DeleteCategory.kt
@@ -3,6 +3,7 @@ package tachiyomi.domain.category.interactor
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.category.repository.CategoryRepository
 import tachiyomi.domain.download.service.DownloadPreferences
@@ -23,6 +24,7 @@ class DeleteCategory(
         }
 
         val categories = categoryRepository.getAll()
+            .filterNot(Category::isSystemCategory)
         val updates = categories.mapIndexed { index, category ->
             CategoryUpdate(
                 id = category.id,

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/PinCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/PinCategory.kt
@@ -1,0 +1,35 @@
+package tachiyomi.domain.category.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.category.repository.CategoryRepository
+
+class PinCategory(
+    private val categoryRepository: CategoryRepository,
+) {
+
+    suspend fun await(categoryId: Long) = withNonCancellableContext {
+        val update = CategoryUpdate(
+            id = categoryId,
+            isPinned = true,
+        )
+
+        try {
+            categoryRepository.updatePartial(update)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    suspend fun await(category: Category, name: String) = await(category.id)
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/ReorderCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/ReorderCategory.kt
@@ -18,6 +18,7 @@ class ReorderCategory(
         mutex.withLock {
             val categories = categoryRepository.getAll()
                 .filterNot(Category::isSystemCategory)
+                .filter { it.isSuper == category.isSuper }
                 .toMutableList()
 
             val currentIndex = categories.indexOfFirst { it.id == category.id }

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/ReorderCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/ReorderCategory.kt
@@ -18,7 +18,7 @@ class ReorderCategory(
         mutex.withLock {
             val categories = categoryRepository.getAll()
                 .filterNot(Category::isSystemCategory)
-                .filter { it.isSuper == category.isSuper }
+                .filter { it.isPinned == category.isPinned }
                 .toMutableList()
 
             val currentIndex = categories.indexOfFirst { it.id == category.id }

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/UnPinCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/UnPinCategory.kt
@@ -1,0 +1,35 @@
+package tachiyomi.domain.category.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.category.repository.CategoryRepository
+
+class UnPinCategory(
+    private val categoryRepository: CategoryRepository,
+) {
+
+    suspend fun await(categoryId: Long) = withNonCancellableContext {
+        val update = CategoryUpdate(
+            id = categoryId,
+            isPinned = false,
+        )
+
+        try {
+            categoryRepository.updatePartial(update)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    suspend fun await(category: Category, name: String) = await(category.id)
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
@@ -7,13 +7,13 @@ data class Category(
     val name: String,
     val order: Long,
     val flags: Long,
-    val isSuper: Boolean,
+    val isPinned: Boolean,
 ) : Serializable {
 
-    val isSystemCategory: Boolean = id == UNCATEGORIZED_ID || id == UNCATEGORIZED_SUPER_ID
+    val isSystemCategory: Boolean = id == UNCATEGORIZED_ID || id == UNCATEGORIZED_PINNED_ID
 
     companion object {
         const val UNCATEGORIZED_ID = 0L
-        const val UNCATEGORIZED_SUPER_ID = -1L
+        const val UNCATEGORIZED_PINNED_ID = -1L
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
@@ -7,6 +7,7 @@ data class Category(
     val name: String,
     val order: Long,
     val flags: Long,
+    val isSuper: Boolean,
 ) : Serializable {
 
     val isSystemCategory: Boolean = id == UNCATEGORIZED_ID

--- a/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
@@ -10,9 +10,10 @@ data class Category(
     val isSuper: Boolean,
 ) : Serializable {
 
-    val isSystemCategory: Boolean = id == UNCATEGORIZED_ID
+    val isSystemCategory: Boolean = id == UNCATEGORIZED_ID || id == UNCATEGORIZED_SUPER_ID
 
     companion object {
         const val UNCATEGORIZED_ID = 0L
+        const val UNCATEGORIZED_SUPER_ID = -1L
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
@@ -5,4 +5,5 @@ data class CategoryUpdate(
     val name: String? = null,
     val order: Long? = null,
     val flags: Long? = null,
+    val isPinned: Boolean? = null,
 )

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibraryManga.kt
@@ -5,7 +5,7 @@ import tachiyomi.domain.manga.model.Manga
 data class LibraryManga(
     val manga: Manga,
     val categories: List<Long>,
-    val superCategories: List<Long>,
+    val pinnedCategories: List<Long>,
     val totalChapters: Long,
     val readCount: Long,
     val bookmarkCount: Long,

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibraryManga.kt
@@ -5,6 +5,7 @@ import tachiyomi.domain.manga.model.Manga
 data class LibraryManga(
     val manga: Manga,
     val categories: List<Long>,
+    val superCategories: List<Long>,
     val totalChapters: Long,
     val readCount: Long,
     val bookmarkCount: Long,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -125,7 +125,7 @@ class LibraryPreferences(
     val defaultCategory: Preference<Int> = preferenceStore.getInt(DEFAULT_CATEGORY_PREF_KEY, -2)
 
     val lastUsedCategory: Preference<Int> = preferenceStore.getInt(Preference.appStateKey("last_used_category"), 0)
-    val lastUsedSuperCategory: Preference<Int> = preferenceStore.getInt(
+    val lastUsedPinnedCategory: Preference<Int> = preferenceStore.getInt(
         Preference.appStateKey("last_used_super_category"),
         -1,
     )

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -123,6 +123,7 @@ class LibraryPreferences(
     // region Category
 
     val defaultCategory: Preference<Int> = preferenceStore.getInt(DEFAULT_CATEGORY_PREF_KEY, -2)
+    val defaultPinnedCategory: Preference<Int> = preferenceStore.getInt(DEFAULT_PINNED_CATEGORY_PREF_KEY, -2)
 
     val lastUsedCategory: Preference<Int> = preferenceStore.getInt(Preference.appStateKey("last_used_category"), 0)
     val lastUsedPinnedCategory: Preference<Int> = preferenceStore.getInt(
@@ -242,10 +243,12 @@ class LibraryPreferences(
         const val MARK_DUPLICATE_CHAPTER_READ_EXISTING = "existing"
 
         const val DEFAULT_CATEGORY_PREF_KEY = "default_category"
+        const val DEFAULT_PINNED_CATEGORY_PREF_KEY = "default_pinned_category"
         private const val LIBRARY_UPDATE_CATEGORIES_PREF_KEY = "library_update_categories"
         private const val LIBRARY_UPDATE_CATEGORIES_EXCLUDE_PREF_KEY = "library_update_categories_exclude"
         val categoryPreferenceKeys = setOf(
             DEFAULT_CATEGORY_PREF_KEY,
+            DEFAULT_PINNED_CATEGORY_PREF_KEY,
             LIBRARY_UPDATE_CATEGORIES_PREF_KEY,
             LIBRARY_UPDATE_CATEGORIES_EXCLUDE_PREF_KEY,
         )

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -122,9 +122,13 @@ class LibraryPreferences(
 
     // region Category
 
-    val defaultCategory: Preference<Int> = preferenceStore.getInt(DEFAULT_CATEGORY_PREF_KEY, -1)
+    val defaultCategory: Preference<Int> = preferenceStore.getInt(DEFAULT_CATEGORY_PREF_KEY, -2)
 
     val lastUsedCategory: Preference<Int> = preferenceStore.getInt(Preference.appStateKey("last_used_category"), 0)
+    val lastUsedSuperCategory: Preference<Int> = preferenceStore.getInt(
+        Preference.appStateKey("last_used_super_category"),
+        -1,
+    )
 
     val categoryTabs: Preference<Boolean> = preferenceStore.getBoolean("display_category_tabs", true)
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -820,6 +820,7 @@
     <!-- missing undo feature after Compose rewrite #7454 -->
     <string name="snack_categories_deleted">Categories deleted</string>
     <string name="categories_pinned">Pinned categories</string>
+    <string name="pinned_category">Pinned category</string>
 
     <!-- Dialog option with checkbox view -->
     <string name="dialog_with_checkbox_remove_description">This will remove the read date of this chapter. Are you sure?</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -306,6 +306,7 @@
 
     <string name="default_category">Default category</string>
     <string name="default_category_summary">Always ask</string>
+    <string name="default_pinned_category">Default pinned category</string>
     <string name="categorized_display_settings">Per-category settings for sort</string>
     <string name="pref_library_update_categories_details">Entries in excluded categories will not be updated even if they are also in included categories.</string>
     <string name="all">All</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -95,6 +95,8 @@
     <string name="action_add_category">Add category</string>
     <string name="action_edit_categories">Edit categories</string>
     <string name="action_rename_category">Rename category</string>
+    <string name="action_pin_category">Pin category</string>
+    <string name="action_unpin_category">Unpin category</string>
     <string name="action_move_category">Set categories</string>
     <string name="delete_category_confirmation">Do you wish to delete the category \"%s\"?</string>
     <string name="delete_category">Delete category</string>
@@ -817,8 +819,7 @@
     <string name="error_category_exists">A category with this name already exists!</string>
     <!-- missing undo feature after Compose rewrite #7454 -->
     <string name="snack_categories_deleted">Categories deleted</string>
-    <string name="is_category_super">Super category</string>
-    <string name="categories_super">Super categories</string>
+    <string name="categories_pinned">Pinned categories</string>
 
     <!-- Dialog option with checkbox view -->
     <string name="dialog_with_checkbox_remove_description">This will remove the read date of this chapter. Are you sure?</string>
@@ -961,7 +962,7 @@
     <string name="information_no_entries_found">No entries found in this category</string>
     <string name="getting_started_guide">Getting started guide</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>
-    <string name="information_empty_super_category">You have no super categories. Tap the plus button to create one for organizing your library.</string>
+    <string name="information_empty_pinned_category">You have no pinned categories. Pin a category below to have a second level of categories.</string>
     <string name="information_empty_category_dialog">You don\'t have any categories yet.</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <string name="information_cloudflare_help">Tap here for help with Cloudflare</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -818,6 +818,7 @@
     <!-- missing undo feature after Compose rewrite #7454 -->
     <string name="snack_categories_deleted">Categories deleted</string>
     <string name="is_category_super">Super category</string>
+    <string name="categories_super">Super categories</string>
 
     <!-- Dialog option with checkbox view -->
     <string name="dialog_with_checkbox_remove_description">This will remove the read date of this chapter. Are you sure?</string>
@@ -960,6 +961,7 @@
     <string name="information_no_entries_found">No entries found in this category</string>
     <string name="getting_started_guide">Getting started guide</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>
+    <string name="information_empty_super_category">You have no super categories. Tap the plus button to create one for organizing your library.</string>
     <string name="information_empty_category_dialog">You don\'t have any categories yet.</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <string name="information_cloudflare_help">Tap here for help with Cloudflare</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -817,6 +817,7 @@
     <string name="error_category_exists">A category with this name already exists!</string>
     <!-- missing undo feature after Compose rewrite #7454 -->
     <string name="snack_categories_deleted">Categories deleted</string>
+    <string name="is_category_super">Super category</string>
 
     <!-- Dialog option with checkbox view -->
     <string name="dialog_with_checkbox_remove_description">This will remove the read date of this chapter. Are you sure?</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -962,7 +962,7 @@
     <string name="information_no_entries_found">No entries found in this category</string>
     <string name="getting_started_guide">Getting started guide</string>
     <string name="information_empty_category">You have no categories. Tap the plus button to create one for organizing your library.</string>
-    <string name="information_empty_pinned_category">You have no pinned categories. Pin a category below to have a second level of categories.</string>
+    <string name="information_empty_pinned_category">You can pin categories below to use them as a second level of categorization.</string>
     <string name="information_empty_category_dialog">You don\'t have any categories yet.</string>
     <string name="information_cloudflare_bypass_failure">Failed to bypass Cloudflare</string>
     <string name="information_cloudflare_help">Tap here for help with Cloudflare</string>


### PR DESCRIPTION
Something _like_ subcategories but _not_. As (briefly) discussed on #1152, this is something of an expanstion on categories as we have now as that is significantly easier to put into place on top of the current system and can serve as subcategories if so desired.

Basically implemented as being able to pin categories to a second set of categories on top of the regular set becoming 'Pinned Categories'. These pinned categories are then grouped outside the regular category groups leading to a double layer of grouping in the library. In effect the user basically has a distinct set of categories within each pinned category, though that is only when used as such. Since in the background they are just another category, if unpinned they go back to being a regular category with no issues.

**if y'all are interested or have any input GIMME**

## TODOs
- Category stuff in settings
	- Default category
		1. Split into default pin and default regular?
		2. Assume no pinned cat for defaults?
	- Global updates
		1. Seperate settings per pinned category?
		2. Pinned category selection over rules underlying categories?
		3. regular category settings overule pinned category settings?
		4. Only settings for regular categories?
- Remember category across different pinned categories in library
- Probably improve choose category dialog visuals (I don't like much but idk what's better)
- 'Show category tabs' off things
	- Tab title - <Pinned cat - cat> maybe?
	- Can't get to other pinned since not in pager
		- Library pager with pinned categorys one after the other?
- Library 'update category' update by pinned too

## Category select bars
<table>
<tr>
 <td> Default (when given no pinned category as normal)
 <td> As part of a pinned category, effectively giving a second library of categories.
<tr>
 <td> <img width="825" height="216" alt="image" src="https://github.com/user-attachments/assets/c1e846dd-2193-4677-baa3-8725c8b761cc" />
 <td> <img width="825" height="198" alt="image" src="https://github.com/user-attachments/assets/360705f7-0204-42dd-8c83-5135e7d6d96b" />
</table>

## Edit Categories Screen
Categories can be pinned on this screen to bring them to a second level of categorization.
<table>
<tr>
 <td> No pinned cats
 <td> With pinned cat
<tr>
 <td> <img width="821" height="1280" alt="image" src="https://github.com/user-attachments/assets/5730d0d0-b950-4150-8151-81cc30cc90a0" />
 <td> <img width="799" height="1253" alt="image" src="https://github.com/user-attachments/assets/72edd478-c30b-4b30-9ba2-d8f7eaa3e252" />
</table>

## Choose Categories Dialog
Pinned Categories seperated on this screen
<table>
<tr>
 <td> No pinned cats
 <td> With pinned cat
<tr>
 <td> <img width="352" height="573" alt="image" src="https://github.com/user-attachments/assets/e3f4eba6-199c-47ad-af50-f6292f6188b1" />
 <td> <img width="359" height="601" alt="image" src="https://github.com/user-attachments/assets/736499fc-aec3-4232-8eed-b20b38a19505" />
</table>