### PR TITLE
fix(installer): use RECEIVER_NOT_EXPORTED for ShizukuInstaller broadcast receiver

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
@@ -145,7 +145,7 @@ class ShizukuInstaller(private val service: Service) : Installer(service) {
             service,
             receiver,
             IntentFilter(ACTION_INSTALL_RESULT),
-            ContextCompat.RECEIVER_EXPORTED,
+            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
 
         initShizuku()


### PR DESCRIPTION
## Description

`ShizukuInstaller` registers its broadcast receiver with `RECEIVER_EXPORTED`,  which unnecessarily exposes the internal `ACTION_INSTALL_RESULT` broadcast to other apps on the device.

This receiver is only meant to handle installation results sent by Mihon itself. Using `RECEIVER_EXPORTED` allows any other app on the device to send a crafted broadcast to this receiver, potentially spoofing installation success or failure results.

The fix is to use `RECEIVER_NOT_EXPORTED` instead, which restricts the receiver to only accept broadcasts from within the same app  consistent with how `PackageInstallerInstaller.kt` already handles its own receiver correctly:

```kotlin
// PackageInstallerInstaller.kt (correct)
ContextCompat.registerReceiver(
    service,
    packageActionReceiver,
    IntentFilter(INSTALL_ACTION),
    ContextCompat.RECEIVER_NOT_EXPORTED,
)

// ShizukuInstaller.kt (before this fix)
ContextCompat.registerReceiver(
    service,
    receiver,
    IntentFilter(ACTION_INSTALL_RESULT),
    ContextCompat.RECEIVER_EXPORTED, // ← incorrect
)
```

## Changes

- `ShizukuInstaller.kt`: changed `RECEIVER_EXPORTED` → `RECEIVER_NOT_EXPORTED`  when registering the `ACTION_INSTALL_RESULT` broadcast receiver

## How to test

1. Enable Shizuku and set it as the installer in More → Settings → Advanced → Installer
2. Install or update any extension via Browse → Extensions
3. Verify the extension installs correctly with no regression