### PR TITLE
Implement multi-selection functionality in History screen with actions

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -1,10 +1,14 @@
 package eu.kanade.presentation.history
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
+import androidx.compose.material.icons.outlined.FlipToBack
+import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -17,6 +21,7 @@ import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.presentation.components.relativeDateText
 import eu.kanade.presentation.history.components.HistoryItem
+import eu.kanade.presentation.manga.components.MangaBottomActionMenu
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.history.HistoryScreenModel
@@ -38,28 +43,73 @@ fun HistoryScreen(
     onClickCover: (mangaId: Long) -> Unit,
     onClickResume: (mangaId: Long, chapterId: Long) -> Unit,
     onClickFavorite: (mangaId: Long) -> Unit,
+    onSelectAll: (Boolean) -> Unit,
+    onInvertSelection: () -> Unit,
+    onHistorySelected: (HistoryWithRelations, Boolean, Boolean) -> Unit,
+    onAddSelectedToLibrary: (List<HistoryWithRelations>) -> Unit,
     onDialogChange: (HistoryScreenModel.Dialog?) -> Unit,
 ) {
+    BackHandler(enabled = state.selectionMode) {
+        onSelectAll(false)
+    }
+
     Scaffold(
         topBar = { scrollBehavior ->
-            SearchToolbar(
-                titleContent = { AppBarTitle(stringResource(MR.strings.history)) },
-                searchQuery = state.searchQuery,
-                onChangeSearchQuery = onSearchQueryChange,
-                actions = {
-                    AppBarActions(
-                        listOf(
-                            AppBar.Action(
-                                title = stringResource(MR.strings.pref_clear_history),
-                                icon = Icons.Outlined.DeleteSweep,
-                                onClick = {
-                                    onDialogChange(HistoryScreenModel.Dialog.DeleteAll)
-                                },
+            if (state.selectionMode) {
+                AppBar(
+                    title = stringResource(MR.strings.history),
+                    actionModeCounter = state.selected.size,
+                    onCancelActionMode = { onSelectAll(false) },
+                    actionModeActions = {
+                        AppBarActions(
+                            listOf(
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.action_select_all),
+                                    icon = Icons.Outlined.SelectAll,
+                                    onClick = { onSelectAll(true) },
+                                ),
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.action_select_inverse),
+                                    icon = Icons.Outlined.FlipToBack,
+                                    onClick = onInvertSelection,
+                                ),
                             ),
-                        ),
-                    )
+                        )
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            } else {
+                SearchToolbar(
+                    titleContent = { AppBarTitle(stringResource(MR.strings.history)) },
+                    searchQuery = state.searchQuery,
+                    onChangeSearchQuery = onSearchQueryChange,
+                    actions = {
+                        AppBarActions(
+                            listOf(
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.pref_clear_history),
+                                    icon = Icons.Outlined.DeleteSweep,
+                                    onClick = {
+                                        onDialogChange(HistoryScreenModel.Dialog.DeleteAll)
+                                    },
+                                ),
+                            ),
+                        )
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            }
+        },
+        bottomBar = {
+            MangaBottomActionMenu(
+                visible = state.selectionMode,
+                modifier = Modifier.fillMaxWidth(),
+                onAddToLibraryClicked = {
+                    onAddSelectedToLibrary(state.selected)
+                }.takeIf { state.selected.any { !it.coverData.isMangaFavorite } },
+                onDeleteClicked = {
+                    onDialogChange(HistoryScreenModel.Dialog.DeleteSelected(state.selected))
                 },
-                scrollBehavior = scrollBehavior,
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
@@ -80,11 +130,14 @@ fun HistoryScreen(
             } else {
                 HistoryScreenContent(
                     history = it,
+                    selection = state.selection,
+                    selectionMode = state.selectionMode,
                     contentPadding = contentPadding,
                     onClickCover = { history -> onClickCover(history.mangaId) },
                     onClickResume = { history -> onClickResume(history.mangaId, history.chapterId) },
                     onClickDelete = { item -> onDialogChange(HistoryScreenModel.Dialog.Delete(item)) },
                     onClickFavorite = { history -> onClickFavorite(history.mangaId) },
+                    onHistorySelected = onHistorySelected,
                 )
             }
         }
@@ -94,11 +147,14 @@ fun HistoryScreen(
 @Composable
 private fun HistoryScreenContent(
     history: List<HistoryUiModel>,
+    selection: Set<Long>,
+    selectionMode: Boolean,
     contentPadding: PaddingValues,
     onClickCover: (HistoryWithRelations) -> Unit,
     onClickResume: (HistoryWithRelations) -> Unit,
     onClickDelete: (HistoryWithRelations) -> Unit,
     onClickFavorite: (HistoryWithRelations) -> Unit,
+    onHistorySelected: (HistoryWithRelations, Boolean, Boolean) -> Unit,
 ) {
     FastScrollLazyColumn(
         contentPadding = contentPadding,
@@ -122,11 +178,21 @@ private fun HistoryScreenContent(
                 }
                 is HistoryUiModel.Item -> {
                     val value = item.item
+                    val selected = value.id in selection
                     HistoryItem(
                         modifier = Modifier.animateItemFastScroll(),
                         history = value,
-                        onClickCover = { onClickCover(value) },
-                        onClickResume = { onClickResume(value) },
+                        selected = selected,
+                        showActions = !selectionMode,
+                        onClickCover = { onClickCover(value) }.takeIf { !selectionMode },
+                        onClickResume = {
+                            if (selectionMode) {
+                                onHistorySelected(value, !selected, false)
+                            } else {
+                                onClickResume(value)
+                            }
+                        },
+                        onLongClick = { onHistorySelected(value, !selected, true) },
                         onClickDelete = { onClickDelete(value) },
                         onClickFavorite = { onClickFavorite(value) },
                     )
@@ -154,8 +220,12 @@ internal fun HistoryScreenPreviews(
             onSearchQueryChange = {},
             onClickCover = {},
             onClickResume = { _, _ -> run {} },
-            onDialogChange = {},
             onClickFavorite = {},
+            onSelectAll = {},
+            onInvertSelection = {},
+            onHistorySelected = { _, _, _ -> },
+            onAddSelectedToLibrary = {},
+            onDialogChange = {},
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/history/components/HistoryDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/components/HistoryDialogs.kt
@@ -88,6 +88,47 @@ fun HistoryDeleteAllDialog(
     )
 }
 
+@Composable
+fun HistoryDeleteSelectedDialog(
+    onDismissRequest: () -> Unit,
+    onDelete: (Boolean) -> Unit,
+) {
+    var removeEverything by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        title = {
+            Text(text = stringResource(MR.strings.action_remove))
+        },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            ) {
+                Text(text = stringResource(MR.strings.history_delete_selected_confirmation))
+
+                LabeledCheckbox(
+                    label = stringResource(MR.strings.dialog_with_checkbox_reset),
+                    checked = removeEverything,
+                    onCheckedChange = { removeEverything = it },
+                )
+            }
+        },
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(onClick = {
+                onDelete(removeEverything)
+                onDismissRequest()
+            }) {
+                Text(text = stringResource(MR.strings.action_remove))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+}
+
 @PreviewLightDark
 @Composable
 private fun HistoryDeleteDialogPreview() {

--- a/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
@@ -1,6 +1,6 @@
 package eu.kanade.presentation.history.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -18,6 +18,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -31,21 +33,34 @@ import tachiyomi.domain.history.model.HistoryWithRelations
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.selectedBackground
 
 private val HistoryItemHeight = 96.dp
 
 @Composable
 fun HistoryItem(
     history: HistoryWithRelations,
-    onClickCover: () -> Unit,
+    selected: Boolean,
+    showActions: Boolean,
+    onClickCover: (() -> Unit)?,
     onClickResume: () -> Unit,
+    onLongClick: () -> Unit,
     onClickDelete: () -> Unit,
     onClickFavorite: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val haptic = LocalHapticFeedback.current
+
     Row(
         modifier = modifier
-            .clickable(onClick = onClickResume)
+            .selectedBackground(selected)
+            .combinedClickable(
+                onClick = onClickResume,
+                onLongClick = {
+                    onLongClick()
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                },
+            )
             .height(HistoryItemHeight)
             .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
         verticalAlignment = Alignment.CenterVertically,
@@ -84,7 +99,7 @@ fun HistoryItem(
             )
         }
 
-        if (!history.coverData.isMangaFavorite) {
+        if (showActions && !history.coverData.isMangaFavorite) {
             IconButton(onClick = onClickFavorite) {
                 Icon(
                     imageVector = Icons.Outlined.FavoriteBorder,
@@ -94,12 +109,14 @@ fun HistoryItem(
             }
         }
 
-        IconButton(onClick = onClickDelete) {
-            Icon(
-                imageVector = Icons.Outlined.Delete,
-                contentDescription = stringResource(MR.strings.action_delete),
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
+        if (showActions) {
+            IconButton(onClick = onClickDelete) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = stringResource(MR.strings.action_delete),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
         }
     }
 }
@@ -114,8 +131,11 @@ private fun HistoryItemPreviews(
         Surface {
             HistoryItem(
                 history = historyWithRelations,
+                selected = false,
+                showActions = true,
                 onClickCover = {},
                 onClickResume = {},
+                onLongClick = {},
                 onClickDelete = {},
                 onClickFavorite = {},
             )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.BookmarkRemove
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.RemoveDone
 import androidx.compose.material.icons.outlined.SwapCalls
@@ -76,6 +77,7 @@ fun MangaBottomActionMenu(
     onMarkAsUnreadClicked: (() -> Unit)? = null,
     onMarkPreviousAsReadClicked: (() -> Unit)? = null,
     onDownloadClicked: (() -> Unit)? = null,
+    onAddToLibraryClicked: (() -> Unit)? = null,
     onDeleteClicked: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
@@ -90,7 +92,7 @@ fun MangaBottomActionMenu(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             val haptic = LocalHapticFeedback.current
-            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false) }
+            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false, false) }
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -164,12 +166,21 @@ fun MangaBottomActionMenu(
                         onClick = onDownloadClicked,
                     )
                 }
+                if (onAddToLibraryClicked != null) {
+                    Button(
+                        title = stringResource(MR.strings.add_to_library),
+                        icon = Icons.Outlined.FavoriteBorder,
+                        toConfirm = confirm[6],
+                        onLongClick = { onLongClickItem(6) },
+                        onClick = onAddToLibraryClicked,
+                    )
+                }
                 if (onDeleteClicked != null) {
                     Button(
                         title = stringResource(MR.strings.action_delete),
                         icon = Icons.Outlined.Delete,
-                        toConfirm = confirm[6],
-                        onLongClick = { onLongClickItem(6) },
+                        toConfirm = confirm[7],
+                        onLongClick = { onLongClickItem(7) },
                         onClick = onDeleteClicked,
                     )
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.core.util.addOrRemove
 import eu.kanade.core.util.insertSeparators
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.track.interactor.AddTracks
@@ -38,10 +39,12 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.time.Instant
 
 class HistoryScreenModel(
     private val addTracks: AddTracks = Injekt.get(),
@@ -61,6 +64,9 @@ class HistoryScreenModel(
     private val _events: Channel<Event> = Channel(Channel.UNLIMITED)
     val events: Flow<Event> = _events.receiveAsFlow()
 
+    private val selectedPositions: Array<Int> = arrayOf(-1, -1)
+    private val selectedHistoryIds: HashSet<Long> = HashSet()
+
     init {
         screenModelScope.launch {
             state.map { it.searchQuery }
@@ -75,7 +81,11 @@ class HistoryScreenModel(
                         .map { it.toHistoryUiModels() }
                         .flowOn(Dispatchers.IO)
                 }
-                .collect { newList -> mutableState.update { it.copy(list = newList) } }
+                .collect { newList ->
+                    val visibleHistoryIds = newList.asHistoryItems().mapTo(HashSet()) { it.id }
+                    selectedHistoryIds.retainAll(visibleHistoryIds)
+                    mutableState.update { it.copy(list = newList, selection = selectedHistoryIds.toSet()) }
+                }
         }
     }
 
@@ -90,6 +100,10 @@ class HistoryScreenModel(
                     else -> null
                 }
             }
+    }
+
+    private fun List<HistoryUiModel>.asHistoryItems(): List<HistoryWithRelations> {
+        return mapNotNull { (it as? HistoryUiModel.Item)?.item }
     }
 
     suspend fun getNextChapter(): Chapter? {
@@ -119,6 +133,23 @@ class HistoryScreenModel(
         }
     }
 
+    fun removeSelectedFromHistory(history: List<HistoryWithRelations>) {
+        screenModelScope.launchIO {
+            removeHistory.await(history)
+            toggleAllSelection(false)
+        }
+    }
+
+    fun removeAllSelectedMangaFromHistory(history: List<HistoryWithRelations>) {
+        screenModelScope.launchIO {
+            history
+                .map { it.mangaId }
+                .distinct()
+                .forEach { removeHistory.await(it) }
+            toggleAllSelection(false)
+        }
+    }
+
     fun removeAllHistory() {
         screenModelScope.launchIO {
             val result = removeHistory.awaitAll()
@@ -129,6 +160,79 @@ class HistoryScreenModel(
 
     fun updateSearchQuery(query: String?) {
         mutableState.update { it.copy(searchQuery = query) }
+    }
+
+    fun toggleSelection(
+        item: HistoryWithRelations,
+        selected: Boolean,
+        fromLongPress: Boolean = false,
+    ) {
+        val historyItems = state.value.list?.asHistoryItems() ?: return
+        val selectedIndex = historyItems.indexOfFirst { it.id == item.id }
+        if (selectedIndex < 0) return
+
+        if ((item.id in selectedHistoryIds) == selected) return
+
+        val firstSelection = selectedHistoryIds.isEmpty()
+        selectedHistoryIds.addOrRemove(item.id, selected)
+
+        if (selected && fromLongPress) {
+            if (firstSelection) {
+                selectedPositions[0] = selectedIndex
+                selectedPositions[1] = selectedIndex
+            } else {
+                val range = when {
+                    selectedIndex < selectedPositions[0] -> {
+                        (selectedIndex + 1)..<selectedPositions[0]
+                    }
+                    selectedIndex > selectedPositions[1] -> {
+                        (selectedPositions[1] + 1)..<selectedIndex
+                    }
+                    else -> IntRange.EMPTY
+                }
+
+                if (selectedIndex < selectedPositions[0]) {
+                    selectedPositions[0] = selectedIndex
+                } else if (selectedIndex > selectedPositions[1]) {
+                    selectedPositions[1] = selectedIndex
+                }
+
+                range.forEach {
+                    selectedHistoryIds.add(historyItems[it].id)
+                }
+            }
+        } else if (!fromLongPress) {
+            val selectedIndices = historyItems
+                .mapIndexedNotNull { index, history -> index.takeIf { history.id in selectedHistoryIds } }
+            selectedPositions[0] = selectedIndices.firstOrNull() ?: -1
+            selectedPositions[1] = selectedIndices.lastOrNull() ?: -1
+        }
+
+        mutableState.update { it.copy(selection = selectedHistoryIds.toSet()) }
+    }
+
+    fun toggleAllSelection(selected: Boolean) {
+        val historyItems = state.value.list?.asHistoryItems().orEmpty()
+        if (selected) {
+            selectedHistoryIds.addAll(historyItems.map { it.id })
+        } else {
+            selectedHistoryIds.clear()
+        }
+
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+        mutableState.update { it.copy(selection = selectedHistoryIds.toSet()) }
+    }
+
+    fun invertSelection() {
+        val historyItems = state.value.list?.asHistoryItems().orEmpty()
+        historyItems.forEach {
+            selectedHistoryIds.addOrRemove(it.id, it.id !in selectedHistoryIds)
+        }
+
+        selectedPositions[0] = -1
+        selectedPositions[1] = -1
+        mutableState.update { it.copy(selection = selectedHistoryIds.toSet()) }
     }
 
     fun setDialog(dialog: Dialog?) {
@@ -214,6 +318,78 @@ class HistoryScreenModel(
         }
     }
 
+    fun addFavorites(history: List<HistoryWithRelations>) {
+        screenModelScope.launchIO {
+            val manga = history
+                .mapNotNull { getManga.await(it.mangaId) }
+                .filterNot { it.favorite }
+                .distinctBy { it.id }
+            if (manga.isEmpty()) {
+                toggleAllSelection(false)
+                return@launchIO
+            }
+
+            manga.firstOrNull { getDuplicateLibraryManga(it).isNotEmpty() }?.let { duplicate ->
+                mutableState.update {
+                    it.copy(dialog = Dialog.DuplicateManga(duplicate, getDuplicateLibraryManga(duplicate)))
+                }
+                return@launchIO
+            }
+
+            val categories = getCategories()
+            val defaultCategoryId = libraryPreferences.defaultCategory.get().toLong()
+            val defaultCategory = categories.find { it.id == defaultCategoryId }
+
+            val categoryIds = when {
+                defaultCategory != null -> listOf(defaultCategory.id)
+                defaultCategoryId == 0L || categories.isEmpty() -> emptyList()
+                else -> {
+                    mutableState.update { currentState ->
+                        currentState.copy(
+                            dialog = Dialog.ChangeCategoryForSelected(
+                                history = history,
+                                initialSelection = categories.mapAsCheckboxState { false },
+                            ),
+                        )
+                    }
+                    return@launchIO
+                }
+            }
+
+            addFavoritesToCategories(manga, categoryIds)
+        }
+    }
+
+    fun addFavoritesToCategories(history: List<HistoryWithRelations>, categoryIds: List<Long>) {
+        screenModelScope.launchIO {
+            val manga = history
+                .mapNotNull { getManga.await(it.mangaId) }
+                .filterNot { it.favorite }
+                .distinctBy { it.id }
+                .filter { getDuplicateLibraryManga(it).isEmpty() }
+            addFavoritesToCategories(manga, categoryIds)
+        }
+    }
+
+    private suspend fun addFavoritesToCategories(manga: List<Manga>, categoryIds: List<Long>) {
+        val now = Instant.now().toEpochMilli()
+        val updates = manga.map {
+            MangaUpdate(
+                id = it.id,
+                favorite = true,
+                dateAdded = now,
+            )
+        }
+        val result = updateManga.awaitAll(updates)
+        if (!result) return
+
+        manga.forEach {
+            setMangaCategories.await(it.id, categoryIds)
+            addTracks.bindEnhancedTrackers(it, sourceManager.getOrStub(it.source))
+        }
+        toggleAllSelection(false)
+    }
+
     fun showMigrateDialog(target: Manga, current: Manga) {
         mutableState.update { currentState ->
             currentState.copy(dialog = Dialog.Migrate(target = target, current = current))
@@ -239,15 +415,28 @@ class HistoryScreenModel(
     data class State(
         val searchQuery: String? = null,
         val list: List<HistoryUiModel>? = null,
+        val selection: Set<Long> = emptySet(),
         val dialog: Dialog? = null,
-    )
+    ) {
+        val selected: List<HistoryWithRelations>
+            get() = list.orEmpty()
+                .mapNotNull { (it as? HistoryUiModel.Item)?.item?.takeIf { item -> item.id in selection } }
+
+        val selectionMode: Boolean
+            get() = selected.isNotEmpty()
+    }
 
     sealed interface Dialog {
         data object DeleteAll : Dialog
         data class Delete(val history: HistoryWithRelations) : Dialog
+        data class DeleteSelected(val history: List<HistoryWithRelations>) : Dialog
         data class DuplicateManga(val manga: Manga, val duplicates: List<MangaWithChapterCount>) : Dialog
         data class ChangeCategory(
             val manga: Manga,
+            val initialSelection: List<CheckboxState<Category>>,
+        ) : Dialog
+        data class ChangeCategoryForSelected(
+            val history: List<HistoryWithRelations>,
             val initialSelection: List<CheckboxState<Category>>,
         ) : Dialog
         data class Migrate(val target: Manga, val current: Manga) : Dialog

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -20,10 +20,12 @@ import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.history.HistoryScreen
 import eu.kanade.presentation.history.components.HistoryDeleteAllDialog
 import eu.kanade.presentation.history.components.HistoryDeleteDialog
+import eu.kanade.presentation.history.components.HistoryDeleteSelectedDialog
 import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
+import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
@@ -71,6 +73,10 @@ data object HistoryTab : Tab {
             onSearchQueryChange = screenModel::updateSearchQuery,
             onClickCover = { navigator.push(MangaScreen(it)) },
             onClickResume = screenModel::getNextChapterForManga,
+            onSelectAll = screenModel::toggleAllSelection,
+            onInvertSelection = screenModel::invertSelection,
+            onHistorySelected = screenModel::toggleSelection,
+            onAddSelectedToLibrary = screenModel::addFavorites,
             onDialogChange = screenModel::setDialog,
             onClickFavorite = screenModel::addFavorite,
         )
@@ -85,6 +91,18 @@ data object HistoryTab : Tab {
                             screenModel.removeAllFromHistory(dialog.history.mangaId)
                         } else {
                             screenModel.removeFromHistory(dialog.history)
+                        }
+                    },
+                )
+            }
+            is HistoryScreenModel.Dialog.DeleteSelected -> {
+                HistoryDeleteSelectedDialog(
+                    onDismissRequest = onDismissRequest,
+                    onDelete = { all ->
+                        if (all) {
+                            screenModel.removeAllSelectedMangaFromHistory(dialog.history)
+                        } else {
+                            screenModel.removeSelectedFromHistory(dialog.history)
                         }
                     },
                 )
@@ -114,6 +132,16 @@ data object HistoryTab : Tab {
                     },
                 )
             }
+            is HistoryScreenModel.Dialog.ChangeCategoryForSelected -> {
+                ChangeCategoryDialog(
+                    initialSelection = dialog.initialSelection,
+                    onDismissRequest = onDismissRequest,
+                    onEditCategories = { navigator.push(CategoryScreen()) },
+                    onConfirm = { include, _ ->
+                        screenModel.addFavoritesToCategories(dialog.history, include)
+                    },
+                )
+            }
             is HistoryScreenModel.Dialog.Migrate -> {
                 MigrateMangaDialog(
                     current = dialog.current,
@@ -124,6 +152,10 @@ data object HistoryTab : Tab {
                 )
             }
             null -> {}
+        }
+
+        LaunchedEffect(state.selectionMode) {
+            HomeScreen.showBottomNav(!state.selectionMode)
         }
 
         LaunchedEffect(state.list) {

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -49,6 +49,14 @@ class HistoryRepositoryImpl(
         }
     }
 
+    override suspend fun resetHistory(historyIds: List<Long>) {
+        try {
+            database.historyQueries.resetHistoryByIds(historyIds)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, throwable = e)
+        }
+    }
+
     override suspend fun resetHistoryByMangaId(mangaId: Long) {
         try {
             database.historyQueries.resetHistoryByMangaId(mangaId)

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -39,6 +39,11 @@ UPDATE history
 SET last_read = 0
 WHERE _id = :historyId;
 
+resetHistoryByIds:
+UPDATE history
+SET last_read = 0
+WHERE _id IN :historyIds;
+
 resetHistoryByMangaId:
 UPDATE history
 SET last_read = 0

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/RemoveHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/RemoveHistory.kt
@@ -15,6 +15,10 @@ class RemoveHistory(
         repository.resetHistory(history.id)
     }
 
+    suspend fun await(history: List<HistoryWithRelations>) {
+        repository.resetHistory(history.map { it.id })
+    }
+
     suspend fun await(mangaId: Long) {
         repository.resetHistoryByMangaId(mangaId)
     }

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -17,6 +17,8 @@ interface HistoryRepository {
 
     suspend fun resetHistory(historyId: Long)
 
+    suspend fun resetHistory(historyIds: List<Long>)
+
     suspend fun resetHistoryByMangaId(mangaId: Long)
 
     suspend fun deleteAllHistory(): Boolean

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -821,6 +821,7 @@
     <!-- Dialog option with checkbox view -->
     <string name="dialog_with_checkbox_remove_description">This will remove the read date of this chapter. Are you sure?</string>
     <string name="dialog_with_checkbox_reset">Reset all chapters for this entry</string>
+    <string name="history_delete_selected_confirmation">Are you sure you want to remove the selected history entries?</string>
 
     <!-- Image notifier -->
     <string name="picture_saved">Picture saved</string>


### PR DESCRIPTION
## Summary
- Add long-press multi-selection support to the History tab
- Add select all, invert selection, and cancel selection mode actions
- Add bulk remove for selected history entries
- Add bulk add-to-library support for selected history entries
- Preserve existing add-to-library behavior for default categories, category selection, and duplicate manga checks

## Motivation
History entries could only be managed one at a time. This brings the History tab closer to the existing multi-select behavior used in Updates and manga chapter lists, making it easier to clean up or save multiple entries from History.

## Screenshots
<img width="320" alt="History selection mode" src="https://github.com/user-attachments/assets/7e286eea-8a0a-4c47-81cd-6bb0c7d332a2" />

<img width="320" alt="History bulk remove dialog" src="https://github.com/user-attachments/assets/30b7fbf4-6794-4c25-b8cd-e072406c3051" />

<img width="320" alt="History add to library flow" src="https://github.com/user-attachments/assets/3cdc196c-9e4f-406a-a999-449c8fa9b59d" />

<img width="320" alt="image" src="https://github.com/user-attachments/assets/471d0c65-53c4-4686-9985-475f0cadb4f9" />


## Testing
- Built and launched locally on an Android emulator
- Ran formatting checks