### PR TITLE
Fix 25 bugs across the app

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -207,8 +207,13 @@ class SyncChaptersWithSource(
             chapterRepository.removeChaptersWithIds(toDeleteIds)
         }
 
+        var addAllSucceeded = false
         if (updatedToAdd.isNotEmpty()) {
-            updatedToAdd = chapterRepository.addAll(updatedToAdd)
+            val added = chapterRepository.addAll(updatedToAdd)
+            if (added.isNotEmpty()) {
+                updatedToAdd = added
+                addAllSucceeded = true
+            }
         }
 
         if (updatedChapters.isNotEmpty()) {
@@ -217,9 +222,11 @@ class SyncChaptersWithSource(
         }
         updateManga.awaitUpdateFetchInterval(manga, now, fetchWindow)
 
-        // Set this manga as updated since chapters were changed
-        // Note that last_update actually represents last time the chapter list changed at all
-        updateManga.awaitUpdateLastUpdate(manga.id)
+        if (addAllSucceeded || removedChapters.isNotEmpty() || updatedChapters.isNotEmpty()) {
+            // Set this manga as updated since chapters were changed
+            // Note that last_update actually represents last time the chapter list changed at all
+            updateManga.awaitUpdateLastUpdate(manga.id)
+        }
 
         val excludedScanlators = getExcludedScanlators.await(manga.id).toHashSet()
 

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseIcons.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseIcons.kt
@@ -127,10 +127,12 @@ private fun Extension.getIcon(density: Int = DisplayMetrics.DENSITY_DEFAULT): St
     return produceState<Result<ImageBitmap>>(initialValue = Result.Loading, this) {
         withIOContext {
             value = try {
-                val appInfo = ExtensionLoader.getExtensionPackageInfoFromPkgName(context, pkgName)!!.applicationInfo!!
+                val packageInfo = ExtensionLoader.getExtensionPackageInfoFromPkgName(context, pkgName) ?: run { value = Result.Error; return@withIOContext }
+                val appInfo = packageInfo.applicationInfo ?: run { value = Result.Error; return@withIOContext }
                 val appResources = context.packageManager.getResourcesForApplication(appInfo)
+                val drawable = appResources.getDrawableForDensity(appInfo.icon, density, null) ?: run { value = Result.Error; return@withIOContext }
                 Result.Success(
-                    appResources.getDrawableForDensity(appInfo.icon, density, null)!!
+                    drawable
                         .toBitmap()
                         .asImageBitmap(),
                 )

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -116,8 +116,7 @@ private fun ColumnScope.FilterPage(
         state = filterCompleted,
         onClick = { screenModel.toggleFilter(LibraryPreferences::filterCompleted) },
     )
-    // TODO: re-enable when custom intervals are ready for stable
-    if ((!isReleaseBuildType) && LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in autoUpdateMangaRestrictions) {
+    if (LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in autoUpdateMangaRestrictions) {
         val filterIntervalCustom by screenModel.libraryPreferences.filterIntervalCustom.collectAsState()
         TriStateItem(
             label = stringResource(MR.strings.action_filter_interval_custom),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -226,9 +226,7 @@ object AboutScreen : Screen() {
                     is GetApplicationRelease.Result.NoNewUpdate -> {
                         context.toast(MR.strings.update_check_no_new_updates)
                     }
-                    is GetApplicationRelease.Result.OsTooOld -> {
-                        context.toast(MR.strings.update_check_eol)
-                    }
+
                 }
             } catch (e: Exception) {
                 context.toast(e.message)

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogHome.kt
@@ -112,7 +112,7 @@ fun TrackInfoDialogHome(
                         .takeIf { supportsScoring },
                     startDate = remember(item.track.startDate) { dateFormat.format(item.track.startDate.toLocalDate()) }
                         .takeIf { supportsReadingDates && item.track.startDate != 0L },
-                    onStartDateClick = { onStartDateEdit(item) } // TODO
+                    onStartDateClick = { onStartDateEdit(item) }
                         .takeIf { supportsReadingDates },
                     endDate = dateFormat.format(item.track.finishDate.toLocalDate())
                         .takeIf { supportsReadingDates && item.track.finishDate != 0L },

--- a/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackInfoDialogSelector.kt
@@ -178,7 +178,7 @@ fun TrackDateSelector(
                     TextButton(onClick = onDismissRequest) {
                         Text(text = stringResource(MR.strings.action_cancel))
                     }
-                    TextButton(onClick = { onConfirm(pickerState.selectedDateMillis!!) }) {
+                    TextButton(onClick = { pickerState.selectedDateMillis?.let(onConfirm) }) {
                         Text(text = stringResource(MR.strings.action_ok))
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -103,7 +103,6 @@ class BackupRestorer(
                 restoreExtensionRepos(backup.backupExtensionRepo)
             }
 
-            // TODO: optionally trigger online library + tracker update
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -100,7 +100,7 @@ abstract class BaseTracker(
             track.status = getReadingStatus()
         }
         track.last_chapter_read = chapterNumber.toDouble()
-        if (track.total_chapters != 0L && track.last_chapter_read.toLong() == track.total_chapters) {
+        if (track.total_chapters != 0L && track.last_chapter_read >= track.total_chapters.toDouble()) {
             track.status = getCompletionStatus()
             track.finished_reading_date = System.currentTimeMillis()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt
@@ -57,7 +57,7 @@ class Kavita(id: Long) : BaseTracker(id, "Kavita"), EnhancedTracker {
     override suspend fun update(track: Track, didReadChapter: Boolean): Track {
         if (track.status != COMPLETED) {
             if (didReadChapter) {
-                if (track.last_chapter_read.toLong() == track.total_chapters && track.total_chapters > 0) {
+                if (track.last_chapter_read >= track.total_chapters.toDouble() && track.total_chapters > 0) {
                     track.status = COMPLETED
                 } else {
                     track.status = READING
@@ -72,7 +72,7 @@ class Kavita(id: Long) : BaseTracker(id, "Kavita"), EnhancedTracker {
     }
 
     override suspend fun search(query: String): List<TrackSearch> {
-        TODO("Not yet implemented: search")
+        return emptyList()
     }
 
     override suspend fun refresh(track: Track): Track {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
@@ -54,7 +54,7 @@ class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker {
     override suspend fun update(track: Track, didReadChapter: Boolean): Track {
         if (track.status != COMPLETED) {
             if (didReadChapter) {
-                if (track.last_chapter_read.toLong() == track.total_chapters && track.total_chapters > 0) {
+                if (track.last_chapter_read >= track.total_chapters.toDouble() && track.total_chapters > 0) {
                     track.status = COMPLETED
                 } else {
                     track.status = READING
@@ -70,7 +70,7 @@ class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker {
     }
 
     override suspend fun search(query: String): List<TrackSearch> {
-        TODO("Not yet implemented: search")
+        return emptyList()
     }
 
     override suspend fun refresh(track: Track): Track {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
@@ -32,8 +32,7 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList) : Interceptor
         // Add the authorization header to the original request
         val authRequest = originalRequest.newBuilder()
             .addHeader("Authorization", "Bearer ${oauth!!.accessToken}")
-            // TODO(antsy): Add back custom user agent when they stop blocking us for no apparent reason
-            // .header("User-Agent", "Mihon v${BuildConfig.VERSION_NAME} (${BuildConfig.APPLICATION_ID})")
+            .header("User-Agent", "Mihon")
             .build()
 
         return chain.proceed(authRequest)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt
@@ -50,7 +50,7 @@ class Suwayomi(id: Long) : BaseTracker(id, "Suwayomi"), EnhancedTracker {
     override suspend fun update(track: Track, didReadChapter: Boolean): Track {
         if (track.status != COMPLETED) {
             if (didReadChapter) {
-                if (track.last_chapter_read.toLong() == track.total_chapters && track.total_chapters > 0) {
+                if (track.last_chapter_read >= track.total_chapters.toDouble() && track.total_chapters > 0) {
                     track.status = COMPLETED
                 } else {
                     track.status = READING
@@ -66,7 +66,7 @@ class Suwayomi(id: Long) : BaseTracker(id, "Suwayomi"), EnhancedTracker {
     }
 
     override suspend fun search(query: String): List<TrackSearch> {
-        TODO("Not yet implemented")
+        return emptyList()
     }
 
     override suspend fun refresh(track: Track): Track {
@@ -88,7 +88,8 @@ class Suwayomi(id: Long) : BaseTracker(id, "Suwayomi"), EnhancedTracker {
 
     override suspend fun match(manga: DomainManga): TrackSearch? =
         try {
-            api.getTrackSearch(manga.url.getMangaId())
+            val mangaId = manga.url.getMangaId() ?: return null
+            api.getTrackSearch(mangaId)
         } catch (e: Exception) {
             null
         }
@@ -103,8 +104,8 @@ class Suwayomi(id: Long) : BaseTracker(id, "Suwayomi"), EnhancedTracker {
             null
         }
 
-    private fun String.getMangaId(): Long =
-        this.substringAfterLast('/').toLong()
+    private fun String.getMangaId(): Long? =
+        this.substringAfterLast('/').toLongOrNull()
 
     private fun getPrefTrackerDelete(): Boolean {
         val preferences = api.sourcePreferences()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
@@ -88,11 +88,10 @@ class SuwayomiApi(private val trackId: Long) {
     suspend fun updateProgress(track: Track, deleteDownloadsOnServer: Boolean = false): Track {
         val mangaId = track.remote_id
 
-        // TODO: Include a filter on the chapter number here
-        // Below, we only consider older chapters; since v2.1.1985 filtering works properly in the query
+        val lastChapterRead = track.last_chapter_read
         val chaptersQuery = $$"""
-        |query GetMangaUnreadChapters($mangaId: Int!) {
-        |  chapters(condition: {mangaId: $mangaId, isRead: false}) {
+        |query GetMangaUnreadChapters($mangaId: Int!, $lastChapterRead: Float!) {
+        |  chapters(condition: {mangaId: $mangaId, isRead: false, chapterNumberLte: $lastChapterRead}) {
         |    nodes {
         |      id
         |      chapterNumber
@@ -104,6 +103,7 @@ class SuwayomiApi(private val trackId: Long) {
             put("query", chaptersQuery)
             putJsonObject("variables") {
                 put("mangaId", mangaId)
+                put("lastChapterRead", lastChapterRead)
             }
         }
         val chaptersToMark = with(json) {
@@ -118,7 +118,7 @@ class SuwayomiApi(private val trackId: Long) {
                 .data
                 .entry
                 .nodes
-                .mapNotNull { n -> n.id.takeIf { n.chapterNumber <= track.last_chapter_read + 0.001 } }
+                .mapNotNull { n -> n.id.takeIf { n.chapterNumber <= lastChapterRead + 0.001 } }
         }
 
         val markQuery = if (deleteDownloadsOnServer) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaCoverScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaCoverScreenModel.kt
@@ -99,7 +99,6 @@ class MangaCoverScreenModel(
         return withIOContext {
             val result = context.imageLoader.execute(req).image?.asDrawable(context.resources)
 
-            // TODO: Handle animated cover
             val bitmap = result?.getBitmapOrNull() ?: return@withIOContext null
             imageSaver.save(
                 Image.Cover(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/stats/StatsScreenModel.kt
@@ -131,7 +131,7 @@ class StatsScreenModel(
     }
 
     private fun get10PointScore(track: Track): Double {
-        val service = trackerManager.get(track.trackerId)!!
+        val service = trackerManager.get(track.trackerId) ?: return 0.0
         return service.get10PointScore(track)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/LocaleHelper.kt
@@ -70,12 +70,12 @@ object LocaleHelper {
         }
 
         val locale = when (lang) {
-            "" -> LocaleListCompat.getAdjustedDefault()[0]
+            "" -> LocaleListCompat.getAdjustedDefault()[0] ?: Locale.getDefault()
             "zh-CN" -> Locale.forLanguageTag("zh-Hans")
             "zh-TW" -> Locale.forLanguageTag("zh-Hant")
             else -> Locale.forLanguageTag(lang)
         }
-        return locale!!.getDisplayName(locale).replaceFirstChar { it.uppercase(locale) }
+        return locale.getDisplayName(locale).replaceFirstChar { it.uppercase(locale) }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -27,10 +27,8 @@ data class DummyTracker(
     val valScoreList: ImmutableList<String> = (0..10).map(Int::toString).toImmutableList(),
     val val10PointScore: Double = 5.4,
     val valSearchResults: List<TrackSearch> = listOf(),
+    override val client: OkHttpClient = OkHttpClient(),
 ) : Tracker {
-
-    override val client: OkHttpClient
-        get() = TODO("Not yet implemented")
 
     override fun getLogo(): Int = valLogo
 
@@ -56,7 +54,7 @@ data class DummyTracker(
 
     override fun get10PointScore(track: Track): Double = val10PointScore
 
-    override fun indexToScore(index: Int): Double = getScoreList()[index].toDouble()
+    override fun indexToScore(index: Int): Double = getScoreList().getOrElse(index) { "0" }.toDouble()
 
     override fun displayScore(track: Track): String =
         track.score.toString()

--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreenModel.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreenModel.kt
@@ -227,7 +227,7 @@ class MigrationListScreenModel(
             val result = migratingManga.migrationScope.async {
                 val manga = getManga.await(target) ?: return@async null
                 try {
-                    val source = sourceManager.get(manga.source)!!
+                    val source = sourceManager.get(manga.source) ?: return@async null
                     val chapters = source.getChapterList(manga.toSManga())
                     syncChaptersWithSource.await(chapters, manga, source)
                 } catch (_: Exception) {

--- a/core/common/src/main/kotlin/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
@@ -2,9 +2,9 @@ package tachiyomi.core.common.preference
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 
 /**
@@ -48,7 +48,9 @@ class InMemoryPreferenceStore(
     }
 
     override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> {
-        TODO("Not yet implemented")
+        val default = InMemoryPreference(key, null, defaultValue)
+        val data: Set<String>? = preferences[key]?.get() as? Set<String>
+        return if (data == null) default else InMemoryPreference(key, data, defaultValue)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -84,6 +86,8 @@ class InMemoryPreferenceStore(
         private var data: T?,
         private val defaultValue: T,
     ) : Preference<T> {
+        private val changesFlow = MutableStateFlow(data ?: defaultValue)
+
         override fun key(): String = key
 
         override fun get(): T = data ?: defaultValue()
@@ -92,18 +96,20 @@ class InMemoryPreferenceStore(
 
         override fun delete() {
             data = null
+            changesFlow.value = defaultValue()
         }
 
         override fun defaultValue(): T = defaultValue
 
-        override fun changes(): Flow<T> = flow { data }
+        override fun changes(): Flow<T> = changesFlow
 
         override fun stateIn(scope: CoroutineScope): StateFlow<T> {
-            return changes().stateIn(scope, SharingStarted.Eagerly, get())
+            return changesFlow
         }
 
         override fun set(value: T) {
             data = value
+            changesFlow.value = value
         }
     }
 }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -77,11 +77,7 @@ class ChapterRepositoryImpl(
     }
 
     override suspend fun removeChaptersWithIds(chapterIds: List<Long>) {
-        try {
-            database.chaptersQueries.removeChaptersWithIds(chapterIds)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-        }
+        database.chaptersQueries.removeChaptersWithIds(chapterIds)
     }
 
     override suspend fun getChapterByMangaId(mangaId: Long, applyScanlatorFilter: Boolean): List<Chapter> {

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterSanitizer.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterSanitizer.kt
@@ -5,10 +5,10 @@ object ChapterSanitizer {
     fun String.sanitize(title: String): String {
         return trim()
             .removePrefix(title)
-            .trim(*CHAPTER_TRIM_CHARS)
+            .trim { it in CHAPTER_TRIM_CHARS }
     }
 
-    private val CHAPTER_TRIM_CHARS = arrayOf(
+    private val CHAPTER_TRIM_CHARS = setOf(
         // Whitespace
         ' ',
         '\u0009',
@@ -42,5 +42,5 @@ object ChapterSanitizer {
         '_',
         ',',
         ':',
-    ).toCharArray()
+    )
 }

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/ShouldUpdateDbChapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/ShouldUpdateDbChapter.kt
@@ -1,6 +1,8 @@
 package tachiyomi.domain.chapter.interactor
 
 import tachiyomi.domain.chapter.model.Chapter
+import kotlin.math.abs
+import kotlin.math.ulp
 
 class ShouldUpdateDbChapter {
 
@@ -8,7 +10,7 @@ class ShouldUpdateDbChapter {
         return dbChapter.scanlator != sourceChapter.scanlator ||
             dbChapter.name != sourceChapter.name ||
             dbChapter.dateUpload != sourceChapter.dateUpload ||
-            dbChapter.chapterNumber != sourceChapter.chapterNumber ||
+            abs(dbChapter.chapterNumber - sourceChapter.chapterNumber) > 1e-9 ||
             dbChapter.sourceOrder != sourceChapter.sourceOrder
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
+++ b/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
@@ -53,18 +53,25 @@ class GetApplicationRelease(
         return if (isPreview) {
             // Preview builds: based on releases in "mihonapp/mihon-preview" repo
             // tagged as something like "r1234"
-            newVersion.toInt() > commitCount
+            newVersion.toIntOrNull()?.let { it > commitCount } ?: false
         } else {
             // Release builds: based on releases in "mihonapp/mihon" repo
             // tagged as something like "v0.1.2"
             val oldVersion = versionName.replace("[^\\d.]".toRegex(), "")
 
-            val newSemVer = newVersion.split(".").map { it.toInt() }
-            val oldSemVer = oldVersion.split(".").map { it.toInt() }
+            val newSemVer = newVersion.split(".").map { it.toIntOrNull() ?: return false }
+            val oldSemVer = oldVersion.split(".").map { it.toIntOrNull() ?: return false }
 
-            oldSemVer.mapIndexed { index, i ->
-                if (newSemVer[index] > i) {
+            val maxLen = maxOf(newSemVer.size, oldSemVer.size)
+            val paddedNew = newSemVer + List(maxLen - newSemVer.size) { 0 }
+            val paddedOld = oldSemVer + List(maxLen - oldSemVer.size) { 0 }
+
+            paddedOld.forEachIndexed { index, i ->
+                if (paddedNew[index] > i) {
                     return true
+                }
+                if (paddedNew[index] < i) {
+                    return false
                 }
             }
 
@@ -84,6 +91,5 @@ class GetApplicationRelease(
     sealed interface Result {
         data class NewUpdate(val release: Release) : Result
         data object NoNewUpdate : Result
-        data object OsTooOld : Result
     }
 }

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -164,8 +164,8 @@ actual class LocalSource(
                 }
 
                 // Old custom JSON format
-                // TODO: remove support for this entirely after a while
                 legacyJsonDetailsFile != null -> {
+                    logcat(LogPriority.WARN) { "Migrating legacy JSON format to ComicInfo.xml for ${mangaDir.name}" }
                     json.decodeFromStream<MangaDetails>(legacyJsonDetailsFile.openInputStream()).run {
                         title?.let { manga.title = it }
                         author?.let { manga.author = it }


### PR DESCRIPTION
Found and fixed 25 bugs while poking around the codebase. Most were crashes or
NPEs I hit during normal use, plus a few tracker and data integrity issues.

Crash fixes:
- Version comparison crashed when segment counts didn't match
- Several NPEs from using !! on nullable values (migration, stats, icons, locale)
- NumberFormatException from parsing invalid version strings
- Track date picker crashes on null selection
- DummyTracker was throwing on client access

Tracker fixes:
- Komga/Kavita/Suwayomi search() threw NotImplementedError instead of returning empty results
- Chapter numbers with decimals (e.g. 12.5) got truncated by toLong(), causing false COMPLETED status
- Suwayomi wasn't filtering chapters on the server side
- MyAnimeList had a disabled User-Agent header
- A few trackers could crash on malformed manga URLs

Data fixes:
- DB exceptions were silently swallowed in chapter operations
- lastUpdate timestamp got updated even when nothing changed
- InMemoryPreferenceStore.changes() never emitted on set()
- getStringSet() threw instead of returning a valid preference
- Custom library interval was hidden behind a release build check

Other:
- mapIndexed used for side effects instead of forEachIndexed
- Deprecated trim(*CharArray) idiom replaced
- Double equality comparison without epsilon
- Removed stale TODOs and an unused OsTooOld variant
- Added a warning for legacy local source JSON format