### PR TITLE
Add option to hide Last Used sources section

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
@@ -17,12 +17,19 @@ class GetEnabledSources(
 
     fun subscribe(): Flow<List<Source>> {
         return combine(
-            preferences.pinnedSources.changes(),
-            preferences.enabledLanguages.changes(),
-            preferences.disabledSources.changes(),
-            preferences.lastUsedSource.changes(),
-            repository.getSources(),
-        ) { pinnedSourceIds, enabledLanguages, disabledSources, lastUsedSource, sources ->
+            combine(
+                preferences.pinnedSources.changes(),
+                preferences.enabledLanguages.changes(),
+                preferences.disabledSources.changes(),
+                ::Triple,
+            ),
+            combine(
+                preferences.lastUsedSource.changes(),
+                preferences.showLastUsedSource.changes(),
+                repository.getSources(),
+                ::Triple,
+            ),
+        ) { (pinnedSourceIds, enabledLanguages, disabledSources), (lastUsedSource, showLastUsedSource, sources) ->
             sources
                 .filter { it.lang in enabledLanguages || it.isLocal() }
                 .filterNot { it.id.toString() in disabledSources }
@@ -31,7 +38,7 @@ class GetEnabledSources(
                     val flag = if ("${it.id}" in pinnedSourceIds) Pins.pinned else Pins.unpinned
                     val source = it.copy(pin = flag)
                     val toFlatten = mutableListOf(source)
-                    if (source.id == lastUsedSource) {
+                    if (showLastUsedSource && source.id == lastUsedSource) {
                         toFlatten.add(source.copy(isUsedLast = true, pin = source.pin - Pin.Actual))
                     }
                     toFlatten

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -36,6 +36,11 @@ class SourcePreferences(
         -1,
     )
 
+    val showLastUsedSource: Preference<Boolean> = preferenceStore.getBoolean(
+        "show_last_used_source",
+        true,
+    )
+
     val showNsfwSource: Preference<Boolean> = preferenceStore.getBoolean("show_nsfw_source", true)
 
     val migrationSortingMode: Preference<SetMigrateSorting.Mode> = preferenceStore.getEnum(

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -1,7 +1,10 @@
 package eu.kanade.presentation.browse
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -16,7 +19,17 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.filled.MoreHoriz
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -45,7 +58,25 @@ fun SourcesScreen(
     onClickItem: (Source, Listing) -> Unit,
     onClickPin: (Source) -> Unit,
     onLongClickItem: (Source) -> Unit,
+    onClickHideLastUsed: () -> Unit,
 ) {
+    var isLastUsedCollapsed by rememberSaveable { mutableStateOf(false) }
+
+    val itemsToDisplay = remember(state.items, isLastUsedCollapsed) {
+        if (!isLastUsedCollapsed) return@remember state.items
+
+        var skipping = false
+        state.items.filter { model ->
+            when (model) {
+                is SourceUiModel.Header -> {
+                    skipping = model.language == SourcesScreenModel.LAST_USED_KEY
+                    true
+                }
+                is SourceUiModel.Item -> !skipping
+            }
+        }
+    }
+
     when {
         state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
         state.isEmpty -> EmptyScreen(
@@ -57,7 +88,7 @@ fun SourcesScreen(
                 contentPadding = contentPadding + topSmallPaddingValues,
             ) {
                 items(
-                    items = state.items,
+                    items = itemsToDisplay,
                     contentType = {
                         when (it) {
                             is SourceUiModel.Header -> "header"
@@ -76,6 +107,12 @@ fun SourcesScreen(
                             SourceHeader(
                                 modifier = Modifier.animateItem(),
                                 language = model.language,
+                                onClickHideLastUsed = onClickHideLastUsed,
+                                onClickToggleCollapse = {
+                                    if (model.language == SourcesScreenModel.LAST_USED_KEY) {
+                                        isLastUsedCollapsed = !isLastUsedCollapsed
+                                    }
+                                },
                             )
                         }
                         is SourceUiModel.Item -> SourceItem(
@@ -96,14 +133,55 @@ fun SourcesScreen(
 private fun SourceHeader(
     language: String,
     modifier: Modifier = Modifier,
+    onClickHideLastUsed: () -> Unit,
+    onClickToggleCollapse: () -> Unit = {},
 ) {
     val context = LocalContext.current
-    Text(
-        text = LocaleHelper.getSourceDisplayName(language, context),
-        modifier = modifier
-            .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
-        style = MaterialTheme.typography.header,
-    )
+    if (language == SourcesScreenModel.LAST_USED_KEY) {
+        var isMenuExpanded by remember { mutableStateOf(false) }
+
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClickToggleCollapse)
+                .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = LocaleHelper.getSourceDisplayName(language, context),
+                style = MaterialTheme.typography.header,
+            )
+
+            Box {
+                IconButton(onClick = { isMenuExpanded = true }) {
+                    Icon(
+                        imageVector = Icons.Default.MoreHoriz,
+                        contentDescription = stringResource(MR.strings.label_more),
+                    )
+                }
+                DropdownMenu(
+                    expanded = isMenuExpanded,
+                    onDismissRequest = { isMenuExpanded = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(text = stringResource(MR.strings.action_hide)) },
+                        onClick = {
+                            isMenuExpanded = false
+                            onClickHideLastUsed()
+                        },
+                    )
+                }
+            }
+        }
+    } else {
+        Text(
+            text = LocaleHelper.getSourceDisplayName(language, context),
+            modifier = modifier
+                .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
+            style = MaterialTheme.typography.header,
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
@@ -46,6 +46,10 @@ object SettingsBrowseScreen : SearchableSettings {
                         preference = sourcePreferences.hideInLibraryItems,
                         title = stringResource(MR.strings.pref_hide_in_library_items),
                     ),
+                    Preference.PreferenceItem.SwitchPreference(
+                        preference = sourcePreferences.showLastUsedSource,
+                        title = stringResource(MR.strings.pref_show_last_used_source),
+                    ),
                     Preference.PreferenceItem.TextPreference(
                         title = stringResource(MR.strings.label_extension_repos),
                         subtitle = pluralStringResource(MR.plurals.num_repos, reposCount, reposCount),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
@@ -6,6 +6,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.source.interactor.GetEnabledSources
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.browse.SourceUiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -28,6 +29,7 @@ class SourcesScreenModel(
     private val getEnabledSources: GetEnabledSources = Injekt.get(),
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : StateScreenModel<SourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -96,6 +98,10 @@ class SourcesScreenModel(
 
     fun closeDialog() {
         mutableState.update { it.copy(dialog = null) }
+    }
+
+    fun hideLastUsedSource() {
+        sourcePreferences.showLastUsedSource.set(false)
     }
 
     sealed interface Event {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -52,6 +52,7 @@ fun Screen.sourcesTab(): TabContent {
                 },
                 onClickPin = screenModel::togglePin,
                 onLongClickItem = screenModel::showSourceDialog,
+                onClickHideLastUsed = screenModel::hideLastUsedSource,
             )
 
             state.dialog?.let { dialog ->

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -85,6 +85,7 @@
     <string name="action_bookmark">Bookmark chapter</string>
     <string name="action_remove_bookmark">Unbookmark chapter</string>
     <string name="action_delete">Delete</string>
+    <string name="action_hide">Hide</string>
     <string name="action_update_library">Update library</string>
     <string name="action_enable_all">Enable all</string>
     <string name="action_disable_all">Disable all</string>
@@ -693,6 +694,7 @@
     <string name="local_source">Local source</string>
     <string name="other_source">Other</string>
     <string name="last_used_source">Last used</string>
+    <string name="pref_show_last_used_source">Show "Last used" source</string>
     <string name="pinned_sources">Pinned</string>
     <string name="action_global_search_hint">Global search…</string>
     <string name="action_global_search_query">Search for \"%1$s\" globally</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

Closes #3235

Added the requested feature. An option to completely hide the "Last Used" sources section. 
in detail :
Tapping the "Last Used" section collapses its contents while leaving the section visible. and added a three dots beside the title where it contains "hide". When Hide is selected, the entire "Last Used" section is removed from the Sources screen.
you can again enable it :
Settings → Browse → Sources → Show "Last Used" source. 