### PR TITLE
Add margins setting for paged view

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -66,6 +66,7 @@ object SettingsReaderScreen : SearchableSettings {
             getEInkGroup(readerPreferences = readerPref),
             getReadingGroup(readerPreferences = readerPref),
             getPagedGroup(readerPreferences = readerPref),
+            getPagedMarginsGroup(readerPreferences = readerPref),
             getWebtoonGroup(readerPreferences = readerPref),
             getNavigationGroup(readerPreferences = readerPref),
             getActionsGroup(readerPreferences = readerPref),
@@ -423,6 +424,56 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = readerPreferences.folderPerManga,
                     title = stringResource(MR.strings.pref_create_folder_per_manga),
                     subtitle = stringResource(MR.strings.pref_create_folder_per_manga_summary),
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getPagedMarginsGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
+        val pagerMarginTop by readerPreferences.pagerMarginTop.collectAsState()
+        val pagerMarginBottom by readerPreferences.pagerMarginBottom.collectAsState()
+        val pagerMarginLeft by readerPreferences.pagerMarginLeft.collectAsState()
+        val pagerMarginRight by readerPreferences.pagerMarginRight.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pager_margins),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SliderPreference(
+                    value = pagerMarginTop,
+                    valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+                    title = stringResource(MR.strings.top_margin),
+                    valueString = "${pagerMarginTop}${stringResource(MR.strings.pixels)}",
+                    onValueChanged = { readerPreferences.pagerMarginTop.set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = pagerMarginBottom,
+                    valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+                    title = stringResource(MR.strings.bottom_margin),
+                    valueString = "${pagerMarginBottom}${stringResource(MR.strings.pixels)}",
+                    onValueChanged = { readerPreferences.pagerMarginBottom.set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = pagerMarginLeft,
+                    valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+                    title = stringResource(MR.strings.left_margin),
+                    valueString = "${pagerMarginLeft}${stringResource(MR.strings.pixels)}",
+                    onValueChanged = { readerPreferences.pagerMarginLeft.set(it) },
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = pagerMarginRight,
+                    valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+                    title = stringResource(MR.strings.right_margin),
+                    valueString = "${pagerMarginRight}${stringResource(MR.strings.pixels)}",
+                    onValueChanged = { readerPreferences.pagerMarginRight.set(it) },
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = readerPreferences.pagerMarginColor,
+                    entries = ReaderPreferences.MarginColors
+                        .mapIndexed { index, it -> index to stringResource(it) }
+                        .toMap()
+                        .toImmutableMap(),
+                    title = stringResource(MR.strings.margin_color),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -134,6 +134,58 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
             pref = screenModel.preferences.dualPageRotateToFitInvert,
         )
     }
+
+    // Image margins
+    val pagerMarginTop by screenModel.preferences.pagerMarginTop.collectAsState()
+    SliderItem(
+        value = pagerMarginTop,
+        valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+        label = stringResource(MR.strings.top_margin),
+        valueString = "${pagerMarginTop}${stringResource(MR.strings.pixels)}",
+        onChange = { screenModel.preferences.pagerMarginTop.set(it) },
+        pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    )
+
+    val pagerMarginBottom by screenModel.preferences.pagerMarginBottom.collectAsState()
+    SliderItem(
+        value = pagerMarginBottom,
+        valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+        label = stringResource(MR.strings.bottom_margin),
+        valueString = "${pagerMarginBottom}${stringResource(MR.strings.pixels)}",
+        onChange = { screenModel.preferences.pagerMarginBottom.set(it) },
+        pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    )
+
+    val pagerMarginLeft by screenModel.preferences.pagerMarginLeft.collectAsState()
+    SliderItem(
+        value = pagerMarginLeft,
+        valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+        label = stringResource(MR.strings.left_margin),
+        valueString = "${pagerMarginLeft}${stringResource(MR.strings.pixels)}",
+        onChange = { screenModel.preferences.pagerMarginLeft.set(it) },
+        pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    )
+
+    val pagerMarginRight by screenModel.preferences.pagerMarginRight.collectAsState()
+    SliderItem(
+        value = pagerMarginRight,
+        valueRange = ReaderPreferences.PAGER_MARGIN_MIN..ReaderPreferences.PAGER_MARGIN_MAX,
+        label = stringResource(MR.strings.right_margin),
+        valueString = "${pagerMarginRight}${stringResource(MR.strings.pixels)}",
+        onChange = { screenModel.preferences.pagerMarginRight.set(it) },
+        pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+    )
+
+    val pagerMarginColor by screenModel.preferences.pagerMarginColor.collectAsState()
+    SettingsChipRow(MR.strings.margin_color) {
+        ReaderPreferences.MarginColors.mapIndexed { index, it ->
+            FilterChip(
+                selected = pagerMarginColor == index,
+                onClick = { screenModel.preferences.pagerMarginColor.set(index) },
+                label = { Text(stringResource(it)) },
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -173,6 +173,16 @@ class ReaderPreferences(
 
     // endregion
 
+    // region Image margins
+
+    val pagerMarginTop: Preference<Int> = preferenceStore.getInt("pager_margin_top", 0)
+    val pagerMarginBottom: Preference<Int> = preferenceStore.getInt("pager_margin_bottom", 0)
+    val pagerMarginLeft: Preference<Int> = preferenceStore.getInt("pager_margin_left", 0)
+    val pagerMarginRight: Preference<Int> = preferenceStore.getInt("pager_margin_right", 0)
+    val pagerMarginColor: Preference<Int> = preferenceStore.getInt("pager_margin_color", 0)
+
+    // endregion
+
     enum class FlashColor {
         BLACK,
         WHITE,
@@ -200,6 +210,9 @@ class ReaderPreferences(
     companion object {
         const val WEBTOON_PADDING_MIN = 0
         const val WEBTOON_PADDING_MAX = 25
+
+        const val PAGER_MARGIN_MIN = 0
+        const val PAGER_MARGIN_MAX = 75
 
         const val MILLI_CONVERSION = 100
 
@@ -246,5 +259,13 @@ class ReaderPreferences(
                 )
             }
         }
+
+        // Margin color options
+        val MarginColors = listOf(
+            MR.strings.margin_color_background,
+            MR.strings.margin_color_white,
+            MR.strings.margin_color_black,
+            MR.strings.margin_color_transparent,
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.pager
 
+import android.graphics.Color
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerConfig
@@ -46,6 +47,18 @@ class PagerConfig(
         private set
 
     var landscapeZoom = false
+        private set
+
+    // Image margins
+    var pagerMarginTop = 0
+        private set
+    var pagerMarginBottom = 0
+        private set
+    var pagerMarginLeft = 0
+        private set
+    var pagerMarginRight = 0
+        private set
+    var pagerMarginColorIndex = 0
         private set
 
     init {
@@ -106,6 +119,18 @@ class PagerConfig(
                 { dualPageRotateToFitInvert = it },
                 { imagePropertyChangedListener?.invoke() },
             )
+
+        // Image margin preferences
+        readerPreferences.pagerMarginTop
+            .register({ pagerMarginTop = it }, { imagePropertyChangedListener?.invoke() })
+        readerPreferences.pagerMarginBottom
+            .register({ pagerMarginBottom = it }, { imagePropertyChangedListener?.invoke() })
+        readerPreferences.pagerMarginLeft
+            .register({ pagerMarginLeft = it }, { imagePropertyChangedListener?.invoke() })
+        readerPreferences.pagerMarginRight
+            .register({ pagerMarginRight = it }, { imagePropertyChangedListener?.invoke() })
+        readerPreferences.pagerMarginColor
+            .register({ pagerMarginColorIndex = it }, { imagePropertyChangedListener?.invoke() })
     }
 
     private fun zoomTypeFromPreference(value: Int) {
@@ -148,5 +173,24 @@ class PagerConfig(
             else -> defaultNavigation()
         }
         navigationModeChangedListener?.invoke()
+    }
+
+    fun pageCanvasColor(): Int {
+        return when (theme) {
+            0 -> Color.WHITE
+            1 -> Color.BLACK
+            2 -> Color.GRAY
+            else -> Color.WHITE
+        }
+    }
+
+    fun pagerMarginColor(marginColorIndex: Int): Int {
+        return when (marginColorIndex) {
+            0 -> pageCanvasColor() // Background color
+            1 -> Color.WHITE // White
+            2 -> Color.BLACK // Black
+            3 -> Color.TRANSPARENT // Transparent
+            else -> pageCanvasColor() // Default to background color
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -153,12 +153,13 @@ class PagerPageHolder(
             val (source, isAnimated, background) = withIOContext {
                 val source = streamFn().use { process(item, Buffer().readFrom(it)) }
                 val isAnimated = ImageUtil.isAnimatedAndSupported(source)
+                val itemSourceMargins = if (!isAnimated) applyMargins(source) else source
                 val background = if (!isAnimated && viewer.config.automaticBackground) {
-                    ImageUtil.chooseBackground(context, source.peek().inputStream())
+                    ImageUtil.chooseBackground(context, itemSourceMargins.peek().inputStream())
                 } else {
                     null
                 }
-                Triple(source, isAnimated, background)
+                Triple(itemSourceMargins, isAnimated, background)
             }
             withUIContext {
                 setImage(
@@ -240,6 +241,24 @@ class PagerPageHolder(
     private fun onPageSplit(page: ReaderPage) {
         val newPage = InsertPage(page)
         viewer.onPageSplit(page, newPage)
+    }
+
+    private fun applyMargins(imageSource: BufferedSource): BufferedSource {
+        val config = viewer.config
+        if (config.pagerMarginTop == 0 && config.pagerMarginBottom == 0 &&
+            config.pagerMarginLeft == 0 && config.pagerMarginRight == 0
+        ) {
+            return imageSource
+        }
+
+        return ImageUtil.addImageMargins(
+            imageSource = imageSource,
+            marginTop = config.pagerMarginTop,
+            marginBottom = config.pagerMarginBottom,
+            marginLeft = config.pagerMarginLeft,
+            marginRight = config.pagerMarginRight,
+            marginColor = config.pagerMarginColor(config.pagerMarginColorIndex),
+        )
     }
 
     /**

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -193,6 +193,79 @@ object ImageUtil {
         return output
     }
 
+    /**
+     * Add margins around an image with specified color.
+     *
+     * @param imageSource The source image
+     * @param horizontalMargin Horizontal margin in pixels (applied to both left and right)
+     * @param verticalMargin Vertical margin in pixels (applied to both top and bottom)
+     * @param marginColor The color of the margins (ARGB format)
+     * @return New image with margins
+     */
+    fun addImageMargins(
+        imageSource: BufferedSource,
+        horizontalMargin: Int,
+        verticalMargin: Int,
+        marginColor: Int,
+    ): BufferedSource {
+        return addImageMargins(
+            imageSource = imageSource,
+            marginTop = verticalMargin,
+            marginBottom = verticalMargin,
+            marginLeft = horizontalMargin,
+            marginRight = horizontalMargin,
+            marginColor = marginColor,
+        )
+    }
+
+    /**
+     * Add individual margins around an image with specified color.
+     *
+     * @param imageSource The source image
+     * @param marginTop Top margin in pixels
+     * @param marginBottom Bottom margin in pixels
+     * @param marginLeft Left margin in pixels
+     * @param marginRight Right margin in pixels
+     * @param marginColor The color of the margins (ARGB format)
+     * @return New image with margins
+     */
+    fun addImageMargins(
+        imageSource: BufferedSource,
+        marginTop: Int,
+        marginBottom: Int,
+        marginLeft: Int,
+        marginRight: Int,
+        marginColor: Int,
+    ): BufferedSource {
+        if (marginTop == 0 && marginBottom == 0 && marginLeft == 0 && marginRight == 0) {
+            return imageSource
+        }
+
+        val imageBitmap = ImageDecoder.newInstance(imageSource.inputStream())?.decode()
+            ?: return imageSource
+
+        val originalWidth = imageBitmap.width
+        val originalHeight = imageBitmap.height
+        val newWidth = originalWidth + marginLeft + marginRight
+        val newHeight = originalHeight + marginTop + marginBottom
+
+        val result = createBitmap(newWidth, newHeight)
+        result.eraseColor(marginColor)
+
+        result.applyCanvas {
+            drawBitmap(
+                imageBitmap,
+                Rect(0, 0, originalWidth, originalHeight),
+                Rect(marginLeft, marginTop, marginLeft + originalWidth, marginTop + originalHeight),
+                null,
+            )
+        }
+
+        val output = Buffer()
+        result.compress(Bitmap.CompressFormat.JPEG, 100, output.outputStream())
+        return output
+    }
+
     enum class Side {
         RIGHT,
         LEFT,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1060,4 +1060,20 @@
     <string name="donationCampaign.paragraph3">Regardless, Mihon will continue to be maintained by me and the volunteers, and it will stay open source.</string>
     <string name="donationCampaign.contactPlatform">Discord</string>
     <string name="donationCampaign.dismiss">Dismiss</string>
+
+    <!-- Image margins -->
+    <string name="pager_margins">Paged Reader Margins</string>
+
+    <string name="top_margin">Top margin</string>
+    <string name="bottom_margin">Bottom margin</string>
+    <string name="left_margin">Left margin</string>
+    <string name="right_margin">Right margin</string>
+    <string name="margin_color">Margin color</string>
+
+    <string name="margin_color_background">Background color</string>
+    <string name="margin_color_white">White</string>
+    <string name="margin_color_black">Black</string>
+    <string name="margin_color_transparent">Transparent</string>
+
+    <string name="pixels">px</string>
 </resources>


### PR DESCRIPTION
DISCLAIMER: This was done with AI assistance. However I did review and polish the code before submitting it.

There are situations when a user may desire to add some margin to the full screen paged view, but still retain the Scale type setting (such as Fit to screen and so on).

For example, (my own issue that I wanted to fix) there are some e-ink devices that cut the display a tiny bit, so when viewing on full display, part of the image is being cut.
Additionally, some viewers may want to avoid round corners or the camera notch of their display.

This change adds 4 sliders for each side and color selection of the margin in the app settings and in the viewer mode.
It retains how things are done, unless you add a margin, and will also revert back if margin is 0. So it should not affect anyone unless they actually use this option.
I've decided to add a section name of it's own in the settings for better visibility.
I put the max value of the sliders to 75px, as more than this makes the slider buggy, but it's good enough to avoid the camera notch on a few devices I've tested.

I would appreciate any feedback for improvement, or any other approach to take here.