### PR TITLE
feat: Video page support in reader via ExoPlayer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -252,6 +252,10 @@ dependencies {
     }
     implementation(libs.image.decoder)
 
+    // Media playback (video support in reader)
+    implementation("androidx.media3:media3-exoplayer:1.4.1")
+    implementation("androidx.media3:media3-ui:1.4.1")
+
     // UI libraries
     implementation(libs.material)
     implementation(libs.flexibleAdapter)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -122,11 +122,16 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
 
     /**
      * Creates a new view for the item at the given [position].
+     * Supports video pages via VideoPageHolder when the page URL is a video file.
      */
     override fun createView(container: ViewGroup, position: Int): View {
-        return when (val item = items[position]) {
-            is ReaderPage -> PagerPageHolder(readerThemedContext, viewer, item)
-            is ChapterTransition -> PagerTransitionHolder(readerThemedContext, viewer, item)
+        val item = items[position]
+        return when {
+            item is ReaderPage && item.url.isVideoUrl() -> {
+                VideoPageHolder(readerThemedContext, viewer, item)
+            }
+            item is ReaderPage -> PagerPageHolder(readerThemedContext, viewer, item)
+            item is ChapterTransition -> PagerTransitionHolder(readerThemedContext, viewer, item)
             else -> throw NotImplementedError("Holder for ${item.javaClass} not implemented")
         }
     }
@@ -188,4 +193,14 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
     fun refresh() {
         readerThemedContext = viewer.activity.createReaderThemeContext()
     }
+}
+
+/**
+ * Check if a URL string is a video file URL.
+ * Used to determine whether to create a VideoPageHolder or PagerPageHolder.
+ */
+private fun String.isVideoUrl(): Boolean {
+    val lower = lowercase()
+    return lower.endsWith(".mp4") || lower.endsWith(".m3u8") ||
+        lower.endsWith(".ts") || lower.endsWith(".mkv") || lower.endsWith(".webm")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/VideoPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/VideoPageHolder.kt
@@ -1,0 +1,174 @@
+package eu.kanade.tachiyomi.ui.reader.viewer.pager
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
+import eu.kanade.tachiyomi.widget.ViewPagerAdapter
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import tachiyomi.core.common.util.lang.launchUI
+import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.core.common.util.system.logcat
+
+/**
+ * View of the ViewPager that contains a video page. Uses ExoPlayer for playback.
+ */
+@SuppressLint("ViewConstructor")
+class VideoPageHolder(
+    readerThemedContext: Context,
+    val viewer: PagerViewer,
+    val page: ReaderPage,
+) : FrameLayout(readerThemedContext), ViewPagerAdapter.PositionableView {
+
+    override val item
+        get() = page
+
+    private var player: ExoPlayer? = null
+    private var playerView: PlayerView? = null
+    private var progressIndicator: ReaderProgressIndicator? = null
+    private var errorLayout: ReaderErrorBinding? = null
+    private val scope = MainScope()
+    private var loadJob: Job? = null
+
+    private var playWhenReady = false
+
+    init {
+        layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+        setBackgroundColor(0xFF000000.toInt())
+        loadJob = scope.launch { loadVideoAndProcessStatus() }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        loadJob?.cancel()
+        loadJob = null
+        releasePlayer()
+    }
+
+    private fun releasePlayer() {
+        player?.stop()
+        player?.release()
+        player = null
+        playerView?.player = null
+    }
+
+    private fun initProgressIndicator() {
+        if (progressIndicator == null) {
+            progressIndicator = ReaderProgressIndicator(context)
+            addView(progressIndicator)
+        }
+    }
+
+    private suspend fun loadVideoAndProcessStatus() {
+        val videoUrl = page.url
+        if (videoUrl.isBlank() || !videoUrl.isVideoUrl()) {
+            setError(IllegalArgumentException("Invalid video URL: $videoUrl"))
+            return
+        }
+
+        initProgressIndicator()
+        progressIndicator?.show()
+
+        try {
+            val player = ExoPlayer.Builder(context).build()
+            this.player = player
+
+            val playerView = PlayerView(context).apply {
+                this.player = player
+                useController = true
+                layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+            }
+            this.playerView = playerView
+
+            val mediaItem = MediaItem.fromUri(videoUrl)
+            player.setMediaItem(mediaItem)
+            player.prepare()
+            player.playWhenReady = playWhenReady
+
+            player.addListener(object : Player.Listener {
+                override fun onPlaybackStateChanged(state: Int) {
+                    when (state) {
+                        Player.STATE_READY -> {
+                            withUIContext {
+                                progressIndicator?.hide()
+                                if (playerView?.parent == null) {
+                                    addView(playerView, 0)
+                                }
+                            }
+                        }
+                        Player.STATE_BUFFERING -> {
+                            withUIContext {
+                                progressIndicator?.show()
+                            }
+                        }
+                        Player.STATE_ENDED -> {
+                            player.seekTo(0)
+                            player.playWhenReady = false
+                        }
+                        Player.STATE_IDLE -> {}
+                    }
+                }
+
+                override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                    withUIContext {
+                        setError(error)
+                    }
+                }
+            })
+
+            withUIContext {
+                addView(playerView)
+            }
+
+        } catch (e: Exception) {
+            logcat(e)
+            withUIContext {
+                setError(e)
+            }
+        }
+    }
+
+    fun pause() {
+        playWhenReady = player?.playWhenReady ?: false
+        player?.playWhenReady = false
+    }
+
+    fun resume() {
+        player?.playWhenReady = playWhenReady
+    }
+
+    private fun setError(error: Throwable?) {
+        progressIndicator?.hide()
+        if (errorLayout == null) {
+            errorLayout = ReaderErrorBinding.inflate(LayoutInflater.from(context), this, true)
+            errorLayout?.actionRetry?.viewer = viewer
+            errorLayout?.actionRetry?.setOnClickListener {
+                releasePlayer()
+                loadJob = scope.launch { loadVideoAndProcessStatus() }
+            }
+        }
+        errorLayout?.errorMessage?.text = error?.message ?: "Video playback error"
+        errorLayout?.root?.isVisible = true
+    }
+}
+
+private fun String.isVideoUrl(): Boolean {
+    return endsWith(".mp4", true) ||
+        endsWith(".m3u8", true) ||
+        endsWith(".ts", true) ||
+        endsWith(".mkv", true) ||
+        endsWith(".webm", true)
+}


### PR DESCRIPTION
## Summary

Adds in-reader video playback support to Mihon. When a chapter page has a video URL (mp4/m3u8/ts/mkv/webm), it renders a native ExoPlayer video player instead of an image viewer.

## How It Works

1. **Extension side**: When creating `Page` objects from a source, if `page.url` ends with a video extension, the reader creates a `VideoPageHolder`.
2. **Reader side**: `PagerViewerAdapter.createView()` checks `page.url.isVideoUrl()` — if true, creates `VideoPageHolder` instead of `PagerPageHolder`.
3. `VideoPageHolder` uses Media3 ExoPlayer for playback with full controls (play/pause/seek).
4. Audio auto-pauses when swiping away (MVP: release on detach, resume-ready).

## Changes

| File | What |
|---|---|
| `build.gradle.kts` | Added `media3-exoplayer:1.4.1` + `media3-ui:1.4.1` |
| `VideoPageHolder.kt` | New: ExoPlayer-based page holder for video pages |
| `PagerViewerAdapter.kt` | Route video pages to `VideoPageHolder` |

## Compatibility

- Non-video pages behave identically (no behavior change)
- Only pages with `.mp4/.m3u8/.ts/.mkv/.webm` URLs are treated as video
- Falls back to error state if playback fails

## Backwards

Fully backwards compatible. Sources that don't produce video pages see zero difference.