### PR TITLE
Fix update badge overflow

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -68,7 +68,7 @@ fun TabbedScreen(
                     Tab(
                         selected = state.currentPage == index,
                         onClick = { scope.launch { state.animateScrollToPage(index) } },
-                        text = { TabText(text = stringResource(tab.titleRes), badgeCount = tab.badgeNumber) },
+                        text = { TabText(text = stringResource(tab.titleRes), badgeCount = tab.badgeNumber, spaceConstrained = true) },
                         unselectedContentColor = MaterialTheme.colorScheme.onSurface,
                     )
                 }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/Tabs.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/material/Tabs.kt
@@ -6,12 +6,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import tachiyomi.presentation.core.components.Pill
 
 @Composable
-fun TabText(text: String, badgeCount: Int? = null) {
+fun TabText(text: String, badgeCount: Int? = null, spaceConstrained: Boolean = false) {
     val pillAlpha = if (isSystemInDarkTheme()) 0.12f else 0.08f
 
     Row(
@@ -19,6 +20,7 @@ fun TabText(text: String, badgeCount: Int? = null) {
     ) {
         Text(
             text = text,
+            modifier = if (spaceConstrained) Modifier.weight(1f, fill = false) else Modifier,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )


### PR DESCRIPTION
Made "Extensions" ellipse itself if the pill is too big.
Tested on various badge numbers, phone, and tablet. Also verified it did not break library category badges when searching.

To test locally without extensions, temporarily hardcode [ExtensionsTab:39](https://github.com/mihonapp/mihon/blob/6552ffe3158f8127ca265f8621ad326be9e173cb/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt#L39).

Closes #3423 

### Images
| Device | Image |
| ------ | ----- |
| Phone 0 | <img width="360" height="99" alt="phone_0" src="https://github.com/user-attachments/assets/dd566259-bb8d-4538-aba5-64ea02811521" /> |
| Phone 2 | <img width="361" height="101" alt="phone_2" src="https://github.com/user-attachments/assets/5eab8aee-1d68-4b36-a654-e22854b89bce" /> |
| Phone 26 | <img width="361" height="104" alt="phone_26" src="https://github.com/user-attachments/assets/3d7d57db-0526-42e6-b6fd-d120666605ac" /> |
| Phone 2026 | <img width="360" height="102" alt="phone_2026" src="https://github.com/user-attachments/assets/38b8ef0b-3a91-4d5e-a631-f2d1db234f5b" /> |
| Tablet 2026 | <img width="688" height="65" alt="tablet_2026" src="https://github.com/user-attachments/assets/acac3686-914d-4312-a04a-88d3776d6fa1" /> |