### PR TITLE
Add "disable doubletap" option to paged reader

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
@@ -178,7 +178,7 @@ fun MangaCoverDialog(
                                     ?.copy(Bitmap.Config.HARDWARE, false)
                                     ?.toDrawable(view.context.resources)
                                     ?: drawable
-                                view.setImage(copy, ReaderPageImageView.Config(zoomDuration = 500))
+                                view.setImage(copy, ReaderPageImageView.Config(zoomDuration = 500, doubleTapZoom = true))
                             }
                             .build()
                         view.context.imageLoader.enqueue(request)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -286,6 +286,10 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_page_rotate_invert),
                     enabled = rotateToFit,
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.webtoonDoubleTapZoomEnabled,
+                    title = stringResource(MR.strings.pref_double_tap_zoom),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -134,6 +134,11 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
             pref = screenModel.preferences.dualPageRotateToFitInvert,
         )
     }
+
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_double_tap_zoom),
+        pref = screenModel.preferences.pref_enable_double_tap_zoom_pager,
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -61,6 +61,11 @@ class ReaderPreferences(
         true,
     )
 
+    val pref_enable_double_tap_zoom_pager: Preference<Boolean> = preferenceStore.getBoolean(
+        "pref_enable_double_tap_zoom_pager",
+        true,
+    )
+
     val imageScaleType: Preference<Int> = preferenceStore.getInt("pref_image_scale_type_key", 1)
 
     val zoomStart: Preference<Int> = preferenceStore.getInt("pref_zoom_start_key", 1)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -263,7 +263,16 @@ open class ReaderPageImageView @JvmOverloads constructor(
     private fun SubsamplingScaleImageView.setupZoom(config: Config?) {
         // 5x zoom
         maxScale = scale * MAX_ZOOM_SCALE
-        setDoubleTapZoomScale(scale * 2)
+
+        if (config?.doubleTapZoom ?: false) {
+            setDoubleTapZoomScale(scale * 2)
+        } else {
+            // HACK: There's no function to disable double tap zoom while preserving pinch gesture,
+            // but we can make it feel like nothing is being zoomed.
+            setDoubleTapZoomScale(1.0f)
+            setDoubleTapZoomDuration(0)
+            setQuickScaleEnabled(false)
+        }
 
         when (config?.zoomStartPosition) {
             ZoomStartPosition.LEFT -> setScaleAndCenter(scale, PointF(0F, 0F))
@@ -355,6 +364,9 @@ open class ReaderPageImageView @JvmOverloads constructor(
                 setOnDoubleTapListener(
                     object : GestureDetector.SimpleOnGestureListener() {
                         override fun onDoubleTap(e: MotionEvent): Boolean {
+                            if (config!!.doubleTapZoom) {
+                                return false
+                            }
                             if (scale > 1F) {
                                 setScale(1F, e.x, e.y, true)
                             } else {
@@ -416,11 +428,12 @@ open class ReaderPageImageView @JvmOverloads constructor(
      * All of the config except [zoomDuration] will only be used for non-animated image.
      */
     data class Config(
-        val zoomDuration: Int,
-        val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
-        val cropBorders: Boolean = false,
-        val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
-        val landscapeZoom: Boolean = false,
+            val zoomDuration: Int,
+            val doubleTapZoom: Boolean,
+            val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
+            val cropBorders: Boolean = false,
+            val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
+            val landscapeZoom: Boolean = false,
     )
 
     enum class ZoomStartPosition {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -270,7 +270,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
             // HACK: There's no function to disable double tap zoom while preserving pinch gesture,
             // but we can make it feel like nothing is being zoomed.
             setDoubleTapZoomScale(1.0f)
-            setDoubleTapZoomDuration(0)
+            setDoubleTapZoomDuration(1)
             setQuickScaleEnabled(false)
         }
 
@@ -364,9 +364,6 @@ open class ReaderPageImageView @JvmOverloads constructor(
                 setOnDoubleTapListener(
                     object : GestureDetector.SimpleOnGestureListener() {
                         override fun onDoubleTap(e: MotionEvent): Boolean {
-                            if (config!!.doubleTapZoom) {
-                                return false
-                            }
                             if (scale > 1F) {
                                 setScale(1F, e.x, e.y, true)
                             } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -425,12 +425,12 @@ open class ReaderPageImageView @JvmOverloads constructor(
      * All of the config except [zoomDuration] will only be used for non-animated image.
      */
     data class Config(
-            val zoomDuration: Int,
-            val doubleTapZoom: Boolean,
-            val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
-            val cropBorders: Boolean = false,
-            val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
-            val landscapeZoom: Boolean = false,
+        val zoomDuration: Int,
+        val doubleTapZoom: Boolean,
+        val minimumScaleType: Int = SCALE_TYPE_CENTER_INSIDE,
+        val cropBorders: Boolean = false,
+        val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
+        val landscapeZoom: Boolean = false,
     )
 
     enum class ZoomStartPosition {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/Pager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/Pager.kt
@@ -31,7 +31,26 @@ open class Pager(
      * Gesture listener that implements tap and long tap events.
      */
     private val gestureListener = object : GestureDetectorWithLongTap.Listener() {
+        override fun onSingleTapUp(ev: MotionEvent): Boolean {
+            if (isDoubleTapGestureEnabled) {
+                return false
+            }
+            tapListener?.invoke(ev)
+            return true
+        }
+
+        override fun onDoubleTapEvent(ev: MotionEvent): Boolean {
+            if (isDoubleTapGestureEnabled || ev.actionMasked != MotionEvent.ACTION_UP) {
+                return false
+            }
+            tapListener?.invoke(ev)
+            return true
+        }
+
         override fun onSingleTapConfirmed(ev: MotionEvent): Boolean {
+            if (!isDoubleTapGestureEnabled) {
+                return false
+            }
             tapListener?.invoke(ev)
             return true
         }
@@ -53,6 +72,12 @@ open class Pager(
      * Whether the gesture detector is currently enabled.
      */
     private var isGestureDetectorEnabled = true
+
+    /**
+     * When the double tap is disabled, we can treat double taps as 2 fast single taps,
+     * and also it enables us to fire the handler for just a single tap without delay.
+     */
+    private var isDoubleTapGestureEnabled = true;
 
     /**
      * Dispatches a touch event.
@@ -107,5 +132,12 @@ open class Pager(
      */
     fun setGestureDetectorEnabled(enabled: Boolean) {
         isGestureDetectorEnabled = enabled
+    }
+
+    /**
+     * Enables or disables double-tap gesture.
+     */
+    fun setDoubleTapGestureEnabled(enabled: Boolean) {
+        isDoubleTapGestureEnabled = enabled
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -48,6 +48,11 @@ class PagerConfig(
     var landscapeZoom = false
         private set
 
+    var doubleTapZoom = false
+        private set
+
+    var doubleTapZoomChangedListener: ((Boolean) -> Unit)? = null
+
     init {
         readerPreferences.readerTheme
             .register(
@@ -105,6 +110,15 @@ class PagerConfig(
             .register(
                 { dualPageRotateToFitInvert = it },
                 { imagePropertyChangedListener?.invoke() },
+            )
+
+        readerPreferences.pref_enable_double_tap_zoom_pager
+            .register(
+                { doubleTapZoom = it },
+                {
+                    doubleTapZoomChangedListener?.invoke(it)
+                    imagePropertyChangedListener?.invoke()
+                },
             )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -166,6 +166,7 @@ class PagerPageHolder(
                     isAnimated,
                     Config(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
+                        doubleTapZoom = viewer.config.doubleTapZoom,
                         minimumScaleType = viewer.config.imageScaleType,
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -44,7 +44,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
     /**
      * Configuration used by the pager, like allow taps, scale mode on images, page transitions...
      */
-    val config = PagerConfig(this, scope)
+    val config = PagerConfig(this, scope) //
 
     /**
      * Adapter of the pager.
@@ -143,6 +143,11 @@ abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
             val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
             activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
         }
+
+        config.doubleTapZoomChangedListener = {
+            pager.setDoubleTapGestureEnabled(it)
+        }
+
     }
 
     override fun destroy() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -44,7 +44,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
     /**
      * Configuration used by the pager, like allow taps, scale mode on images, page transitions...
      */
-    val config = PagerConfig(this, scope) //
+    val config = PagerConfig(this, scope)
 
     /**
      * Adapter of the pager.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -201,6 +201,8 @@ class WebtoonPageHolder(
                     isAnimated,
                     ReaderPageImageView.Config(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
+                        doubleTapZoom = true, // WebtoonViewer uses a separate doubletap suppression mechanism,
+                                              // but maybe it could be refactored to use this too.
                         minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH,
                         cropBorders = viewer.config.imageCropBorders,
                     ),


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

Closes https://github.com/mihonapp/mihon/issues/815

This PR introduces a new option for paged reader, allowing to disable double tap to zoom. `WebtoonViewer` has pretty much identical option, but it doesn't apply to paged reader.

I decided go other impl route than trying to re-use the one from `WebtoonViewer`, as at first I thought I through that I found a simpler (though a bit hacky) way to effectively disable double tap. And it works okayish, only a bit weird behavior (mentioned in the "Future work" at the end).

One notable discovery I made during writing the code, is that when the new zoom-on-double-tap option is disabled page flips can be made much faster, now that we don't need to wait have a delay for tap confirmation (`onSingleTapConfirmed`). So I took a bit longer route to implement it to enable this lower delay path.

Future work: 
- double-tap-then-drag should not trigger scroll on 2nd tap release - this feels a bit buggy. 
	- `WebtoonViewer` in fact already contains gesture handler with `onDoubleTapConfirmed`, which we would something like this, and it could probably solve this issue. Looks like an angle for refactor, but feels like it would be a lot more changes than those I made.