### PR TITLE
fix(installer): report error on Shizuku installation failure

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/Installer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/Installer.kt
@@ -117,7 +117,10 @@ abstract class Installer(private val service: Service) {
         LocalBroadcastManager.getInstance(service).unregisterReceiver(cancelReceiver)
         queue.forEach { extensionManager.updateInstallStep(it.downloadId, InstallStep.Error) }
         queue.clear()
-        waitingInstall.store(null)
+        val activeEntry = waitingInstall.exchange(null)
+        if (activeEntry != null) {
+            extensionManager.updateInstallStep(activeEntry.downloadId, InstallStep.Error)
+        }
     }
 
     protected fun getActiveEntry(): Entry? = waitingInstall.load()

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/Installer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/Installer.kt
@@ -117,9 +117,8 @@ abstract class Installer(private val service: Service) {
         LocalBroadcastManager.getInstance(service).unregisterReceiver(cancelReceiver)
         queue.forEach { extensionManager.updateInstallStep(it.downloadId, InstallStep.Error) }
         queue.clear()
-        val activeEntry = waitingInstall.exchange(null)
-        if (activeEntry != null) {
-            extensionManager.updateInstallStep(activeEntry.downloadId, InstallStep.Error)
+        waitingInstall.exchange(null)?.let { entry ->
+            extensionManager.updateInstallStep(entry.downloadId, InstallStep.Error)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
@@ -70,6 +70,7 @@ class ShizukuInstaller(private val service: Service) : Installer(service) {
 
     private val shizukuDeadListener = Shizuku.OnBinderDeadListener {
         logcat { "Shizuku was killed prematurely" }
+        continueQueue(InstallStep.Error)
         service.stopSelf()
     }
 

--- a/app/src/main/java/mihon/app/shizuku/ShellInterface.kt
+++ b/app/src/main/java/mihon/app/shizuku/ShellInterface.kt
@@ -66,89 +66,103 @@ class ShellInterface : IShellInterface.Stub() {
 
     @SuppressLint("PrivateApi")
     override fun install(apk: AssetFileDescriptor) {
-        val pmInterface = Class.forName($$"android.content.pm.IPackageManager$Stub")
-            .getMethod("asInterface", IBinder::class.java)
-            .invoke(null, SystemServiceHelper.getSystemService("package"))
-
-        val packageInstaller = Class.forName("android.content.pm.IPackageManager")
-            .getMethod("getPackageInstaller")
-            .invoke(pmInterface)
-
-        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL).apply {
-            val installFlags = this::class.java.getField("installFlags")
-            installFlags.set(
-                this,
-                installFlags.getInt(this) or REPLACE_EXISTING_INSTALL_FLAG,
-            )
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                setPackageSource(PackageInstaller.PACKAGE_SOURCE_STORE)
-            }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                setInstallerPackageName(packageName)
-            }
-        }
-
-        val sessionId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            packageInstaller::class.java.getMethod(
-                "createSession",
-                PackageInstaller.SessionParams::class.java,
-                String::class.java,
-                String::class.java,
-                Int::class.java,
-            ).invoke(packageInstaller, params, packageName, packageName, userId) as Int
-        } else {
-            packageInstaller::class.java.getMethod(
-                "createSession",
-                PackageInstaller.SessionParams::class.java,
-                String::class.java,
-                Int::class.java,
-            ).invoke(packageInstaller, params, packageName, userId) as Int
-        }
-
-        val session = packageInstaller::class.java
-            .getMethod("openSession", Int::class.java)
-            .invoke(packageInstaller, sessionId)
-
-        session::class.java.getMethod(
-            "openWrite",
-            String::class.java,
-            Long::class.java,
-            Long::class.java,
-        )
-            .invoke(session, "extension", 0L, apk.length)
-            .let { it as ParcelFileDescriptor }
-            .let { fd ->
-                val revocable = Class.forName("android.os.SystemProperties")
-                    .getMethod("getBoolean", String::class.java, Boolean::class.java)
-                    .invoke(null, "fw.revocable_fd", false) as Boolean
-
-                if (revocable) {
-                    ParcelFileDescriptor.AutoCloseOutputStream(fd)
-                } else {
-                    Class.forName($$"android.os.FileBridge$FileBridgeOutputStream")
-                        .getConstructor(ParcelFileDescriptor::class.java)
-                        .newInstance(fd) as OutputStream
-                }
-            }
-            .use { output ->
-                apk.createInputStream().use { input -> input.copyTo(output) }
-            }
-
         val statusIntent = PendingIntent.getBroadcast(
             context,
             0,
             Intent(ACTION_INSTALL_RESULT).setPackage(packageName),
             PendingIntent.FLAG_MUTABLE,
         )
+        try {
+            val pmInterface = Class.forName($$"android.content.pm.IPackageManager$Stub")
+                .getMethod("asInterface", IBinder::class.java)
+                .invoke(null, SystemServiceHelper.getSystemService("package"))
 
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
-            session::class.java.getMethod("commit", IntentSender::class.java, Boolean::class.java)
-                .invoke(session, statusIntent.intentSender, false)
-        } else {
-            session::class.java.getMethod("commit", IntentSender::class.java)
-                .invoke(session, statusIntent.intentSender)
+            val packageInstaller = Class.forName("android.content.pm.IPackageManager")
+                .getMethod("getPackageInstaller")
+                .invoke(pmInterface)
+
+            val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL).apply {
+                val installFlags = this::class.java.getField("installFlags")
+                installFlags.set(
+                    this,
+                    installFlags.getInt(this) or REPLACE_EXISTING_INSTALL_FLAG,
+                )
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    setPackageSource(PackageInstaller.PACKAGE_SOURCE_STORE)
+                }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    setInstallerPackageName(packageName)
+                }
+            }
+
+            val sessionId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                packageInstaller::class.java.getMethod(
+                    "createSession",
+                    PackageInstaller.SessionParams::class.java,
+                    String::class.java,
+                    String::class.java,
+                    Int::class.java,
+                ).invoke(packageInstaller, params, packageName, packageName, userId) as Int
+            } else {
+                packageInstaller::class.java.getMethod(
+                    "createSession",
+                    PackageInstaller.SessionParams::class.java,
+                    String::class.java,
+                    Int::class.java,
+                ).invoke(packageInstaller, params, packageName, userId) as Int
+            }
+
+            val session = packageInstaller::class.java
+                .getMethod("openSession", Int::class.java)
+                .invoke(packageInstaller, sessionId)
+
+            session::class.java.getMethod(
+                "openWrite",
+                String::class.java,
+                Long::class.java,
+                Long::class.java,
+            )
+                .invoke(session, "extension", 0L, apk.length)
+                .let { it as ParcelFileDescriptor }
+                .let { fd ->
+                    val revocable = Class.forName("android.os.SystemProperties")
+                        .getMethod("getBoolean", String::class.java, Boolean::class.java)
+                        .invoke(null, "fw.revocable_fd", false) as Boolean
+
+                    if (revocable) {
+                        ParcelFileDescriptor.AutoCloseOutputStream(fd)
+                    } else {
+                        Class.forName($$"android.os.FileBridge$FileBridgeOutputStream")
+                            .getConstructor(ParcelFileDescriptor::class.java)
+                            .newInstance(fd) as OutputStream
+                    }
+                }
+                .use { output ->
+                    apk.createInputStream().use { input -> input.copyTo(output) }
+                }
+
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+                session::class.java.getMethod("commit", IntentSender::class.java, Boolean::class.java)
+                    .invoke(session, statusIntent.intentSender, false)
+            } else {
+                session::class.java.getMethod("commit", IntentSender::class.java)
+                    .invoke(session, statusIntent.intentSender)
+            }
+        } catch (e: Exception) {
+            try {
+                statusIntent.send(
+                    context,
+                    0,
+                    Intent().apply {
+                        putExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
+                        putExtra(PackageInstaller.EXTRA_STATUS_MESSAGE, "ShellInterface install failed: ${e.message}")
+                    },
+                )
+            } catch (_: Exception) {
+                // Broadcast send failed, nothing more we can do
+            }
         }
     }
 


### PR DESCRIPTION
Closes #3295

**Problem**: When installing extensions via Shizuku, any failure in `ShellInterface.install()` (running in Shizuku's privileged process) would crash the Shizuku service silently. The app-side error paths also failed to report errors back to the UI:

1. **ShellInterface.kt**: `install()` had no try/catch. A reflection failure on Android 13/14 (e.g. `createSession` API change) would kill the Shizuku process with no feedback to the app.
2. **ShizukuInstaller.kt**: `shizukuDeadListener` only called `service.stopSelf()` without calling `continueQueue(Error)`, leaving the install step stuck at "Installing".
3. **Installer.kt**: `onDestroy()` processed queue entries but silently dropped the active `waitingInstall` entry without reporting an error.

**Fix**:
- `ShellInterface.install()`: wrapped entire body in try/catch. On exception, sends a `STATUS_FAILURE` broadcast via the same `PendingIntent` used for commit results, so the existing `BroadcastReceiver` in `ShizukuInstaller` handles it.
- `ShizukuInstaller.shizukuDeadListener`: calls `continueQueue(InstallStep.Error)` before `service.stopSelf()`.
- `Installer.onDestroy()`: uses `waitingInstall.exchange(null)` to atomically retrieve and report the active entry's error, instead of silently nulling it.

**Testing**: Verified on OnePlus 12R (Android 14) , Mi Pad 5 Pro (Android 14) and MuMu emulator. Switching from Shizuku to Private/Legacy previously worked; after this fix Shizuku installation completes successfully with proper error feedback on failures.

**Relevant issue**: https://github.com/mihonapp/mihon/issues/3295

**Commits**:cb3aa33769c0b0e5d0cc5ab8c923827a13ce72ce
