### PR TITLE
Add source groups to browse and global search

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -12,11 +12,14 @@ import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.interactor.UpdateManga
+import eu.kanade.domain.source.interactor.DeleteSourcePinGroup
 import eu.kanade.domain.source.interactor.GetEnabledSources
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.interactor.GetLanguagesWithSources
+import eu.kanade.domain.source.interactor.GetSourcePinGroups
 import eu.kanade.domain.source.interactor.GetSourcesWithFavoriteCount
 import eu.kanade.domain.source.interactor.SetMigrateSorting
+import eu.kanade.domain.source.interactor.SetSourcePinGroups
 import eu.kanade.domain.source.interactor.ToggleIncognito
 import eu.kanade.domain.source.interactor.ToggleLanguage
 import eu.kanade.domain.source.interactor.ToggleSource
@@ -189,10 +192,13 @@ class DomainModule : InjektModule {
         addFactory { GetRemoteManga(get()) }
         addFactory { GetSourcesWithFavoriteCount(get(), get()) }
         addFactory { GetSourcesWithNonLibraryManga(get()) }
+        addFactory { GetSourcePinGroups(get()) }
         addFactory { SetMigrateSorting(get()) }
+        addFactory { SetSourcePinGroups(get()) }
         addFactory { ToggleLanguage(get()) }
         addFactory { ToggleSource(get()) }
         addFactory { ToggleSourcePin(get()) }
+        addFactory { DeleteSourcePinGroup(get()) }
         addFactory { TrustExtension(get(), get()) }
 
         addSingletonFactory { ExtensionStoreService(get(), get(), get()) }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/DeleteSourcePinGroup.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/DeleteSourcePinGroup.kt
@@ -1,0 +1,16 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.core.common.preference.getAndSet
+
+class DeleteSourcePinGroup(
+    private val preferences: SourcePreferences,
+) {
+
+    fun await(group: String) {
+        preferences.groupPinnedSources.getAndSet { entries ->
+            entries.filterNot { it.substringBeforeLast("|") == group }
+                .toSet()
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetEnabledSources.kt
@@ -18,18 +18,30 @@ class GetEnabledSources(
     fun subscribe(): Flow<List<Source>> {
         return combine(
             preferences.pinnedSources.changes(),
+            preferences.groupPinnedSources.changes(),
             preferences.enabledLanguages.changes(),
             preferences.disabledSources.changes(),
             preferences.lastUsedSource.changes(),
             repository.getSources(),
-        ) { pinnedSourceIds, enabledLanguages, disabledSources, lastUsedSource, sources ->
+        ) { args ->
+            val pinnedSourceIds = args[0] as Set<String>
+            val groupPinnedSources = args[1] as Set<String>
+            val enabledLanguages = args[2] as Set<String>
+            val disabledSources = args[3] as Set<String>
+            val lastUsedSource = args[4] as Long
+            val sources = args[5] as List<Source>
+
             sources
                 .filter { it.lang in enabledLanguages || it.isLocal() }
                 .filterNot { it.id.toString() in disabledSources }
                 .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
                 .flatMap {
                     val flag = if ("${it.id}" in pinnedSourceIds) Pins.pinned else Pins.unpinned
-                    val source = it.copy(pin = flag)
+                    val sourceGroups = groupPinnedSources
+                        .filter { entry -> entry.endsWith("|${it.id}") }
+                        .map { entry -> entry.substringBeforeLast("|") }
+                        .toSet()
+                    val source = it.copy(pin = flag, pinnedGroups = sourceGroups)
                     val toFlatten = mutableListOf(source)
                     if (source.id == lastUsedSource) {
                         toFlatten.add(source.copy(isUsedLast = true, pin = source.pin - Pin.Actual))

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetSourcePinGroups.kt
@@ -1,0 +1,21 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.domain.source.model.Source
+
+class GetSourcePinGroups(
+    private val preferences: SourcePreferences,
+) {
+
+    fun execute(source: Source): Pair<List<String>, List<Boolean>> {
+        val allPinGroups = preferences.groupPinnedSources.get()
+            .map { it.substringBeforeLast("|") }
+            .distinct()
+
+        val sourcePinnedGroups = preferences.groupPinnedSources.get()
+            .filter { it.endsWith("|${source.id}") }
+            .map { it.substringBeforeLast("|") }
+
+        return allPinGroups to allPinGroups.map { it in sourcePinnedGroups }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/interactor/SetSourcePinGroups.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/SetSourcePinGroups.kt
@@ -1,0 +1,22 @@
+package eu.kanade.domain.source.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import tachiyomi.core.common.preference.getAndSet
+import tachiyomi.domain.source.model.Source
+
+class SetSourcePinGroups(
+    private val preferences: SourcePreferences,
+) {
+
+    fun await(source: Source, groups: Set<String>) {
+        val newEntries = groups.map { "$it|${source.id}" }.toSet()
+
+        val prevEntries = preferences.groupPinnedSources.get().filter {
+            it.substringAfterLast("|") == source.id.toString()
+        }.toSet()
+
+        preferences.groupPinnedSources.getAndSet { entries ->
+            entries.minus(prevEntries).plus(newEntries)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -31,6 +31,14 @@ class SourcePreferences(
 
     val pinnedSources: Preference<Set<String>> = preferenceStore.getStringSet("pinned_catalogues", emptySet())
 
+    /**
+     * Format: { "$group_name|$sourceid" }
+     */
+    val groupPinnedSources: Preference<Set<String>> = preferenceStore.getStringSet(
+        "group_pinned_catalogues",
+        emptySet(),
+    )
+
     val lastUsedSource: Preference<Long> = preferenceStore.getLong(
         Preference.appStateKey("last_catalogue_source"),
         -1,

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -42,6 +42,7 @@ fun GlobalSearchScreen(
                 onSearch = onSearch,
                 hideSourceFilter = false,
                 sourceFilter = state.sourceFilter,
+                pinGroups = state.pinGroups,
                 onChangeSearchFilter = onChangeSearchFilter,
                 onlyShowHasResults = state.onlyShowHasResults,
                 onToggleResults = onToggleResults,

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -1,22 +1,39 @@
 package eu.kanade.presentation.browse
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -44,6 +61,8 @@ fun SourcesScreen(
     contentPadding: PaddingValues,
     onClickItem: (Source, Listing) -> Unit,
     onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
     onLongClickItem: (Source) -> Unit,
 ) {
     when {
@@ -67,7 +86,7 @@ fun SourcesScreen(
                     key = {
                         when (it) {
                             is SourceUiModel.Header -> it.hashCode()
-                            is SourceUiModel.Item -> "source-${it.source.key()}"
+                            is SourceUiModel.Item -> "source-${it.sectionKey}-${it.source.key()}"
                         }
                     },
                 ) { model ->
@@ -76,14 +95,18 @@ fun SourcesScreen(
                             SourceHeader(
                                 modifier = Modifier.animateItem(),
                                 language = model.language,
+                                isGroup = model.isGroup,
                             )
                         }
                         is SourceUiModel.Item -> SourceItem(
                             modifier = Modifier.animateItem(),
                             source = model.source,
+                            groupSection = model.sectionKey.ifEmpty { null },
                             onClickItem = onClickItem,
                             onLongClickItem = onLongClickItem,
                             onClickPin = onClickPin,
+                            onLongClickPin = onLongClickPin,
+                            onRemoveFromGroup = onRemoveFromGroup,
                         )
                     }
                 }
@@ -96,10 +119,11 @@ fun SourcesScreen(
 private fun SourceHeader(
     language: String,
     modifier: Modifier = Modifier,
+    isGroup: Boolean = false,
 ) {
     val context = LocalContext.current
     Text(
-        text = LocaleHelper.getSourceDisplayName(language, context),
+        text = if (isGroup) language else LocaleHelper.getSourceDisplayName(language, context),
         modifier = modifier
             .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
         style = MaterialTheme.typography.header,
@@ -109,9 +133,12 @@ private fun SourceHeader(
 @Composable
 private fun SourceItem(
     source: Source,
+    groupSection: String?,
     onClickItem: (Source, Listing) -> Unit,
     onLongClickItem: (Source) -> Unit,
     onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BaseSourceItem(
@@ -131,8 +158,11 @@ private fun SourceItem(
                 }
             }
             SourcePinButton(
-                isPinned = Pin.Pinned in source.pin,
-                onClick = { onClickPin(source) },
+                source = source,
+                groupSection = groupSection,
+                onClickPin = onClickPin,
+                onLongClickPin = onLongClickPin,
+                onRemoveFromGroup = onRemoveFromGroup,
             )
         },
     )
@@ -140,19 +170,57 @@ private fun SourceItem(
 
 @Composable
 private fun SourcePinButton(
-    isPinned: Boolean,
-    onClick: () -> Unit,
+    source: Source,
+    groupSection: String?,
+    onClickPin: (Source) -> Unit,
+    onLongClickPin: (Source) -> Unit,
+    onRemoveFromGroup: (Source, String) -> Unit,
 ) {
-    val icon = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin
-    val tint = if (isPinned) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.onBackground.copy(
-            alpha = SECONDARY_ALPHA,
-        )
+    val isPinned = Pin.Pinned in source.pin
+    val isInGroup = source.pinnedGroups.isNotEmpty()
+    val showGroupIcon = groupSection != null || (isInGroup && !isPinned)
+
+    val icon = when {
+        showGroupIcon -> Icons.AutoMirrored.Filled.Label
+        isPinned -> Icons.Filled.PushPin
+        else -> Icons.Outlined.PushPin
     }
-    val description = if (isPinned) MR.strings.action_unpin else MR.strings.action_pin
-    IconButton(onClick = onClick) {
+    val tint = when {
+        showGroupIcon -> MaterialTheme.colorScheme.secondary
+        isPinned -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onBackground.copy(alpha = SECONDARY_ALPHA)
+    }
+    val description = when {
+        groupSection != null -> MR.strings.action_remove
+        showGroupIcon -> MR.strings.action_pin_groups
+        isPinned -> MR.strings.action_unpin
+        else -> MR.strings.action_pin
+    }
+    // In a group section: remove from that group; grouped elsewhere: open dialog; else: toggle pin.
+    val onClick: () -> Unit = when {
+        groupSection != null -> {
+            { onRemoveFromGroup(source, groupSection) }
+        }
+        showGroupIcon -> {
+            { onLongClickPin(source) }
+        }
+        else -> {
+            { onClickPin(source) }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .minimumInteractiveComponentSize()
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = { onLongClickPin(source) },
+                role = androidx.compose.ui.semantics.Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple(bounded = false, radius = 24.dp),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
         Icon(
             imageVector = icon,
             tint = tint,
@@ -165,6 +233,7 @@ private fun SourcePinButton(
 fun SourceOptionsDialog(
     source: Source,
     onClickPin: () -> Unit,
+    onClickPinGroups: () -> Unit,
     onClickDisable: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -179,6 +248,13 @@ fun SourceOptionsDialog(
                     text = stringResource(textId),
                     modifier = Modifier
                         .clickable(onClick = onClickPin)
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                )
+                Text(
+                    text = stringResource(MR.strings.action_pin_groups),
+                    modifier = Modifier
+                        .clickable(onClick = onClickPinGroups)
                         .fillMaxWidth()
                         .padding(vertical = 16.dp),
                 )
@@ -198,7 +274,145 @@ fun SourceOptionsDialog(
     )
 }
 
+@Composable
+fun SourcePinGroupsDialog(
+    pinGroups: Pair<List<String>, List<Boolean>>,
+    isPinned: Boolean,
+    onTogglePin: () -> Unit,
+    onConfirm: (Set<String>) -> Unit,
+    onDeleteGroup: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val (initialGroups, initialSelections) = pinGroups
+    val groups = remember {
+        mutableStateListOf<String>().apply { addAll(initialGroups) }
+    }
+    val selectedIndices = remember {
+        mutableStateListOf<Boolean>().apply { addAll(initialSelections) }
+    }
+    var pinned by remember { mutableStateOf(isPinned) }
+    var newGroupName by remember { mutableStateOf("") }
+    var createNewGroup by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        title = {
+            Text(text = stringResource(MR.strings.action_pin_groups))
+        },
+        text = {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            pinned = !pinned
+                            onTogglePin()
+                        }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = if (pinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = null,
+                        tint = if (pinned) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                    Text(
+                        text = stringResource(if (pinned) MR.strings.action_unpin else MR.strings.action_pin),
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+                groups.forEachIndexed { index, group ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                selectedIndices[index] = !selectedIndices[index]
+                            }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = selectedIndices[index],
+                            onCheckedChange = null,
+                        )
+                        Text(
+                            text = group,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 12.dp),
+                        )
+                        IconButton(
+                            onClick = {
+                                onDeleteGroup(group)
+                                groups.removeAt(index)
+                                selectedIndices.removeAt(index)
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Delete,
+                                contentDescription = stringResource(MR.strings.action_delete),
+                            )
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { createNewGroup = !createNewGroup }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Checkbox(
+                        checked = createNewGroup,
+                        onCheckedChange = null,
+                    )
+                    OutlinedTextField(
+                        value = newGroupName,
+                        onValueChange = {
+                            newGroupName = it
+                            createNewGroup = it.isNotBlank()
+                        },
+                        modifier = Modifier
+                            .padding(start = 12.dp)
+                            .fillMaxWidth(),
+                        placeholder = { Text(text = stringResource(MR.strings.action_add_pin_group)) },
+                        singleLine = true,
+                    )
+                }
+            }
+        },
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val finalGroups = groups
+                        .filterIndexed { index, _ -> selectedIndices[index] }
+                        .toMutableSet()
+
+                    if (createNewGroup && newGroupName.isNotBlank()) {
+                        finalGroups.add(newGroupName.trim())
+                    }
+                    onConfirm(finalGroups)
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+}
+
 sealed interface SourceUiModel {
-    data class Item(val source: Source) : SourceUiModel
-    data class Header(val language: String) : SourceUiModel
+    data class Item(val source: Source, val sectionKey: String = "") : SourceUiModel
+    data class Header(val language: String, val isGroup: Boolean = false) : SourceUiModel
 }

--- a/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
@@ -42,6 +43,7 @@ fun GlobalSearchToolbar(
     onSearch: (String) -> Unit,
     hideSourceFilter: Boolean,
     sourceFilter: SourceFilter,
+    pinGroups: List<String> = emptyList(),
     onChangeSearchFilter: (SourceFilter) -> Unit,
     onlyShowHasResults: Boolean,
     onToggleResults: () -> Unit,
@@ -105,6 +107,23 @@ fun GlobalSearchToolbar(
                         Text(text = stringResource(MR.strings.all))
                     },
                 )
+                pinGroups.forEach { group ->
+                    FilterChip(
+                        selected = sourceFilter == SourceFilter.Group(group),
+                        onClick = { onChangeSearchFilter(SourceFilter.Group(group)) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.Label,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(FilterChipDefaults.IconSize),
+                            )
+                        },
+                        label = {
+                            Text(text = group)
+                        },
+                    )
+                }
 
                 VerticalDivider()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
@@ -3,7 +3,10 @@ package eu.kanade.tachiyomi.ui.browse.source
 import androidx.compose.runtime.Immutable
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.interactor.DeleteSourcePinGroup
 import eu.kanade.domain.source.interactor.GetEnabledSources
+import eu.kanade.domain.source.interactor.GetSourcePinGroups
+import eu.kanade.domain.source.interactor.SetSourcePinGroups
 import eu.kanade.domain.source.interactor.ToggleSource
 import eu.kanade.domain.source.interactor.ToggleSourcePin
 import eu.kanade.presentation.browse.SourceUiModel
@@ -25,6 +28,9 @@ class SourcesScreenModel(
     private val getEnabledSources: GetEnabledSources = Injekt.get(),
     private val toggleSource: ToggleSource = Injekt.get(),
     private val toggleSourcePin: ToggleSourcePin = Injekt.get(),
+    private val setSourcePinGroups: SetSourcePinGroups = Injekt.get(),
+    private val getSourcePinGroups: GetSourcePinGroups = Injekt.get(),
+    private val deleteSourcePinGroup: DeleteSourcePinGroup = Injekt.get(),
 ) : StateScreenModel<SourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -63,17 +69,30 @@ class SourcesScreenModel(
                 }
             }
 
+            val groupNames = sources.flatMap { it.pinnedGroups }.distinct().sorted()
+            val groupSections = groupNames.flatMap { group ->
+                listOf<SourceUiModel>(SourceUiModel.Header(group, isGroup = true)) +
+                    sources.filter { !it.isUsedLast && group in it.pinnedGroups }
+                        .map { SourceUiModel.Item(it, sectionKey = group) }
+            }
+
+            val items = buildList {
+                var groupsInserted = false
+                for ((key, value) in byLang) {
+                    val isSpecial = key == LAST_USED_KEY || key == PINNED_KEY
+                    if (!isSpecial && !groupsInserted) {
+                        addAll(groupSections)
+                        groupsInserted = true
+                    }
+                    add(SourceUiModel.Header(key))
+                    value.forEach { add(SourceUiModel.Item(it)) }
+                }
+                if (!groupsInserted) addAll(groupSections)
+            }
+
             state.copy(
                 isLoading = false,
-                items = byLang
-                    .flatMap {
-                        listOf(
-                            SourceUiModel.Header(it.key),
-                            *it.value.map { source ->
-                                SourceUiModel.Item(source)
-                            }.toTypedArray(),
-                        )
-                    },
+                items = items,
             )
         }
     }
@@ -86,8 +105,28 @@ class SourcesScreenModel(
         toggleSourcePin.await(source)
     }
 
+    fun setSourcePinGroups(source: Source, pinGroups: Set<String>) {
+        setSourcePinGroups.await(source, pinGroups)
+    }
+
+    fun removeSourceFromGroup(source: Source, group: String) {
+        setSourcePinGroups.await(source, source.pinnedGroups - group)
+    }
+
+    fun getSourcePinGroups(source: Source): Pair<List<String>, List<Boolean>> {
+        return getSourcePinGroups.execute(source)
+    }
+
+    fun deleteSourcePinGroup(pinGroup: String) {
+        deleteSourcePinGroup.await(pinGroup)
+    }
+
     fun showSourceDialog(source: Source) {
-        mutableState.update { it.copy(dialog = Dialog(source)) }
+        mutableState.update { it.copy(dialog = Dialog.SourceOptions(source)) }
+    }
+
+    fun showPinGroupsDialog(source: Source) {
+        mutableState.update { it.copy(dialog = Dialog.PinGroups(source)) }
     }
 
     fun closeDialog() {
@@ -98,7 +137,10 @@ class SourcesScreenModel(
         data object FailedFetchingSources : Event
     }
 
-    data class Dialog(val source: Source)
+    sealed interface Dialog {
+        data class SourceOptions(val source: Source) : Dialog
+        data class PinGroups(val source: Source) : Dialog
+    }
 
     @Immutable
     data class State(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -12,6 +12,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.SourceOptionsDialog
+import eu.kanade.presentation.browse.SourcePinGroupsDialog
 import eu.kanade.presentation.browse.SourcesScreen
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
@@ -19,6 +20,7 @@ import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import tachiyomi.domain.source.model.Pin
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 
@@ -51,22 +53,47 @@ fun Screen.sourcesTab(): TabContent {
                 },
                 onClickPin = screenModel::togglePin,
                 onLongClickItem = screenModel::showSourceDialog,
+                onLongClickPin = screenModel::showPinGroupsDialog,
+                onRemoveFromGroup = screenModel::removeSourceFromGroup,
             )
 
-            state.dialog?.let { dialog ->
-                val source = dialog.source
-                SourceOptionsDialog(
-                    source = source,
-                    onClickPin = {
-                        screenModel.togglePin(source)
-                        screenModel.closeDialog()
-                    },
-                    onClickDisable = {
-                        screenModel.toggleSource(source)
-                        screenModel.closeDialog()
-                    },
-                    onDismiss = screenModel::closeDialog,
-                )
+            val currentDialog = state.dialog
+
+            if (currentDialog != null) {
+                when (currentDialog) {
+                    is SourcesScreenModel.Dialog.SourceOptions -> {
+                        val source = currentDialog.source
+                        SourceOptionsDialog(
+                            source = source,
+                            onClickPin = {
+                                screenModel.togglePin(source)
+                                screenModel.closeDialog()
+                            },
+                            onClickPinGroups = {
+                                screenModel.showPinGroupsDialog(source)
+                            },
+                            onClickDisable = {
+                                screenModel.toggleSource(source)
+                                screenModel.closeDialog()
+                            },
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                    is SourcesScreenModel.Dialog.PinGroups -> {
+                        val source = currentDialog.source
+                        SourcePinGroupsDialog(
+                            pinGroups = screenModel.getSourcePinGroups(source),
+                            isPinned = Pin.Pinned in source.pin,
+                            onTogglePin = { screenModel.togglePin(source) },
+                            onConfirm = { selectedGroups ->
+                                screenModel.setSourcePinGroups(source, selectedGroups)
+                                screenModel.closeDialog()
+                            },
+                            onDeleteGroup = screenModel::deleteSourcePinGroup,
+                            onDismiss = screenModel::closeDialog,
+                        )
+                    }
+                }
             }
 
             val internalErrString = stringResource(MR.strings.internal_error)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -19,7 +19,14 @@ class GlobalSearchScreenModel(
     }
 
     override fun getEnabledSources(): List<Source> {
+        val filter = state.value.sourceFilter
         return super.getEnabledSources()
-            .filter { state.value.sourceFilter != SourceFilter.PinnedOnly || "${it.id}" in pinnedSources }
+            .filter {
+                when (filter) {
+                    SourceFilter.All -> true
+                    SourceFilter.PinnedOnly -> "${it.id}" in pinnedSources
+                    is SourceFilter.Group -> "${it.id}" in sourceGroups.getOrElse(filter.name) { emptySet() }
+                }
+            }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -47,6 +47,12 @@ abstract class SearchScreenModel(
     private val disabledSources = sourcePreferences.disabledSources.get()
     protected val pinnedSources = sourcePreferences.pinnedSources.get()
 
+    // Group name -> member source ids
+    protected val sourceGroups: Map<String, Set<String>> =
+        sourcePreferences.groupPinnedSources.get()
+            .groupBy({ it.substringBeforeLast("|") }, { it.substringAfterLast("|") })
+            .mapValues { (_, ids) -> ids.toSet() }
+
     private var lastQuery: String? = null
     private var lastSourceFilter: SourceFilter? = null
 
@@ -61,6 +67,7 @@ abstract class SearchScreenModel(
     }
 
     init {
+        mutableState.update { it.copy(pinGroups = sourceGroups.keys.sorted()) }
         screenModelScope.launch {
             preferences.globalSearchFilterState.changes().collectLatest { state ->
                 mutableState.update { it.copy(onlyShowHasResults = state) }
@@ -207,6 +214,7 @@ abstract class SearchScreenModel(
         val from: Manga? = null,
         val searchQuery: String? = null,
         val sourceFilter: SourceFilter = SourceFilter.PinnedOnly,
+        val pinGroups: List<String> = emptyList(),
         val onlyShowHasResults: Boolean = false,
         val items: Map<Source, SearchItemResult> = mapOf(),
         val dialog: Dialog? = null,
@@ -221,9 +229,10 @@ abstract class SearchScreenModel(
     }
 }
 
-enum class SourceFilter {
-    All,
-    PinnedOnly,
+sealed interface SourceFilter {
+    data object All : SourceFilter
+    data object PinnedOnly : SourceFilter
+    data class Group(val name: String) : SourceFilter
 }
 
 sealed interface SearchItemResult {

--- a/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
@@ -7,6 +7,7 @@ data class Source(
     val supportsLatest: Boolean,
     val isStub: Boolean,
     val pin: Pins = Pins.unpinned,
+    val pinnedGroups: Set<String> = emptySet(),
     val isUsedLast: Boolean = false,
 ) {
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -132,6 +132,8 @@
     <string name="action_disable">Disable</string>
     <string name="action_pin">Pin</string>
     <string name="action_unpin">Unpin</string>
+    <string name="action_pin_groups">Source groups</string>
+    <string name="action_add_pin_group">Add source group</string>
     <string name="action_apply">Apply</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_ok">OK</string>


### PR DESCRIPTION
Add the ability to organize sources into named groups (issue #3385), alongside the existing single pinned state.

Group membership is persisted as a `Set<String>` preference of `"group|sourceId"` entries — mirroring how pinned sources are already stored — and is kept separate from the existing `Pins` bitflags (which can't represent arbitrary named groups).

Long-press a source's pin icon to open a dialog to pin/unpin and check/uncheck its groups, create a new group, or delete a group. This dialog can also be accessed by a new entry in the source options dialog.
Grouped sources appear as their own sections (between Pinned and the language sections). Tapping the group icon within a group's section removes the source from that group; tapping it elsewhere opens the dialog.
A filter chip per group scopes a global search to that group's sources, next to the existing Pinned/All chips.

Only `base/strings.xml` is touched for new strings; translations are left to Weblate.

Closes #3385

### Images
| Sources list | New source options dialog | Groups dialog | Global search |
| - | - | - | - |
| ![](https://github.com/user-attachments/assets/0745205f-b39a-4130-831b-fc9991bd892a) | ![](https://github.com/user-attachments/assets/03f60e0f-631a-4925-a609-464f7448f23e) | ![](https://github.com/user-attachments/assets/ddcc6eb9-80fe-4f5f-898f-025e4186e26f) | ![](https://github.com/user-attachments/assets/c3fe63b2-c600-4803-be73-286662e74bf7) |

### Testing
- `./gradlew :app:compileDebugKotlin` — builds successfully
- `./gradlew spotlessCheck` — ktlint/formatting passes
- `./gradlew test` — unit test suite passes (no regressions)
- Manually tested the functionality on-device, as shown in the images above