### PR TITLE
Add setting for manual updates to respect search and filters

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -190,6 +190,11 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_library_update_refresh_metadata),
                     subtitle = stringResource(MR.strings.pref_library_update_refresh_metadata_summary),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.filterManualUpdates,
+                    title = stringResource(MR.strings.pref_library_update_filter_manual_updates),
+                    subtitle = stringResource(MR.strings.pref_library_update_filter_manual_updates_summary),
+                ),
                 Preference.PreferenceItem.MultiSelectListPreference(
                     preference = libraryPreferences.autoUpdateMangaRestrictions,
                     entries = mapOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -111,7 +111,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         libraryPreferences.lastUpdatedTimestamp.set(Instant.now().toEpochMilli())
 
         val categoryId = inputData.getLong(KEY_CATEGORY, -1L)
-        addMangaToQueue(categoryId)
+        val mangaIds = inputData.getLongArray(KEY_MANGA_IDS)?.toSet()
+        addMangaToQueue(categoryId, mangaIds)
 
         return withIOContext {
             try {
@@ -148,20 +149,24 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
      * Adds list of manga to be updated.
      *
      * @param categoryId the ID of the category to update, or -1 if no category specified.
+     * @param mangaIds the specific manga IDs to update, or null for entire category or library.
      */
-    private suspend fun addMangaToQueue(categoryId: Long) {
+    private suspend fun addMangaToQueue(categoryId: Long, mangaIds: Set<Long>?) {
         val libraryManga = getLibraryManga.await()
 
-        val listToUpdate = if (categoryId != -1L) {
-            libraryManga.filter { categoryId in it.categories }
-        } else {
-            val includedCategories = libraryPreferences.updateCategories.get().map { it.toLong() }
-            val excludedCategories = libraryPreferences.updateCategoriesExclude.get().map { it.toLong() }
+        val listToUpdate = when {
+            mangaIds != null -> libraryManga.filter { it.id in mangaIds }
+            categoryId != -1L -> libraryManga.filter { categoryId in it.categories }
+            else -> {
+                val includedCategories = libraryPreferences.updateCategories.get().map { it.toLong() }
+                val excludedCategories = libraryPreferences.updateCategoriesExclude.get().map { it.toLong() }
 
-            libraryManga.filter {
-                val included = includedCategories.isEmpty() || it.categories.intersect(includedCategories).isNotEmpty()
-                val excluded = it.categories.intersect(excludedCategories).isNotEmpty()
-                included && !excluded
+                libraryManga.filter {
+                    val included =
+                        includedCategories.isEmpty() || it.categories.intersect(includedCategories).isNotEmpty()
+                    val excluded = it.categories.intersect(excludedCategories).isNotEmpty()
+                    included && !excluded
+                }
             }
         }
 
@@ -410,6 +415,11 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
          */
         private const val KEY_CATEGORY = "category"
 
+        /**
+         * Key for manga ids to update.
+         */
+        private const val KEY_MANGA_IDS = "manga_ids"
+
         fun setupTask(
             context: Context,
             prefInterval: Int? = null,
@@ -465,6 +475,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         fun startNow(
             context: Context,
             category: Category? = null,
+            mangaIds: List<Long>? = null,
         ): Boolean {
             val wm = context.workManager
             if (wm.isRunning(TAG)) {
@@ -474,6 +485,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
             val inputData = workDataOf(
                 KEY_CATEGORY to category?.id,
+                KEY_MANGA_IDS to mangaIds?.toLongArray(),
             )
             val request = OneTimeWorkRequestBuilder<LibraryUpdateJob>()
                 .addTag(TAG)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -596,6 +596,19 @@ class LibraryScreenModel(
             .asState(screenModelScope)
     }
 
+    fun getVisibleMangaIdsForCurrentCategory(): List<Long> {
+        val state = state.value
+        return state.getItemsForCategoryId(state.activeCategory?.id).map { it.id }
+    }
+
+    fun getVisibleMangaIdsForLibrary(): List<Long> {
+        val state = state.value
+        return state.displayedCategories
+            .flatMap { state.getItemsForCategory(it) }
+            .map { it.id }
+            .distinct()
+    }
+
     fun getRandomLibraryItemForCurrentCategory(): LibraryItem? {
         val state = state.value
         return state.getItemsForCategoryId(state.activeCategory?.id).randomOrNull()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -92,8 +92,18 @@ data object LibraryTab : Tab {
 
         val snackbarHostState = remember { SnackbarHostState() }
 
-        val onClickRefresh: (Category?) -> Boolean = { category ->
-            val started = LibraryUpdateJob.startNow(context, category)
+        fun shouldScopeUpdateToVisibleItems(): Boolean {
+            return state.hasActiveFilters || !state.searchQuery.isNullOrEmpty()
+        }
+
+        fun onClickRefresh(category: Category?, mangaIds: List<Long>?): Boolean {
+            if (mangaIds?.isEmpty() == true) {
+                scope.launch {
+                    snackbarHostState.showSnackbar(context.stringResource(MR.strings.information_no_entries_found))
+                }
+                return false
+            }
+            val started = LibraryUpdateJob.startNow(context, category, mangaIds)
             scope.launch {
                 val msgRes = when {
                     !started -> MR.strings.update_already_running
@@ -102,7 +112,7 @@ data object LibraryTab : Tab {
                 }
                 snackbarHostState.showSnackbar(context.stringResource(msgRes))
             }
-            started
+            return started
         }
 
         Scaffold(
@@ -120,8 +130,18 @@ data object LibraryTab : Tab {
                     onClickSelectAll = screenModel::selectAll,
                     onClickInvertSelection = screenModel::invertSelection,
                     onClickFilter = screenModel::showSettingsDialog,
-                    onClickRefresh = { onClickRefresh(state.activeCategory) },
-                    onClickGlobalUpdate = { onClickRefresh(null) },
+                    onClickRefresh = {
+                        onClickRefresh(
+                            state.activeCategory,
+                            screenModel.getVisibleMangaIdsForCurrentCategory().takeIf { shouldScopeUpdateToVisibleItems() },
+                        )
+                    },
+                    onClickGlobalUpdate = {
+                        onClickRefresh(
+                            null,
+                            screenModel.getVisibleMangaIdsForLibrary().takeIf { shouldScopeUpdateToVisibleItems() },
+                        )
+                    },
                     onClickOpenRandomManga = {
                         scope.launch {
                             val randomItem = screenModel.getRandomLibraryItemForCurrentCategory()
@@ -205,7 +225,12 @@ data object LibraryTab : Tab {
                             screenModel.toggleRangeSelection(category, manga)
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         },
-                        onRefresh = { onClickRefresh(state.activeCategory) },
+                        onRefresh = {
+                            onClickRefresh(
+                                state.activeCategory,
+                                screenModel.getVisibleMangaIdsForCurrentCategory().takeIf { shouldScopeUpdateToVisibleItems() },
+                            )
+                        },
                         onGlobalSearchClicked = {
                             navigator.push(GlobalSearchScreen(screenModel.state.value.searchQuery ?: ""))
                         },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -52,6 +52,7 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.model.LibraryManga
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -59,7 +60,10 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.EmptyScreenAction
 import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.util.collectAsState
 import tachiyomi.source.local.isLocal
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 data object LibraryTab : Tab {
 
@@ -89,11 +93,13 @@ data object LibraryTab : Tab {
         val screenModel = rememberScreenModel { LibraryScreenModel() }
         val settingsScreenModel = rememberScreenModel { LibrarySettingsScreenModel() }
         val state by screenModel.state.collectAsState()
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val filterManualUpdates by libraryPreferences.filterManualUpdates.collectAsState()
 
         val snackbarHostState = remember { SnackbarHostState() }
 
         fun shouldScopeUpdateToVisibleItems(): Boolean {
-            return state.hasActiveFilters || !state.searchQuery.isNullOrEmpty()
+            return filterManualUpdates && (state.hasActiveFilters || !state.searchQuery.isNullOrEmpty())
         }
 
         fun onClickRefresh(category: Category?, mangaIds: List<Long>?): Boolean {
@@ -107,6 +113,8 @@ data object LibraryTab : Tab {
             scope.launch {
                 val msgRes = when {
                     !started -> MR.strings.update_already_running
+                    mangaIds != null && category != null -> MR.strings.updating_filtered_category
+                    mangaIds != null -> MR.strings.updating_filtered_library
                     category != null -> MR.strings.updating_category
                     else -> MR.strings.updating_library
                 }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -56,6 +56,8 @@ class LibraryPreferences(
 
     val autoUpdateMetadata: Preference<Boolean> = preferenceStore.getBoolean("auto_update_metadata", false)
 
+    val filterManualUpdates: Preference<Boolean> = preferenceStore.getBoolean("filter_manual_updates", false)
+
     val showContinueReadingButton: Preference<Boolean> = preferenceStore.getBoolean(
         "display_continue_reading_button",
         false,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -278,6 +278,8 @@
     <string name="landscape">Landscape</string>
 
     <string name="pref_category_library_update">Global update</string>
+    <string name="pref_library_update_filter_manual_updates">Filter Manual Updates</string>
+    <string name="pref_library_update_filter_manual_updates_summary">Manually triggered library and category updates respect search and filter options</string>
     <string name="pref_library_update_interval">Automatic updates</string>
     <string name="update_never">Off</string>
     <string name="update_6hour">Every 6 hours</string>
@@ -679,6 +681,7 @@
 
     <!-- Library -->
     <string name="updating_category">Updating category</string>
+    <string name="updating_filtered_category">Updating filtered category</string>
     <string name="manga_from_library">From library</string>
     <string name="downloaded_chapters">Downloaded chapters</string>
     <string name="intervals_header">Intervals</string>
@@ -850,6 +853,7 @@
 
     <!-- Updates -->
     <string name="updating_library">Updating library</string>
+    <string name="updating_filtered_library">Updating filtered library</string>
     <string name="update_already_running">An update is already running</string>
     <string name="cant_open_last_read_chapter">Unable to open last read chapter</string>
     <string name="updates_last_update_info">Library last updated: %s</string>


### PR DESCRIPTION
Closes #3425.

### Summary

Add a switch setting (Settings -> Library -> Global update -> Filter Manual Updates) defaulting to off.

When switched on, update actions (Drag down refresh, selecting "Update category", and selecting "Update library") will respect any search and filters in the library. This doesn't impact automatic updates, just the ones triggered manually.

Selecting "Open random entry" already respects search and filters, so this PR allows users to opt-in to having the other actions respect search/filters.

Two new strings have been added: "Update filtered category" and "Update filtered library". Translations left for Weblate(?).


### Technical changes

The three actions are `onRefresh()`, `onClickRefresh()`, and `onClickGlobalRefresh()`.

Some of `LibraryUpdateJob.kt`'s functions now support specific manga ids.
- Before: `addMangaToQueue()` and `startNow()` takes in only a `categoryId`, where a -1 refers to a global update, and when specified is a single category update.
- After: They now also take in an additional `mangaIds`, specified only when helper `shouldScopeUpdateToVisibleItems()` says that filter or search was enabled. If for whatever reason it's non-null but empty I fail with message "No entries found in this category". `categoryId` is still used to determine whether the update is global or category-only.

### Images
| Image | 
| ------- | 
| <img width="360" height="613" alt="Mihon filter manual updates" src="https://github.com/user-attachments/assets/b872a51c-eeb9-4efd-80d3-ec524188f70a" /> |

