### PR TITLE
Fix downloads with SAF providers that do not support rename

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -43,6 +43,7 @@ import nl.adaptivity.xmlutil.serialization.XML
 import okhttp3.Response
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.storage.renameToOrCopy
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.launchNow
 import tachiyomi.core.common.util.lang.withIOContext
@@ -410,11 +411,10 @@ class Downloader(
             if (downloadPreferences.saveChaptersAsCBZ.get()) {
                 archiveChapter(mangaDir, chapterDirname, tmpDir)
             } else {
-                tmpDir.renameTo(chapterDirname)
+                val chapterDir = tmpDir.renameToOrCopy(chapterDirname)
+                DiskUtil.createNoMediaFile(chapterDir, context)
             }
             cache.addChapter(chapterDirname, mangaDir, download.manga)
-
-            DiskUtil.createNoMediaFile(tmpDir, context)
 
             download.status = Download.State.DOWNLOADED
         } catch (error: Throwable) {
@@ -490,16 +490,16 @@ class Downloader(
         return flow {
             val response = source.getImage(page)
             val file = tmpDir.createFile("$filename.tmp")!!
-            try {
+            val completedFile = try {
                 response.body.source().saveTo(file.openOutputStream())
                 val extension = getImageExtension(response, file)
-                file.renameTo("$filename.$extension")
+                file.renameToOrCopy("$filename.$extension")
             } catch (e: Exception) {
                 response.close()
                 file.delete()
                 throw e
             }
-            emit(file)
+            emit(completedFile)
         }
             // Retry 3 times, waiting 2, 4 and 8 seconds between attempts.
             .retryWhen { _, attempt ->
@@ -528,9 +528,9 @@ class Downloader(
             }
         }
         val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
-        tmpFile.renameTo("$filename.${extension.extension}")
+        val imageFile = tmpFile.renameToOrCopy("$filename.${extension.extension}")
         cacheFile.delete()
-        return tmpFile
+        return imageFile
     }
 
     /**
@@ -608,7 +608,7 @@ class Downloader(
                 writer.write(file)
             }
         }
-        zip.renameTo("$dirname.cbz")
+        zip.renameToOrCopy("$dirname.cbz")
         tmpDir.delete()
     }
 

--- a/core/common/src/main/kotlin/tachiyomi/core/common/storage/UniFileExtensions.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/storage/UniFileExtensions.kt
@@ -1,6 +1,7 @@
 package tachiyomi.core.common.storage
 
 import com.hippo.unifile.UniFile
+import java.io.IOException
 
 val UniFile.extension: String?
     get() = name?.substringAfterLast('.')
@@ -10,3 +11,74 @@ val UniFile.nameWithoutExtension: String?
 
 val UniFile.displayablePath: String
     get() = filePath ?: uri.toString()
+
+/**
+ * Renames this file, falling back to copying and deleting it when the storage provider does not
+ * support renaming documents.
+ *
+ * @return the renamed file, or the newly created file when the fallback is used.
+ */
+fun UniFile.renameToOrCopy(targetName: String): UniFile {
+    if (renameTo(targetName)) return this
+
+    val parent = parentFile
+        ?: throw IOException("Failed to rename $displayablePath: parent directory is unavailable")
+    if (parent.findFile(targetName) != null) {
+        throw IOException("Failed to rename $displayablePath: target '$targetName' already exists")
+    }
+
+    val target = createCopyTarget(parent, targetName)
+        ?: throw IOException("Failed to rename $displayablePath: could not create target '$targetName'")
+
+    try {
+        copyContentsTo(target)
+    } catch (e: Exception) {
+        val rollbackFailed = !target.deleteSafely()
+        val rollbackMessage = if (rollbackFailed) "; failed to remove incomplete target" else ""
+        throw IOException("Failed to copy $displayablePath to '$targetName'$rollbackMessage", e)
+    }
+
+    val sourceDeleted = try {
+        delete()
+    } catch (e: Exception) {
+        val rollbackFailed = !target.deleteSafely()
+        val rollbackMessage = if (rollbackFailed) "; failed to remove copied target" else ""
+        throw IOException("Copied $displayablePath to '$targetName', but failed to delete source$rollbackMessage", e)
+    }
+    if (!sourceDeleted) {
+        val rollbackFailed = !target.deleteSafely()
+        val rollbackMessage = if (rollbackFailed) "; failed to remove copied target" else ""
+        throw IOException("Copied $displayablePath to '$targetName', but failed to delete source$rollbackMessage")
+    }
+
+    return target
+}
+
+private fun UniFile.createCopyTarget(parent: UniFile, targetName: String): UniFile? =
+    if (isDirectory) parent.createDirectory(targetName) else parent.createFile(targetName)
+
+private fun UniFile.deleteSafely(): Boolean = try {
+    delete()
+} catch (_: Exception) {
+    false
+}
+
+private fun UniFile.copyContentsTo(target: UniFile) {
+    if (isDirectory) {
+        val children = listFiles()
+            ?: throw IOException("Failed to list directory $displayablePath")
+        children.forEach { child ->
+            val childName = child.name
+                ?: throw IOException("A file in $displayablePath has no name")
+            val childTarget = child.createCopyTarget(target, childName)
+                ?: throw IOException("Failed to create '$childName' in " + target.displayablePath)
+            child.copyContentsTo(childTarget)
+        }
+    } else {
+        openInputStream().use { input ->
+            target.openOutputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+}

--- a/core/common/src/test/java/tachiyomi/core/common/storage/UniFileExtensionsTest.kt
+++ b/core/common/src/test/java/tachiyomi/core/common/storage/UniFileExtensionsTest.kt
@@ -1,0 +1,133 @@
+package tachiyomi.core.common.storage
+
+import com.hippo.unifile.UniFile
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+
+class UniFileExtensionsTest {
+
+    @Test
+    fun `uses rename when supported`() {
+        val source = mockFile()
+        every { source.renameTo("001.jpg") } returns true
+
+        assertSame(source, source.renameToOrCopy("001.jpg"))
+        verify(exactly = 1) { source.renameTo("001.jpg") }
+        verify(exactly = 0) { source.parentFile }
+    }
+
+    @Test
+    fun `copies file and deletes source when rename is unsupported`() {
+        val contents = "image".toByteArray()
+        val output = ByteArrayOutputStream()
+        val parent = mockDirectory()
+        val source = mockFile()
+        val target = mockFile()
+        every { source.renameTo("001.jpg") } returns false
+        every { source.parentFile } returns parent
+        every { parent.findFile("001.jpg") } returns null
+        every { parent.createFile("001.jpg") } returns target
+        every { source.openInputStream() } returns ByteArrayInputStream(contents)
+        every { target.openOutputStream() } returns output
+        every { source.delete() } returns true
+
+        assertSame(target, source.renameToOrCopy("001.jpg"))
+        assertArrayEquals(contents, output.toByteArray())
+        verify(exactly = 1) { source.delete() }
+        verify(exactly = 0) { target.delete() }
+    }
+
+    @Test
+    fun `copies directories recursively`() {
+        val contents = "image".toByteArray()
+        val output = ByteArrayOutputStream()
+        val parent = mockDirectory()
+        val source = mockDirectory()
+        val child = mockFile()
+        val target = mockDirectory()
+        val childTarget = mockFile()
+        every { source.renameTo("chapter") } returns false
+        every { source.parentFile } returns parent
+        every { parent.findFile("chapter") } returns null
+        every { parent.createDirectory("chapter") } returns target
+        every { source.listFiles() } returns arrayOf(child)
+        every { child.name } returns "001.jpg"
+        every { target.createFile("001.jpg") } returns childTarget
+        every { child.openInputStream() } returns ByteArrayInputStream(contents)
+        every { childTarget.openOutputStream() } returns output
+        every { source.delete() } returns true
+
+        assertSame(target, source.renameToOrCopy("chapter"))
+        assertArrayEquals(contents, output.toByteArray())
+    }
+
+    @Test
+    fun `fails without overwriting an existing target`() {
+        val parent = mockDirectory()
+        val source = mockFile(path = "/source.tmp")
+        every { source.renameTo("source.jpg") } returns false
+        every { source.parentFile } returns parent
+        every { parent.findFile("source.jpg") } returns mockFile()
+
+        assertThrows(IOException::class.java) {
+            source.renameToOrCopy("source.jpg")
+        }
+        verify(exactly = 0) { parent.createFile(any()) }
+    }
+
+    @Test
+    fun `removes incomplete target when copying fails`() {
+        val parent = mockDirectory()
+        val source = mockFile(path = "/source.tmp")
+        val target = mockFile()
+        every { source.renameTo("source.jpg") } returns false
+        every { source.parentFile } returns parent
+        every { parent.findFile("source.jpg") } returns null
+        every { parent.createFile("source.jpg") } returns target
+        every { source.openInputStream() } throws IOException("read failed")
+        every { target.delete() } returns true
+
+        assertThrows(IOException::class.java) {
+            source.renameToOrCopy("source.jpg")
+        }
+        verify(exactly = 1) { target.delete() }
+        verify(exactly = 0) { source.delete() }
+    }
+
+    @Test
+    fun `removes copied target when deleting source fails`() {
+        val parent = mockDirectory()
+        val source = mockFile(path = "/source.tmp")
+        val target = mockFile()
+        every { source.renameTo("source.jpg") } returns false
+        every { source.parentFile } returns parent
+        every { parent.findFile("source.jpg") } returns null
+        every { parent.createFile("source.jpg") } returns target
+        every { source.openInputStream() } returns ByteArrayInputStream(byteArrayOf())
+        every { target.openOutputStream() } returns ByteArrayOutputStream()
+        every { source.delete() } returns false
+        every { target.delete() } returns true
+
+        assertThrows(IOException::class.java) {
+            source.renameToOrCopy("source.jpg")
+        }
+        verify(exactly = 1) { target.delete() }
+    }
+
+    private fun mockFile(path: String = "/file"): UniFile = mockk {
+        every { isDirectory } returns false
+        every { filePath } returns path
+    }
+
+    private fun mockDirectory(): UniFile = mockk {
+        every { isDirectory } returns true
+    }
+}


### PR DESCRIPTION
## Summary

Fixes chapter downloads when the selected SAF document provider does not support document renaming.

## Problem

The downloader writes images, chapter directories, and CBZ archives using temporary names before renaming them to their final names.

`UniFile.renameTo()` returns `false` when the underlying document provider does not support `renameDocument`. Its return value was previously ignored, causing downloads to fail while leaving valid temporary files behind.

## Solution

- Continue using `renameTo()` as the preferred path.
- When renaming returns `false`, create the destination, copy the source contents, and delete the source.
- Support both files and directories.
- Throw an `IOException` when the fallback cannot complete safely.
- Return the newly created `UniFile` so callers use the correct URI.

This covers downloaded images, cached images, chapter directories, and CBZ archives.

## Testing

- Added unit tests for:
  - successful native rename
  - file copy fallback
  - recursive directory fallback
  - existing destination handling
  - copy failure cleanup
  - source deletion failure cleanup
- Ran `spotlessKotlinCheck`.
- Ran `:core:common:testDebugUnitTest`.
- Ran `assembleDebug`.