### PR TITLE
feat: Add SyncYomi cross-device sync (port from TachiyomiSY)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
@@ -1,0 +1,85 @@
+package eu.kanade.domain.sync
+
+import eu.kanade.domain.sync.models.SyncSettings
+import eu.kanade.tachiyomi.data.sync.models.SyncTriggerOptions
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+import java.util.UUID
+
+class SyncPreferences(
+    private val preferenceStore: PreferenceStore,
+) {
+    val clientHost: Preference<String> = preferenceStore.getString("sync_client_host", "")
+    val clientAPIKey: Preference<String> = preferenceStore.getString("sync_client_api_key", "")
+    val lastSyncTimestamp: Preference<Long> = preferenceStore.getLong(Preference.appStateKey("last_sync_timestamp"), 0L)
+
+    val lastSyncEtag: Preference<String> = preferenceStore.getString("sync_etag", "")
+
+    val syncInterval: Preference<Int> = preferenceStore.getInt("sync_interval", 0)
+    val syncService: Preference<Int> = preferenceStore.getInt("sync_service", 0)
+
+    fun uniqueDeviceID(): String {
+        val uniqueIDPreference = preferenceStore.getString(Preference.appStateKey("unique_device_id"), "")
+
+        // Retrieve the current value of the preference
+        var uniqueID = uniqueIDPreference.get()
+        if (uniqueID.isBlank()) {
+            uniqueID = UUID.randomUUID().toString()
+            uniqueIDPreference.set(uniqueID)
+        }
+
+        return uniqueID
+    }
+
+    fun isSyncEnabled(): Boolean {
+        return syncService.get() != 0
+    }
+
+    fun getSyncSettings(): SyncSettings {
+        return SyncSettings(
+            libraryEntries = preferenceStore.getBoolean("library_entries", true).get(),
+            categories = preferenceStore.getBoolean("categories", true).get(),
+            chapters = preferenceStore.getBoolean("chapters", true).get(),
+            tracking = preferenceStore.getBoolean("tracking", true).get(),
+            history = preferenceStore.getBoolean("history", true).get(),
+            readEntries = preferenceStore.getBoolean("readEntries", true).get(),
+            appSettings = preferenceStore.getBoolean("appSettings", true).get(),
+            extensionStores = preferenceStore.getBoolean("extensionStores", true).get(),
+            sourceSettings = preferenceStore.getBoolean("sourceSettings", true).get(),
+            privateSettings = preferenceStore.getBoolean("privateSettings", false).get(),
+        )
+    }
+
+    fun setSyncSettings(syncSettings: SyncSettings) {
+        preferenceStore.getBoolean("library_entries", true).set(syncSettings.libraryEntries)
+        preferenceStore.getBoolean("categories", true).set(syncSettings.categories)
+        preferenceStore.getBoolean("chapters", true).set(syncSettings.chapters)
+        preferenceStore.getBoolean("tracking", true).set(syncSettings.tracking)
+        preferenceStore.getBoolean("history", true).set(syncSettings.history)
+        preferenceStore.getBoolean("readEntries", true).set(syncSettings.readEntries)
+        preferenceStore.getBoolean("appSettings", true).set(syncSettings.appSettings)
+        preferenceStore.getBoolean("extensionStores", true).set(syncSettings.extensionStores)
+        preferenceStore.getBoolean("sourceSettings", true).set(syncSettings.sourceSettings)
+        preferenceStore.getBoolean("privateSettings", false).set(syncSettings.privateSettings)
+    }
+
+    fun getSyncTriggerOptions(): SyncTriggerOptions {
+        return SyncTriggerOptions(
+            syncOnChapterRead = preferenceStore.getBoolean("sync_on_chapter_read", false).get(),
+            syncOnChapterOpen = preferenceStore.getBoolean("sync_on_chapter_open", false).get(),
+            syncOnAppStart = preferenceStore.getBoolean("sync_on_app_start", false).get(),
+            syncOnAppResume = preferenceStore.getBoolean("sync_on_app_resume", false).get(),
+        )
+    }
+
+    fun setSyncTriggerOptions(syncTriggerOptions: SyncTriggerOptions) {
+        preferenceStore.getBoolean("sync_on_chapter_read", false)
+            .set(syncTriggerOptions.syncOnChapterRead)
+        preferenceStore.getBoolean("sync_on_chapter_open", false)
+            .set(syncTriggerOptions.syncOnChapterOpen)
+        preferenceStore.getBoolean("sync_on_app_start", false)
+            .set(syncTriggerOptions.syncOnAppStart)
+        preferenceStore.getBoolean("sync_on_app_resume", false)
+            .set(syncTriggerOptions.syncOnAppResume)
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/sync/models/SyncSettings.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/models/SyncSettings.kt
@@ -1,0 +1,14 @@
+package eu.kanade.domain.sync.models
+
+data class SyncSettings(
+    val libraryEntries: Boolean = true,
+    val categories: Boolean = true,
+    val chapters: Boolean = true,
+    val tracking: Boolean = true,
+    val history: Boolean = true,
+    val readEntries: Boolean = true,
+    val appSettings: Boolean = true,
+    val extensionStores: Boolean = true,
+    val sourceSettings: Boolean = true,
+    val privateSettings: Boolean = false,
+)

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -36,6 +36,7 @@ fun LibraryToolbar(
     onClickRefresh: () -> Unit,
     onClickGlobalUpdate: () -> Unit,
     onClickOpenRandomManga: () -> Unit,
+    onClickSyncNow: () -> Unit,
     searchQuery: String?,
     onSearchQueryChange: (String?) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior?,
@@ -55,6 +56,7 @@ fun LibraryToolbar(
         onClickRefresh = onClickRefresh,
         onClickGlobalUpdate = onClickGlobalUpdate,
         onClickOpenRandomManga = onClickOpenRandomManga,
+        onClickSyncNow = onClickSyncNow,
         scrollBehavior = scrollBehavior,
     )
 }
@@ -69,6 +71,7 @@ private fun LibraryRegularToolbar(
     onClickRefresh: () -> Unit,
     onClickGlobalUpdate: () -> Unit,
     onClickOpenRandomManga: () -> Unit,
+    onClickSyncNow: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior?,
 ) {
     val pillAlpha = if (isSystemInDarkTheme()) 0.12f else 0.08f
@@ -113,6 +116,10 @@ private fun LibraryRegularToolbar(
                     AppBar.OverflowAction(
                         title = stringResource(MR.strings.action_open_random_manga),
                         onClick = onClickOpenRandomManga,
+                    ),
+                    AppBar.OverflowAction(
+                        title = stringResource(MR.strings.sync_library),
+                        onClick = onClickSyncNow,
                     ),
                 ),
             )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -42,10 +42,13 @@ import androidx.core.net.toUri
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.hippo.unifile.UniFile
+import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.screen.data.CreateBackupScreen
 import eu.kanade.presentation.more.settings.screen.data.RestoreBackupScreen
 import eu.kanade.presentation.more.settings.screen.data.StorageInfo
+import eu.kanade.presentation.more.settings.screen.data.SyncSettingsSelector
+import eu.kanade.presentation.more.settings.screen.data.SyncTriggerOptionsScreen
 import eu.kanade.presentation.more.settings.widget.BasePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.PrefsHorizontalPadding
 import eu.kanade.presentation.util.relativeTimeSpanString
@@ -54,6 +57,8 @@ import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
 import eu.kanade.tachiyomi.data.cache.ChapterCache
 import eu.kanade.tachiyomi.data.export.LibraryExporter
 import eu.kanade.tachiyomi.data.export.LibraryExporter.ExportOptions
+import eu.kanade.tachiyomi.data.sync.SyncDataJob
+import eu.kanade.tachiyomi.data.sync.SyncManager
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
@@ -101,6 +106,9 @@ object SettingsDataScreen : SearchableSettings {
         val backupPreferences = Injekt.get<BackupPreferences>()
         val storagePreferences = Injekt.get<StoragePreferences>()
 
+        val syncPreferences = remember { Injekt.get<SyncPreferences>() }
+        val syncService by syncPreferences.syncService.collectAsState()
+
         return listOf(
             getStorageLocationPref(storagePreferences = storagePreferences),
             Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.pref_storage_location_info)),
@@ -108,7 +116,7 @@ object SettingsDataScreen : SearchableSettings {
             getBackupAndRestoreGroup(backupPreferences = backupPreferences),
             getDataGroup(),
             getExportGroup(),
-        )
+        ) + getSyncPreferences(syncPreferences = syncPreferences, syncService = syncService)
     }
 
     @Composable
@@ -460,6 +468,144 @@ object SettingsDataScreen : SearchableSettings {
                     Text(text = stringResource(MR.strings.action_cancel))
                 }
             },
+        )
+    }
+
+    @Composable
+    private fun getSyncPreferences(syncPreferences: SyncPreferences, syncService: Int): List<Preference> {
+        return listOf(
+            Preference.PreferenceGroup(
+                title = stringResource(MR.strings.pref_sync_service_category),
+                preferenceItems = listOf(
+                    Preference.PreferenceItem.ListPreference(
+                        preference = syncPreferences.syncService,
+                        title = stringResource(MR.strings.pref_sync_service),
+                        entries = mapOf(
+                            SyncManager.SyncService.NONE.value to stringResource(MR.strings.off),
+                            SyncManager.SyncService.SYNCYOMI.value to stringResource(MR.strings.syncyomi),
+                        ),
+                        onValueChanged = { true },
+                    ),
+                ),
+            ),
+        ) + getSyncServicePreferences(syncPreferences, syncService)
+    }
+
+    @Composable
+    private fun getSyncServicePreferences(syncPreferences: SyncPreferences, syncService: Int): List<Preference> {
+        val syncServiceType = SyncManager.SyncService.fromInt(syncService)
+
+        val basePreferences = getBasePreferences(syncServiceType, syncPreferences)
+
+        return if (syncServiceType != SyncManager.SyncService.NONE) {
+            basePreferences + getAdditionalPreferences(syncPreferences)
+        } else {
+            basePreferences
+        }
+    }
+
+    @Composable
+    private fun getBasePreferences(
+        syncServiceType: SyncManager.SyncService,
+        syncPreferences: SyncPreferences,
+    ): List<Preference> {
+        return when (syncServiceType) {
+            SyncManager.SyncService.NONE -> emptyList()
+            SyncManager.SyncService.SYNCYOMI -> getSelfHostPreferences(syncPreferences)
+        }
+    }
+
+    @Composable
+    private fun getAdditionalPreferences(syncPreferences: SyncPreferences): List<Preference> {
+        return listOf(getSyncNowPref(), getAutomaticSyncGroup(syncPreferences))
+    }
+
+    @Composable
+    private fun getSelfHostPreferences(syncPreferences: SyncPreferences): List<Preference> {
+        val scope = rememberCoroutineScope()
+        return listOf(
+            Preference.PreferenceItem.EditTextPreference(
+                title = stringResource(MR.strings.pref_sync_host),
+                subtitle = stringResource(MR.strings.pref_sync_host_summ),
+                preference = syncPreferences.clientHost,
+                onValueChanged = { newValue ->
+                    scope.launch {
+                        // Trim spaces at the beginning and end, then remove trailing slash if present
+                        val trimmedValue = newValue.trim()
+                        val modifiedValue = trimmedValue.trimEnd { it == '/' }
+                        syncPreferences.clientHost.set(modifiedValue)
+                    }
+                    true
+                },
+            ),
+            Preference.PreferenceItem.EditTextPreference(
+                title = stringResource(MR.strings.pref_sync_api_key),
+                subtitle = stringResource(MR.strings.pref_sync_api_key_summ),
+                preference = syncPreferences.clientAPIKey,
+            ),
+        )
+    }
+
+    @Composable
+    private fun getSyncNowPref(): Preference.PreferenceGroup {
+        val navigator = LocalNavigator.currentOrThrow
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_sync_now_group_title),
+            preferenceItems = listOf(
+                getSyncOptionsPref(),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_sync_now),
+                    subtitle = stringResource(MR.strings.pref_sync_now_subtitle),
+                    onClick = {
+                        navigator.push(SyncSettingsSelector())
+                    },
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getSyncOptionsPref(): Preference.PreferenceItem.TextPreference {
+        val navigator = LocalNavigator.currentOrThrow
+        return Preference.PreferenceItem.TextPreference(
+            title = stringResource(MR.strings.pref_sync_options),
+            subtitle = stringResource(MR.strings.pref_sync_options_summ),
+            onClick = { navigator.push(SyncTriggerOptionsScreen()) },
+        )
+    }
+
+    @Composable
+    private fun getAutomaticSyncGroup(syncPreferences: SyncPreferences): Preference.PreferenceGroup {
+        val context = LocalContext.current
+        val syncIntervalPref = syncPreferences.syncInterval
+        val lastSync by syncPreferences.lastSyncTimestamp.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_sync_automatic_category),
+            preferenceItems = listOf(
+                Preference.PreferenceItem.ListPreference(
+                    preference = syncIntervalPref,
+                    title = stringResource(MR.strings.pref_sync_interval),
+                    entries = mapOf(
+                        0 to stringResource(MR.strings.off),
+                        30 to stringResource(MR.strings.update_30min),
+                        60 to stringResource(MR.strings.update_1hour),
+                        180 to stringResource(MR.strings.update_3hour),
+                        360 to stringResource(MR.strings.update_6hour),
+                        720 to stringResource(MR.strings.update_12hour),
+                        1440 to stringResource(MR.strings.update_24hour),
+                        2880 to stringResource(MR.strings.update_48hour),
+                        10080 to stringResource(MR.strings.update_weekly),
+                    ),
+                    onValueChanged = {
+                        SyncDataJob.setupTask(context, it)
+                        true
+                    },
+                ),
+                Preference.PreferenceItem.InfoPreference(
+                    stringResource(MR.strings.last_synchronization, relativeTimeSpanString(lastSync)),
+                ),
+            ),
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncSettingsSelector.kt
@@ -1,0 +1,133 @@
+package eu.kanade.presentation.more.settings.screen.data
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.domain.sync.models.SyncSettings
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.backup.create.BackupOptions
+import kotlinx.coroutines.flow.update
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.LabeledCheckbox
+import tachiyomi.presentation.core.components.LazyColumnWithAction
+import tachiyomi.presentation.core.components.SectionCard
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class SyncSettingsSelector : Screen() {
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val model = rememberScreenModel { SyncSettingsSelectorModel() }
+        val state by model.state.collectAsState()
+
+        Scaffold(
+            topBar = {
+                AppBar(
+                    title = stringResource(MR.strings.pref_choose_what_to_sync),
+                    navigateUp = navigator::pop,
+                    scrollBehavior = it,
+                )
+            },
+        ) { contentPadding ->
+            LazyColumnWithAction(
+                contentPadding = contentPadding,
+                actionLabel = stringResource(MR.strings.action_save),
+                actionEnabled = true,
+                onClickAction = {
+                    navigator.pop()
+                },
+            ) {
+                item {
+                    SectionCard(MR.strings.label_library) {
+                        Options(BackupOptions.libraryOptions, state, model)
+                    }
+                }
+
+                item {
+                    SectionCard(MR.strings.label_settings) {
+                        Options(BackupOptions.settingsOptions, state, model)
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Options(
+        options: List<BackupOptions.Entry>,
+        state: SyncSettingsSelectorModel.State,
+        model: SyncSettingsSelectorModel,
+    ) {
+        options.forEach { option ->
+            LabeledCheckbox(
+                label = stringResource(option.label),
+                checked = option.getter(state.options),
+                onCheckedChange = {
+                    model.toggle(option.setter, it)
+                },
+                enabled = option.enabled(state.options),
+            )
+        }
+    }
+}
+
+private class SyncSettingsSelectorModel(
+    val syncPreferences: SyncPreferences = Injekt.get(),
+) : StateScreenModel<SyncSettingsSelectorModel.State>(
+    State(syncOptionsToBackupOptions(syncPreferences.getSyncSettings())),
+) {
+    fun toggle(setter: (BackupOptions, Boolean) -> BackupOptions, enabled: Boolean) {
+        mutableState.update {
+            val updatedOptions = setter(it.options, enabled)
+            syncPreferences.setSyncSettings(backupOptionsToSyncOptions(updatedOptions))
+            it.copy(options = updatedOptions)
+        }
+    }
+
+    @Immutable
+    data class State(
+        val options: BackupOptions = BackupOptions(),
+    )
+
+    companion object {
+        private fun syncOptionsToBackupOptions(syncSettings: SyncSettings): BackupOptions {
+            return BackupOptions(
+                libraryEntries = syncSettings.libraryEntries,
+                categories = syncSettings.categories,
+                chapters = syncSettings.chapters,
+                tracking = syncSettings.tracking,
+                history = syncSettings.history,
+                readEntries = syncSettings.readEntries,
+                appSettings = syncSettings.appSettings,
+                extensionStores = syncSettings.extensionStores,
+                sourceSettings = syncSettings.sourceSettings,
+                privateSettings = syncSettings.privateSettings,
+            )
+        }
+
+        private fun backupOptionsToSyncOptions(backupOptions: BackupOptions): SyncSettings {
+            return SyncSettings(
+                libraryEntries = backupOptions.libraryEntries,
+                categories = backupOptions.categories,
+                chapters = backupOptions.chapters,
+                tracking = backupOptions.tracking,
+                history = backupOptions.history,
+                readEntries = backupOptions.readEntries,
+                appSettings = backupOptions.appSettings,
+                extensionStores = backupOptions.extensionStores,
+                sourceSettings = backupOptions.sourceSettings,
+                privateSettings = backupOptions.privateSettings,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncTriggerOptionsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/SyncTriggerOptionsScreen.kt
@@ -1,0 +1,100 @@
+package eu.kanade.presentation.more.settings.screen.data
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.sync.models.SyncTriggerOptions
+import kotlinx.coroutines.flow.update
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.LabeledCheckbox
+import tachiyomi.presentation.core.components.LazyColumnWithAction
+import tachiyomi.presentation.core.components.SectionCard
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class SyncTriggerOptionsScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val model = rememberScreenModel { SyncOptionsScreenModel() }
+        val state by model.state.collectAsState()
+
+        Scaffold(
+            topBar = {
+                AppBar(
+                    title = stringResource(MR.strings.pref_sync_options),
+                    navigateUp = navigator::pop,
+                    scrollBehavior = it,
+                )
+            },
+        ) { contentPadding ->
+            LazyColumnWithAction(
+                contentPadding = contentPadding,
+                actionLabel = stringResource(MR.strings.action_save),
+                actionEnabled = true,
+                onClickAction = {
+                    navigator.pop()
+                },
+            ) {
+                item {
+                    SectionCard(MR.strings.label_triggers) {
+                        Options(SyncTriggerOptions.mainOptions, state, model)
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Options(
+        options: List<SyncTriggerOptions.Entry>,
+        state: SyncOptionsScreenModel.State,
+        model: SyncOptionsScreenModel,
+    ) {
+        options.forEach { option ->
+            LabeledCheckbox(
+                label = stringResource(option.label),
+                checked = option.getter(state.options),
+                onCheckedChange = {
+                    model.toggle(option.setter, it)
+                },
+                enabled = option.enabled(state.options),
+            )
+        }
+    }
+}
+
+private class SyncOptionsScreenModel(
+    val syncPreferences: SyncPreferences = Injekt.get(),
+) : StateScreenModel<SyncOptionsScreenModel.State>(
+    State(
+        syncPreferences.getSyncTriggerOptions(),
+    ),
+) {
+
+    fun toggle(setter: (SyncTriggerOptions, Boolean) -> SyncTriggerOptions, enabled: Boolean) {
+        mutableState.update {
+            val updatedTriggerOptions = setter(it.options, enabled)
+            syncPreferences.setSyncTriggerOptions(updatedTriggerOptions)
+            it.copy(
+                options = updatedTriggerOptions,
+            )
+        }
+    }
+
+    @Immutable
+    data class State(
+        val options: SyncTriggerOptions = SyncTriggerOptions(),
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -25,6 +25,7 @@ import coil3.util.DebugLogger
 import dev.mihon.injekt.patchInjekt
 import eu.kanade.domain.DomainModule
 import eu.kanade.domain.base.BasePreferences
+import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.tachiyomi.core.security.PrivacyPreferences
@@ -36,6 +37,7 @@ import eu.kanade.tachiyomi.data.coil.MangaCoverKeyer
 import eu.kanade.tachiyomi.data.coil.MangaKeyer
 import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.data.sync.SyncDataJob
 import eu.kanade.tachiyomi.di.AppModule
 import eu.kanade.tachiyomi.di.PreferenceModule
 import eu.kanade.tachiyomi.network.NetworkHelper
@@ -169,6 +171,13 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         }
 
         initializeMigrator()
+
+        // Schedule periodic sync and trigger sync on app start if enabled
+        val syncPreferences = Injekt.get<SyncPreferences>()
+        SyncDataJob.setupTask(this)
+        if (syncPreferences.isSyncEnabled() && syncPreferences.getSyncTriggerOptions().syncOnAppStart) {
+            SyncDataJob.startNow(this@App)
+        }
     }
 
     private fun initializeMigrator() {
@@ -222,6 +231,11 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
 
     override fun onStart(owner: LifecycleOwner) {
         SecureActivityDelegate.onApplicationStart()
+
+        val syncPreferences = Injekt.get<SyncPreferences>()
+        if (syncPreferences.isSyncEnabled() && syncPreferences.getSyncTriggerOptions().syncOnAppResume) {
+            SyncDataJob.startNow(this@App)
+        }
     }
 
     override fun onStop(owner: LifecycleOwner) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -119,35 +119,35 @@ class BackupCreator(
         }
     }
 
-    private suspend fun backupCategories(options: BackupOptions): List<BackupCategory> {
+    suspend fun backupCategories(options: BackupOptions): List<BackupCategory> {
         if (!options.categories) return emptyList()
 
         return categoriesBackupCreator()
     }
 
-    private suspend fun backupMangas(mangas: List<Manga>, options: BackupOptions): List<BackupManga> {
+    suspend fun backupMangas(mangas: List<Manga>, options: BackupOptions): List<BackupManga> {
         if (!options.libraryEntries) return emptyList()
 
         return mangaBackupCreator(mangas, options)
     }
 
-    private fun backupSources(mangas: List<BackupManga>): List<BackupSource> {
+    fun backupSources(mangas: List<BackupManga>): List<BackupSource> {
         return sourcesBackupCreator(mangas)
     }
 
-    private fun backupAppPreferences(options: BackupOptions): List<BackupPreference> {
+    fun backupAppPreferences(options: BackupOptions): List<BackupPreference> {
         if (!options.appSettings) return emptyList()
 
         return preferenceBackupCreator.createApp(includePrivatePreferences = options.privateSettings)
     }
 
-    private suspend fun backupExtensionStores(options: BackupOptions): List<BackupExtensionStore> {
+    suspend fun backupExtensionStores(options: BackupOptions): List<BackupExtensionStore> {
         if (!options.extensionStores) return emptyList()
 
         return extensionStoresBackupCreator()
     }
 
-    private fun backupSourcePreferences(options: BackupOptions): List<BackupSourcePreferences> {
+    fun backupSourcePreferences(options: BackupOptions): List<BackupSourcePreferences> {
         if (!options.sourceSettings) return emptyList()
 
         return preferenceBackupCreator.createSource(includePrivatePreferences = options.privateSettings)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
@@ -5,18 +5,24 @@ import kotlinx.serialization.protobuf.ProtoNumber
 import tachiyomi.domain.category.model.Category
 
 @Serializable
-class BackupCategory(
+data class BackupCategory(
     @ProtoNumber(1) var name: String,
     @ProtoNumber(2) var order: Long = 0,
     @ProtoNumber(3) var id: Long = 0,
     // @ProtoNumber(3) val updateInterval: Int = 0, 1.x value not used in 0.x
     @ProtoNumber(100) var flags: Long = 0,
+    @ProtoNumber(601) var version: Long = 0,
+    @ProtoNumber(602) var uid: Long = 0,
+    @ProtoNumber(603) var lastModifiedAt: Long = 0,
 ) {
     fun toCategory(id: Long) = Category(
         id = id,
         name = this@BackupCategory.name,
         flags = this@BackupCategory.flags,
         order = this@BackupCategory.order,
+        version = this@BackupCategory.version,
+        uid = this@BackupCategory.uid,
+        lastModifiedAt = this@BackupCategory.lastModifiedAt,
     )
 }
 
@@ -26,5 +32,8 @@ val backupCategoryMapper = { category: Category ->
         name = category.name,
         order = category.order,
         flags = category.flags,
+        version = category.version,
+        uid = category.uid,
+        lastModifiedAt = category.lastModifiedAt,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -9,7 +9,7 @@ import tachiyomi.data.MemoColumnAdapter
 import tachiyomi.domain.chapter.model.Chapter
 
 @Serializable
-class BackupChapter(
+data class BackupChapter(
     // in 1.x some of these values have different names
     // url is called key in 1.x
     @ProtoNumber(1) var url: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupExtensionStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupExtensionStore.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.protobuf.ProtoNumber
 import mihon.domain.extension.model.ExtensionStore
 
 @Serializable
-class BackupExtensionStore(
+data class BackupExtensionStore(
     @ProtoNumber(1) var indexUrl: String,
     @ProtoNumber(2) var name: String,
     @ProtoNumber(3) var badgeLabel: String?,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -11,7 +11,7 @@ import tachiyomi.domain.manga.model.Manga
 
 @Suppress("DEPRECATION")
 @Serializable
-class BackupManga(
+data class BackupManga(
     // in 1.x some of these values have different names
     @ProtoNumber(1) var source: Long,
     // url is called key in 1.x

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -33,7 +33,7 @@ class BackupRestorer(
     private val categoriesRestorer: CategoriesRestorer = CategoriesRestorer(),
     private val preferenceRestorer: PreferenceRestorer = PreferenceRestorer(context),
     private val extensionStoreRestorer: ExtensionStoreRestorer = ExtensionStoreRestorer(),
-    private val mangaRestorer: MangaRestorer = MangaRestorer(),
+    private val mangaRestorer: MangaRestorer = MangaRestorer(isSync),
 ) {
 
     private var restoreAmount = 0

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -17,18 +17,50 @@ class CategoriesRestorer(
         if (backupCategories.isNotEmpty()) {
             val dbCategories = getCategories.await()
             val dbCategoriesByName = dbCategories.associateBy { it.name }
+            val dbCategoriesByUid = dbCategories.associateBy { it.uid }
             var nextOrder = dbCategories.maxOfOrNull { it.order }?.plus(1) ?: 0
 
             val categories = backupCategories
                 .sortedBy { it.order }
-                .map {
-                    val dbCategory = dbCategoriesByName[it.name]
-                    if (dbCategory != null) return@map dbCategory
+                .map { backupCategory ->
+                    var dbCategory = if (backupCategory.uid != 0L) {
+                        dbCategoriesByUid[backupCategory.uid]
+                    } else {
+                        null
+                    }
+
+                    if (dbCategory == null) {
+                        dbCategory = dbCategoriesByName[backupCategory.name]
+                    }
+
+                    if (dbCategory != null) {
+                        database.categoriesQueries.update(
+                            name = backupCategory.name,
+                            order = backupCategory.order,
+                            flags = backupCategory.flags,
+                            version = backupCategory.version,
+                            uid = if (backupCategory.uid != 0L) backupCategory.uid else dbCategory.uid,
+                            lastModifiedAt = backupCategory.lastModifiedAt,
+                            isSyncing = 1,
+                            categoryId = dbCategory.id,
+                        )
+                        return@map dbCategory
+                    }
+
                     val order = nextOrder++
                     database.categoriesQueries
-                        .insert(it.name, order, it.flags)
-                        .let { id -> it.toCategory(id).copy(order = order) }
+                        .insert(
+                            name = backupCategory.name,
+                            order = order,
+                            flags = backupCategory.flags,
+                            version = backupCategory.version,
+                            uid = backupCategory.uid,
+                            lastModifiedAt = backupCategory.lastModifiedAt,
+                        )
+                        .let { id -> backupCategory.toCategory(id).copy(order = order) }
                 }
+
+            database.categoriesQueries.resetIsSyncing()
 
             libraryPreferences.categorizedDisplaySettings.set(
                 (dbCategories + categories)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -29,6 +29,8 @@ import java.util.Date
 import kotlin.math.max
 
 class MangaRestorer(
+    private var isSync: Boolean = false,
+
     private val database: Database = Injekt.get(),
     private val getCategories: GetCategories = Injekt.get(),
     private val getMangaByUrlAndSourceId: GetMangaByUrlAndSourceId = Injekt.get(),
@@ -82,6 +84,11 @@ class MangaRestorer(
                 tracks = backupManga.tracking,
                 excludedScanlators = backupManga.excludedScanlators,
             )
+
+            if (isSync) {
+                database.mangasQueries.resetIsSyncing()
+                database.chaptersQueries.resetIsSyncing()
+            }
         }
     }
 
@@ -111,7 +118,7 @@ class MangaRestorer(
         )
     }
 
-    private suspend fun updateManga(manga: Manga): Manga {
+    suspend fun updateManga(manga: Manga): Manga {
         database.mangasQueries.update(
             source = manga.source,
             url = manga.url,
@@ -154,41 +161,44 @@ class MangaRestorer(
             .associateBy { it.url }
 
         val (existingChapters, newChapters) = backupChapters
-            .mapNotNull {
-                val chapter = it.toChapterImpl().copy(mangaId = manga.id)
-
+            .mapNotNull { backupChapter ->
+                val chapter = backupChapter.toChapterImpl().copy(mangaId = manga.id)
                 val dbChapter = dbChaptersByUrl[chapter.url]
-                    ?: // New chapter
-                    return@mapNotNull chapter
 
-                if (chapter.forComparison() == dbChapter.forComparison()) {
-                    // Same state; skip
-                    return@mapNotNull null
+                when {
+                    dbChapter == null -> chapter // New chapter
+                    chapter.forComparison() == dbChapter.forComparison() -> null // Same state; skip
+                    else -> updateChapterBasedOnSyncState(chapter, dbChapter)
                 }
-
-                // Update to an existing chapter
-                var updatedChapter = chapter
-                    .copyFrom(dbChapter)
-                    .copy(
-                        id = dbChapter.id,
-                        bookmark = chapter.bookmark || dbChapter.bookmark,
-                    )
-                if (dbChapter.read && !updatedChapter.read) {
-                    updatedChapter = updatedChapter.copy(
-                        read = true,
-                        lastPageRead = dbChapter.lastPageRead,
-                    )
-                } else if (updatedChapter.lastPageRead == 0L && dbChapter.lastPageRead != 0L) {
-                    updatedChapter = updatedChapter.copy(
-                        lastPageRead = dbChapter.lastPageRead,
-                    )
-                }
-                updatedChapter
             }
             .partition { it.id > 0 }
 
         insertNewChapters(newChapters)
         updateExistingChapters(existingChapters)
+    }
+
+    private fun updateChapterBasedOnSyncState(chapter: Chapter, dbChapter: Chapter): Chapter {
+        return if (isSync) {
+            chapter.copy(
+                id = dbChapter.id,
+                bookmark = chapter.bookmark || dbChapter.bookmark,
+                read = chapter.read,
+                lastPageRead = chapter.lastPageRead,
+            )
+        } else {
+            chapter.copyFrom(dbChapter).let {
+                when {
+                    dbChapter.read && !it.read -> it.copy(read = true, lastPageRead = dbChapter.lastPageRead)
+                    it.lastPageRead == 0L && dbChapter.lastPageRead != 0L -> it.copy(
+                        lastPageRead = dbChapter.lastPageRead,
+                    )
+                    else -> it
+                }
+            }.copy(
+                id = dbChapter.id,
+                bookmark = chapter.bookmark || dbChapter.bookmark,
+            )
+        }
     }
 
     private fun Chapter.forComparison() =
@@ -233,7 +243,7 @@ class MangaRestorer(
                     dateUpload = null,
                     chapterId = chapter.id,
                     version = chapter.version,
-                    isSyncing = 0,
+                    isSyncing = if (isSync) 1 else 0,
                     memo = chapter.memo.let(MemoColumnAdapter::encode),
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -9,6 +9,7 @@ import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
+import eu.kanade.tachiyomi.data.sync.SyncDataJob
 import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
@@ -70,6 +71,7 @@ class NotificationReceiver : BroadcastReceiver() {
                     "application/x-protobuf+gzip",
                 )
             ACTION_CANCEL_RESTORE -> cancelRestore(context)
+            ACTION_CANCEL_SYNC -> cancelSync(context)
             // Cancel library update and dismiss notification
             ACTION_CANCEL_LIBRARY_UPDATE -> cancelLibraryUpdate(context)
             // Start downloading app update
@@ -170,6 +172,15 @@ class NotificationReceiver : BroadcastReceiver() {
     }
 
     /**
+     * Method called when user wants to stop a sync job.
+     *
+     * @param context context of application
+     */
+    private fun cancelSync(context: Context) {
+        SyncDataJob.stop(context)
+    }
+
+    /**
      * Method called when user wants to stop a library update
      *
      * @param context context of application
@@ -238,6 +249,8 @@ class NotificationReceiver : BroadcastReceiver() {
         private const val ACTION_SHARE_BACKUP = "$ID.$NAME.SEND_BACKUP"
 
         private const val ACTION_CANCEL_RESTORE = "$ID.$NAME.CANCEL_RESTORE"
+
+        private const val ACTION_CANCEL_SYNC = "$ID.$NAME.CANCEL_SYNC"
 
         private const val ACTION_CANCEL_LIBRARY_UPDATE = "$ID.$NAME.CANCEL_LIBRARY_UPDATE"
 
@@ -627,6 +640,26 @@ class NotificationReceiver : BroadcastReceiver() {
         internal fun cancelRestorePendingBroadcast(context: Context, notificationId: Int): PendingIntent {
             val intent = Intent(context, NotificationReceiver::class.java).apply {
                 action = ACTION_CANCEL_RESTORE
+                putExtra(EXTRA_NOTIFICATION_ID, notificationId)
+            }
+            return PendingIntent.getBroadcast(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
+
+        /**
+         * Returns [PendingIntent] that cancels a sync job.
+         *
+         * @param context context of application
+         * @param notificationId id of notification
+         * @return [PendingIntent]
+         */
+        internal fun cancelSyncPendingBroadcast(context: Context, notificationId: Int): PendingIntent {
+            val intent = Intent(context, NotificationReceiver::class.java).apply {
+                action = ACTION_CANCEL_SYNC
                 putExtra(EXTRA_NOTIFICATION_ID, notificationId)
             }
             return PendingIntent.getBroadcast(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
@@ -1,0 +1,131 @@
+package eu.kanade.tachiyomi.data.sync
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkQuery
+import androidx.work.WorkerParameters
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.isOnline
+import eu.kanade.tachiyomi.util.system.isRunning
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class SyncDataJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val notifier = SyncNotifier(context)
+
+    override suspend fun doWork(): Result {
+        if (tags.contains(TAG_AUTO)) {
+            if (!context.isOnline()) {
+                return Result.retry()
+            }
+            // Find a running manual worker. If exists, try again later
+            if (context.workManager.isRunning(TAG_MANUAL)) {
+                return Result.retry()
+            }
+        }
+
+        setForegroundSafely()
+
+        return try {
+            SyncManager(context).syncData()
+            Result.success()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            notifier.showSyncError(e.message)
+            Result.success() // try again next time
+        } finally {
+            context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return ForegroundInfo(
+            Notifications.ID_RESTORE_PROGRESS,
+            notifier.showSyncProgress().build(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        private const val TAG_JOB = "SyncDataJob"
+        private const val TAG_AUTO = "$TAG_JOB:auto"
+        const val TAG_MANUAL = "$TAG_JOB:manual"
+
+        fun isRunning(context: Context): Boolean {
+            return context.workManager.isRunning(TAG_JOB)
+        }
+
+        fun setupTask(context: Context, prefInterval: Int? = null) {
+            val syncPreferences = Injekt.get<SyncPreferences>()
+            val interval = prefInterval ?: syncPreferences.syncInterval.get()
+
+            if (interval > 0) {
+                val request = PeriodicWorkRequestBuilder<SyncDataJob>(
+                    interval.toLong(),
+                    TimeUnit.MINUTES,
+                    10,
+                    TimeUnit.MINUTES,
+                )
+                    .addTag(TAG_JOB)
+                    .addTag(TAG_AUTO)
+                    .build()
+
+                context.workManager.enqueueUniquePeriodicWork(TAG_AUTO, ExistingPeriodicWorkPolicy.UPDATE, request)
+            } else {
+                context.workManager.cancelUniqueWork(TAG_AUTO)
+            }
+        }
+
+        fun startNow(context: Context, manual: Boolean = false) {
+            val wm = context.workManager
+            if (wm.isRunning(TAG_JOB)) {
+                // Already running either as a scheduled or manual job
+                return
+            }
+            val tag = if (manual) TAG_MANUAL else TAG_AUTO
+            val request = OneTimeWorkRequestBuilder<SyncDataJob>()
+                .addTag(TAG_JOB)
+                .addTag(tag)
+                .build()
+            context.workManager.enqueueUniqueWork(tag, ExistingWorkPolicy.KEEP, request)
+        }
+
+        fun stop(context: Context) {
+            val wm = context.workManager
+            val workQuery = WorkQuery.Builder.fromTags(listOf(TAG_JOB, TAG_AUTO, TAG_MANUAL))
+                .addStates(listOf(WorkInfo.State.RUNNING))
+                .build()
+            wm.getWorkInfos(workQuery).get()
+                // Should only return one work but just in case
+                .forEach {
+                    wm.cancelWorkById(it.id)
+
+                    // Re-enqueue cancelled scheduled work
+                    if (it.tags.contains(TAG_AUTO)) {
+                        setupTask(context)
+                    }
+                }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -1,0 +1,366 @@
+package eu.kanade.tachiyomi.data.sync
+
+import android.content.Context
+import android.net.Uri
+import app.cash.sqldelight.async.coroutines.awaitAsList
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.data.backup.create.BackupCreator
+import eu.kanade.tachiyomi.data.backup.create.BackupOptions
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
+import eu.kanade.tachiyomi.data.backup.restore.RestoreOptions
+import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
+import eu.kanade.tachiyomi.data.sync.service.SyncData
+import eu.kanade.tachiyomi.data.sync.service.SyncYomiSyncService
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.Chapters
+import tachiyomi.data.Database
+import tachiyomi.data.manga.MangaMapper
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.manga.model.Manga
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+import java.io.IOException
+import java.util.Date
+import kotlin.system.measureTimeMillis
+
+/**
+ * A manager to handle synchronization tasks in the app, such as updating
+ * sync preferences and performing synchronization with a remote server.
+ *
+ * @property context The application context.
+ */
+class SyncManager(
+    private val context: Context,
+    private val database: Database = Injekt.get(),
+    private val syncPreferences: SyncPreferences = Injekt.get(),
+    private var json: Json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    },
+    private val getCategories: GetCategories = Injekt.get(),
+) {
+    private val backupCreator: BackupCreator = BackupCreator(context, false)
+    private val notifier: SyncNotifier = SyncNotifier(context)
+    private val mangaRestorer: MangaRestorer = MangaRestorer()
+
+    enum class SyncService(val value: Int) {
+        NONE(0),
+        SYNCYOMI(1),
+        ;
+
+        companion object {
+            fun fromInt(value: Int) = entries.firstOrNull { it.value == value } ?: NONE
+        }
+    }
+
+    /**
+     * Syncs data with a sync service.
+     *
+     * This function retrieves local data (favorites, manga, extensions, and categories)
+     * from the database using the BackupManager, then synchronizes the data with a sync service.
+     */
+    suspend fun syncData() {
+        // Reset isSyncing in case it was left over or failed syncing during restore.
+        database.transaction {
+            database.mangasQueries.resetIsSyncing()
+            database.chaptersQueries.resetIsSyncing()
+            database.categoriesQueries.resetIsSyncing()
+        }
+
+        val syncOptions = syncPreferences.getSyncSettings()
+        val databaseManga = getAllMangaThatNeedsSync()
+
+        val backupOptions = BackupOptions(
+            libraryEntries = syncOptions.libraryEntries,
+            categories = syncOptions.categories,
+            chapters = syncOptions.chapters,
+            tracking = syncOptions.tracking,
+            history = syncOptions.history,
+            readEntries = syncOptions.readEntries,
+            appSettings = syncOptions.appSettings,
+            extensionStores = syncOptions.extensionStores,
+            sourceSettings = syncOptions.sourceSettings,
+            privateSettings = syncOptions.privateSettings,
+        )
+
+        logcat(LogPriority.DEBUG) { "Begin create backup" }
+        val backupManga = backupCreator.backupMangas(databaseManga, backupOptions)
+        val backup = Backup(
+            backupManga = backupManga,
+            backupCategories = backupCreator.backupCategories(backupOptions),
+            backupSources = backupCreator.backupSources(backupManga),
+            backupPreferences = backupCreator.backupAppPreferences(backupOptions),
+            backupSourcePreferences = backupCreator.backupSourcePreferences(backupOptions),
+            backupExtensionStores = backupCreator.backupExtensionStores(backupOptions),
+        )
+        logcat(LogPriority.DEBUG) { "End create backup" }
+
+        // Create the SyncData object
+        val syncData = SyncData(
+            deviceId = syncPreferences.uniqueDeviceID(),
+            backup = backup,
+        )
+
+        // Handle sync based on the selected service
+        val syncService = when (val syncService = SyncService.fromInt(syncPreferences.syncService.get())) {
+            SyncService.SYNCYOMI -> {
+                SyncYomiSyncService(
+                    context,
+                    json,
+                    syncPreferences,
+                    notifier,
+                )
+            }
+
+            else -> {
+                logcat(LogPriority.ERROR) { "Invalid sync service type: $syncService" }
+                null
+            }
+        }
+
+        val remoteBackup = syncService?.doSync(syncData)
+
+        if (remoteBackup == null) {
+            logcat(LogPriority.DEBUG) { "Skip restore due to network issues" }
+            return
+        }
+
+        if (remoteBackup === syncData.backup) {
+            // nothing changed
+            logcat(LogPriority.DEBUG) { "Skip restore due to remote was overwrite from local" }
+            syncPreferences.lastSyncTimestamp.set(Date().time)
+            notifier.showSyncSuccess("Sync completed successfully")
+            return
+        }
+
+        // Stop the sync early if the remote backup is null or empty
+        if (remoteBackup.backupManga.isEmpty() &&
+            remoteBackup.backupCategories.isEmpty() &&
+            remoteBackup.backupSources.isEmpty()
+        ) {
+            notifier.showSyncError("No data found on remote server.")
+            return
+        }
+
+        // Check if it's first sync based on lastSyncTimestamp
+        if (syncPreferences.lastSyncTimestamp.get() == 0L && databaseManga.isNotEmpty()) {
+            // It's first sync no need to restore data. (just update remote data)
+            syncPreferences.lastSyncTimestamp.set(Date().time)
+            notifier.showSyncSuccess("Updated remote data successfully")
+            return
+        }
+
+        val (filteredFavorites, nonFavorites) = filterFavoritesAndNonFavorites(remoteBackup)
+        updateNonFavorites(nonFavorites)
+
+        val newSyncData = backup.copy(
+            backupManga = filteredFavorites,
+            backupCategories = remoteBackup.backupCategories,
+            backupSources = remoteBackup.backupSources,
+            backupPreferences = remoteBackup.backupPreferences,
+            backupSourcePreferences = remoteBackup.backupSourcePreferences,
+            backupExtensionStores = remoteBackup.backupExtensionStores,
+        )
+
+        val hasMangaChanges = filteredFavorites.isNotEmpty()
+        val hasCategoryChanges = remoteBackup.backupCategories != backup.backupCategories
+        val hasSourceChanges = remoteBackup.backupSources != backup.backupSources
+        val hasPreferenceChanges = remoteBackup.backupPreferences != backup.backupPreferences
+        val hasSourcePreferenceChanges = remoteBackup.backupSourcePreferences != backup.backupSourcePreferences
+        val hasExtensionStoreChanges = remoteBackup.backupExtensionStores != backup.backupExtensionStores
+
+        if (!hasMangaChanges && !hasCategoryChanges && !hasSourceChanges &&
+            !hasPreferenceChanges && !hasSourcePreferenceChanges && !hasExtensionStoreChanges
+        ) {
+            // update the sync timestamp
+            syncPreferences.lastSyncTimestamp.set(Date().time)
+            notifier.showSyncSuccess("Sync completed successfully")
+            return
+        }
+
+        if (syncOptions.categories) {
+            val mergedUids = newSyncData.backupCategories.map { it.uid }.toSet()
+            val mergedNames = newSyncData.backupCategories.map { it.name }.toSet()
+            val localCategories = getCategories.await().filterNot { it.id == 0L } // Exclude system category
+            val categoriesToDelete = localCategories.filter {
+                it.uid !in mergedUids && it.name !in mergedNames
+            }
+            if (categoriesToDelete.isNotEmpty()) {
+                database.transaction {
+                    categoriesToDelete.forEach {
+                        database.categoriesQueries.delete(it.id)
+                    }
+                }
+            }
+        }
+
+        val backupUri = writeSyncDataToCache(context, newSyncData)
+        logcat(LogPriority.DEBUG) { "Got Backup Uri: $backupUri" }
+        if (backupUri != null) {
+            BackupRestoreJob.start(
+                context = context,
+                uri = backupUri,
+                sync = true,
+                options = RestoreOptions(
+                    appSettings = syncOptions.appSettings,
+                    sourceSettings = syncOptions.sourceSettings,
+                    libraryEntries = syncOptions.libraryEntries,
+                    categories = syncOptions.categories,
+                    extensionStores = syncOptions.extensionStores,
+                ),
+            )
+
+            // update the sync timestamp
+            syncPreferences.lastSyncTimestamp.set(Date().time)
+        } else {
+            logcat(LogPriority.ERROR) { "Failed to write sync data to file" }
+        }
+    }
+
+    private fun writeSyncDataToCache(context: Context, backup: Backup): Uri? {
+        val cacheFile = File(context.cacheDir, "tachiyomi_sync_data.proto.gz")
+        return try {
+            cacheFile.outputStream().use { output ->
+                output.write(ProtoBuf.encodeToByteArray(Backup.serializer(), backup))
+                Uri.fromFile(cacheFile)
+            }
+        } catch (e: IOException) {
+            logcat(LogPriority.ERROR, throwable = e) { "Failed to write sync data to cache" }
+            null
+        }
+    }
+
+    /**
+     * Retrieves all manga from the local database.
+     *
+     * @return a list of all manga stored in the database
+     */
+    private suspend fun getAllMangaFromDB(): List<Manga> {
+        return database.mangasQueries
+            .getAllManga(MangaMapper::mapManga)
+            .awaitAsList()
+    }
+
+    private suspend fun getAllMangaThatNeedsSync(): List<Manga> {
+        return database.mangasQueries
+            .getMangasWithFavoriteTimestamp(MangaMapper::mapManga)
+            .awaitAsList()
+    }
+
+    private suspend fun isMangaDifferent(localManga: Manga, remoteManga: BackupManga): Boolean {
+        val localChapters = database.chaptersQueries.getChaptersByMangaId(localManga.id, 0).awaitAsList()
+        val localCategories = getCategories.await(localManga.id).map { it.order }
+
+        if (areChaptersDifferent(localChapters, remoteManga.chapters)) {
+            return true
+        }
+
+        if (localManga.version != remoteManga.version) {
+            return true
+        }
+
+        if (localCategories.toSet() != remoteManga.categories.toSet()) {
+            return true
+        }
+
+        return false
+    }
+
+    private fun areChaptersDifferent(localChapters: List<Chapters>, remoteChapters: List<BackupChapter>): Boolean {
+        val localChapterMap = localChapters.associateBy { it.url }
+        val remoteChapterMap = remoteChapters.associateBy { it.url }
+
+        if (localChapterMap.size != remoteChapterMap.size) {
+            return true
+        }
+
+        for ((url, localChapter) in localChapterMap) {
+            val remoteChapter = remoteChapterMap[url]
+
+            // If a matching remote chapter doesn't exist, or the version numbers are different, consider them different
+            if (remoteChapter == null || localChapter.version != remoteChapter.version) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    /**
+     * Filters the favorite and non-favorite manga from the backup and checks
+     * if the favorite manga is different from the local database.
+     * @param backup the Backup object containing the backup data.
+     * @return a Pair of lists, where the first list contains different favorite manga
+     * and the second list contains non-favorite manga.
+     */
+    private suspend fun filterFavoritesAndNonFavorites(backup: Backup): Pair<List<BackupManga>, List<BackupManga>> {
+        val favorites = mutableListOf<BackupManga>()
+        val nonFavorites = mutableListOf<BackupManga>()
+
+        val elapsedTimeMillis = measureTimeMillis {
+            val databaseManga = getAllMangaFromDB()
+            val localMangaMap = databaseManga.associateBy {
+                Pair(it.source, it.url)
+            }
+
+            logcat(LogPriority.DEBUG) { "Starting to filter favorites and non-favorites from backup data." }
+
+            backup.backupManga.forEach { remoteManga ->
+                val compositeKey = Pair(remoteManga.source, remoteManga.url)
+                val localManga = localMangaMap[compositeKey]
+                when {
+                    // Checks if the manga is in favorites and needs updating or adding
+                    remoteManga.favorite -> {
+                        if (localManga == null || isMangaDifferent(localManga, remoteManga)) {
+                            logcat(LogPriority.DEBUG) { "Adding to favorites: ${remoteManga.title}" }
+                            favorites.add(remoteManga)
+                        } else {
+                            logcat(LogPriority.DEBUG) { "Already up-to-date favorite: ${remoteManga.title}" }
+                        }
+                    }
+                    // Handle non-favorites
+                    !remoteManga.favorite -> {
+                        logcat(LogPriority.DEBUG) { "Adding to non-favorites: ${remoteManga.title}" }
+                        nonFavorites.add(remoteManga)
+                    }
+                }
+            }
+        }
+
+        val minutes = elapsedTimeMillis / 60000
+        val seconds = (elapsedTimeMillis % 60000) / 1000
+        logcat(LogPriority.DEBUG) {
+            "Filtering completed in ${minutes}m ${seconds}s. Favorites found: ${favorites.size}, " +
+                "Non-favorites found: ${nonFavorites.size}"
+        }
+
+        return Pair(favorites, nonFavorites)
+    }
+
+    /**
+     * Updates the non-favorite manga in the local database with their favorite status from the backup.
+     * @param nonFavorites the list of non-favorite BackupManga objects from the backup.
+     */
+    private suspend fun updateNonFavorites(nonFavorites: List<BackupManga>) {
+        val localMangaList = getAllMangaFromDB()
+
+        val localMangaMap = localMangaList.associateBy { Pair(it.source, it.url) }
+
+        nonFavorites.forEach { nonFavorite ->
+            val key = Pair(nonFavorite.source, nonFavorite.url)
+            localMangaMap[key]?.let { localManga ->
+                if (localManga.favorite != nonFavorite.favorite) {
+                    val updatedManga = localManga.copy(favorite = nonFavorite.favorite)
+                    mangaRestorer.updateManga(updatedManga)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
@@ -1,0 +1,88 @@
+package eu.kanade.tachiyomi.data.sync
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.core.app.NotificationCompat
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.data.notification.NotificationReceiver
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import eu.kanade.tachiyomi.util.system.notify
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.injectLazy
+
+class SyncNotifier(private val context: Context) {
+
+    private val preferences: SecurityPreferences by injectLazy()
+
+    private val progressNotificationBuilder = context.notificationBuilder(
+        Notifications.CHANNEL_BACKUP_RESTORE_PROGRESS,
+    ) {
+        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setSmallIcon(R.drawable.ic_mihon)
+        setAutoCancel(false)
+        setOngoing(true)
+        setOnlyAlertOnce(true)
+    }
+
+    private val completeNotificationBuilder = context.notificationBuilder(
+        Notifications.CHANNEL_BACKUP_RESTORE_COMPLETE,
+    ) {
+        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setSmallIcon(R.drawable.ic_mihon)
+        setAutoCancel(false)
+    }
+
+    private fun NotificationCompat.Builder.show(id: Int) {
+        context.notify(id, build())
+    }
+
+    fun showSyncProgress(content: String = "", progress: Int = 0, maxAmount: Int = 100): NotificationCompat.Builder {
+        val builder = with(progressNotificationBuilder) {
+            setContentTitle(context.stringResource(MR.strings.syncing_library))
+
+            if (!preferences.hideNotificationContent.get()) {
+                setContentText(content)
+            }
+
+            setProgress(maxAmount, progress, true)
+            setOnlyAlertOnce(true)
+
+            clearActions()
+            addAction(
+                R.drawable.ic_close_24dp,
+                context.stringResource(MR.strings.action_cancel),
+                NotificationReceiver.cancelSyncPendingBroadcast(context, Notifications.ID_RESTORE_PROGRESS),
+            )
+        }
+
+        builder.show(Notifications.ID_RESTORE_PROGRESS)
+
+        return builder
+    }
+
+    fun showSyncError(error: String?) {
+        context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+
+        with(completeNotificationBuilder) {
+            setContentTitle(context.stringResource(MR.strings.sync_error))
+            setContentText(error)
+
+            show(Notifications.ID_RESTORE_COMPLETE)
+        }
+    }
+
+    fun showSyncSuccess(message: String?) {
+        context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+
+        with(completeNotificationBuilder) {
+            setContentTitle(context.stringResource(MR.strings.sync_complete))
+            setContentText(message)
+
+            show(Notifications.ID_RESTORE_COMPLETE)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/SyncTriggerOptions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/SyncTriggerOptions.kt
@@ -1,0 +1,62 @@
+package eu.kanade.tachiyomi.data.sync.models
+
+import dev.icerock.moko.resources.StringResource
+import tachiyomi.i18n.MR
+
+data class SyncTriggerOptions(
+    val syncOnChapterRead: Boolean = false,
+    val syncOnChapterOpen: Boolean = false,
+    val syncOnAppStart: Boolean = false,
+    val syncOnAppResume: Boolean = false,
+) {
+    fun asBooleanArray() = booleanArrayOf(
+        syncOnChapterRead,
+        syncOnChapterOpen,
+        syncOnAppStart,
+        syncOnAppResume,
+    )
+
+    fun anyEnabled() = syncOnChapterRead ||
+        syncOnChapterOpen ||
+        syncOnAppStart ||
+        syncOnAppResume
+
+    companion object {
+        val mainOptions = listOf(
+            Entry(
+                label = MR.strings.sync_on_chapter_read,
+                getter = SyncTriggerOptions::syncOnChapterRead,
+                setter = { options, enabled -> options.copy(syncOnChapterRead = enabled) },
+            ),
+            Entry(
+                label = MR.strings.sync_on_chapter_open,
+                getter = SyncTriggerOptions::syncOnChapterOpen,
+                setter = { options, enabled -> options.copy(syncOnChapterOpen = enabled) },
+            ),
+            Entry(
+                label = MR.strings.sync_on_app_start,
+                getter = SyncTriggerOptions::syncOnAppStart,
+                setter = { options, enabled -> options.copy(syncOnAppStart = enabled) },
+            ),
+            Entry(
+                label = MR.strings.sync_on_app_resume,
+                getter = SyncTriggerOptions::syncOnAppResume,
+                setter = { options, enabled -> options.copy(syncOnAppResume = enabled) },
+            ),
+        )
+
+        fun fromBooleanArray(array: BooleanArray) = SyncTriggerOptions(
+            syncOnChapterRead = array[0],
+            syncOnChapterOpen = array[1],
+            syncOnAppStart = array[2],
+            syncOnAppResume = array[3],
+        )
+    }
+
+    data class Entry(
+        val label: StringResource,
+        val getter: (SyncTriggerOptions) -> Boolean,
+        val setter: (SyncTriggerOptions, Boolean) -> SyncTriggerOptions,
+        val enabled: (SyncTriggerOptions) -> Boolean = { true },
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncService.kt
@@ -1,0 +1,497 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.content.Context
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.models.BackupPreference
+import eu.kanade.tachiyomi.data.backup.models.BackupSource
+import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import logcat.LogPriority
+import logcat.logcat
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@Serializable
+data class SyncData(
+    val deviceId: String = "",
+    val backup: Backup? = null,
+)
+
+abstract class SyncService(
+    val context: Context,
+    val json: Json,
+    val syncPreferences: SyncPreferences,
+) {
+    abstract suspend fun doSync(syncData: SyncData): Backup?
+
+    /**
+     * Merges the local and remote sync data into a single sync data object.
+     *
+     * @param localSyncData The [SyncData] containing the local sync data.
+     * @param remoteSyncData The [SyncData] containing the remote sync data.
+     * @return The [SyncData] containing the merged sync data.
+     */
+    protected fun mergeSyncData(localSyncData: SyncData, remoteSyncData: SyncData): SyncData {
+        val mergedCategoriesList =
+            mergeCategoriesLists(localSyncData.backup?.backupCategories, remoteSyncData.backup?.backupCategories)
+
+        val mergedMangaList = mergeMangaLists(
+            localSyncData.backup?.backupManga,
+            remoteSyncData.backup?.backupManga,
+            localSyncData.backup?.backupCategories ?: emptyList(),
+            remoteSyncData.backup?.backupCategories ?: emptyList(),
+            mergedCategoriesList,
+        )
+
+        val mergedSourcesList =
+            mergeSourcesLists(localSyncData.backup?.backupSources, remoteSyncData.backup?.backupSources)
+        val mergedPreferencesList =
+            mergePreferencesLists(localSyncData.backup?.backupPreferences, remoteSyncData.backup?.backupPreferences)
+        val mergedSourcePreferencesList = mergeSourcePreferencesLists(
+            localSyncData.backup?.backupSourcePreferences,
+            remoteSyncData.backup?.backupSourcePreferences,
+        )
+        val mergedExtensionStoresList = mergeExtensionStoresLists(
+            localSyncData.backup?.backupExtensionStores,
+            remoteSyncData.backup?.backupExtensionStores,
+        )
+
+        // Create the merged Backup object
+        val mergedBackup = Backup(
+            backupManga = mergedMangaList,
+            backupCategories = mergedCategoriesList,
+            backupSources = mergedSourcesList,
+            backupPreferences = mergedPreferencesList,
+            backupSourcePreferences = mergedSourcePreferencesList,
+            backupExtensionStores = mergedExtensionStoresList,
+        )
+
+        // Create the merged SyncData object
+        return SyncData(
+            deviceId = syncPreferences.uniqueDeviceID(),
+            backup = mergedBackup,
+        )
+    }
+
+    /**
+     * Merges two lists of BackupManga objects, selecting the most recent manga based on the version value.
+     *
+     * @param localMangaList The list of local BackupManga objects or null.
+     * @param remoteMangaList The list of remote BackupManga objects or null.
+     * @return A list of BackupManga objects, each representing the most recent version of the manga from either local or remote sources.
+     */
+    private fun mergeMangaLists(
+        localMangaList: List<BackupManga>?,
+        remoteMangaList: List<BackupManga>?,
+        localCategories: List<BackupCategory>,
+        remoteCategories: List<BackupCategory>,
+        mergedCategories: List<BackupCategory>,
+    ): List<BackupManga> {
+        val logTag = "MergeMangaLists"
+
+        val localMangaListSafe = localMangaList.orEmpty()
+        val remoteMangaListSafe = remoteMangaList.orEmpty()
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Starting merge. Local list size: ${localMangaListSafe.size}, Remote list size: ${remoteMangaListSafe.size}"
+        }
+
+        fun mangaCompositeKey(manga: BackupManga): String {
+            return "${manga.source}|${manga.url}"
+        }
+
+        // Create maps using composite keys
+        val localMangaMap = localMangaListSafe.associateBy { mangaCompositeKey(it) }
+        val remoteMangaMap = remoteMangaListSafe.associateBy { mangaCompositeKey(it) }
+
+        val localCategoriesMapByOrder = localCategories.associateBy { it.order }
+        val remoteCategoriesMapByOrder = remoteCategories.associateBy { it.order }
+        val mergedCategoriesMapByName = mergedCategories.associateBy { it.name }
+
+        fun updateCategories(theManga: BackupManga, theMap: Map<Long, BackupCategory>): BackupManga {
+            return theManga.copy(
+                categories = theManga.categories.mapNotNull {
+                    theMap[it]?.let { category ->
+                        mergedCategoriesMapByName[category.name]?.order
+                    }
+                },
+            )
+        }
+
+        val lastSyncTime = syncPreferences.lastSyncTimestamp.get().milliseconds.inWholeSeconds
+        val syncOptions = syncPreferences.getSyncSettings()
+
+        val mergedList = (localMangaMap.keys + remoteMangaMap.keys).distinct().mapNotNull { compositeKey ->
+            val local = localMangaMap[compositeKey]
+            val remote = remoteMangaMap[compositeKey]
+
+            // New version comparison logic
+            when {
+                local != null && remote == null -> {
+                    if (lastSyncTime == 0L || local.lastModifiedAt > lastSyncTime) {
+                        updateCategories(local, localCategoriesMapByOrder)
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping local manga deleted on remote: ${local.title}." }
+                        null
+                    }
+                }
+                local == null && remote != null -> {
+                    if (lastSyncTime == 0L || remote.lastModifiedAt > lastSyncTime) {
+                        updateCategories(remote, remoteCategoriesMapByOrder)
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) { "Dropping deleted remote manga: ${remote.title}." }
+                        null
+                    }
+                }
+                local != null && remote != null -> {
+                    // Compare versions to decide which manga to keep
+                    if (local.version >= remote.version) {
+                        logcat(LogPriority.DEBUG, logTag) {
+                            "Keeping local version of ${local.title} with merged chapters."
+                        }
+                        updateCategories(
+                            local.copy(
+                                chapters = mergeChapters(
+                                    local.chapters,
+                                    remote.chapters,
+                                    lastSyncTime,
+                                    syncOptions.chapters,
+                                ),
+                            ),
+                            localCategoriesMapByOrder,
+                        )
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) {
+                            "Keeping remote version of ${remote.title} with merged chapters."
+                        }
+                        updateCategories(
+                            remote.copy(
+                                chapters = mergeChapters(
+                                    local.chapters,
+                                    remote.chapters,
+                                    lastSyncTime,
+                                    syncOptions.chapters,
+                                ),
+                            ),
+                            remoteCategoriesMapByOrder,
+                        )
+                    }
+                }
+                else -> null // No manga found for key
+            }
+        }
+
+        // Counting favorites and non-favorites
+        val (favorites, nonFavorites) = mergedList.partition { it.favorite }
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Merge completed. Total merged manga: ${mergedList.size}, Favorites: ${favorites.size}, " +
+                "Non-Favorites: ${nonFavorites.size}"
+        }
+
+        return mergedList
+    }
+
+    /**
+     * Merges two lists of BackupChapter objects, selecting the most recent chapter based on the version value.
+     *
+     * @param localChapters The list of local BackupChapter objects.
+     * @param remoteChapters The list of remote BackupChapter objects.
+     * @return A list of BackupChapter objects, each representing the most recent version of the chapter from either local or remote sources.
+     */
+    private fun mergeChapters(
+        localChapters: List<BackupChapter>,
+        remoteChapters: List<BackupChapter>,
+        lastSyncTime: Long,
+        syncingChapters: Boolean,
+    ): List<BackupChapter> {
+        val logTag = "MergeChapters"
+
+        if (!syncingChapters) {
+            return remoteChapters // If not syncing chapters, keep remote untouched
+        }
+
+        fun chapterCompositeKey(chapter: BackupChapter): String {
+            return chapter.url
+        }
+
+        val localChapterMap = localChapters.associateBy { chapterCompositeKey(it) }
+        val remoteChapterMap = remoteChapters.associateBy { chapterCompositeKey(it) }
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Starting chapter merge. Local chapters: ${localChapters.size}, Remote chapters: ${remoteChapters.size}"
+        }
+
+        // Merge both chapter maps based on version numbers
+        val mergedChapters = (localChapterMap.keys + remoteChapterMap.keys).distinct().mapNotNull { compositeKey ->
+            val localChapter = localChapterMap[compositeKey]
+            val remoteChapter = remoteChapterMap[compositeKey]
+
+            when {
+                localChapter != null && remoteChapter == null -> {
+                    if (lastSyncTime == 0L || localChapter.lastModifiedAt > lastSyncTime) {
+                        logcat(LogPriority.DEBUG, logTag) { "Keeping local chapter: ${localChapter.name}." }
+                        localChapter
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) {
+                            "Dropping local chapter deleted on remote: ${localChapter.name}."
+                        }
+                        null
+                    }
+                }
+                localChapter == null && remoteChapter != null -> {
+                    if (lastSyncTime == 0L || remoteChapter.lastModifiedAt > lastSyncTime) {
+                        logcat(LogPriority.DEBUG, logTag) { "Taking remote chapter: ${remoteChapter.name}." }
+                        remoteChapter
+                    } else {
+                        logcat(LogPriority.DEBUG, logTag) {
+                            "Dropping deleted remote chapter: ${remoteChapter.name}."
+                        }
+                        null
+                    }
+                }
+                localChapter != null && remoteChapter != null -> {
+                    // Use version number to decide which chapter to keep
+                    val chosenChapter = if (localChapter.version >= remoteChapter.version) {
+                        // If there are more chapters on remote, local sourceOrder will need to be updated to
+                        // maintain correct source order.
+                        if (localChapters.size < remoteChapters.size) {
+                            localChapter.copy(sourceOrder = remoteChapter.sourceOrder)
+                        } else {
+                            localChapter
+                        }
+                    } else {
+                        remoteChapter
+                    }
+                    chosenChapter
+                }
+                else -> null
+            }
+        }
+
+        logcat(LogPriority.DEBUG, logTag) { "Chapter merge completed. Total merged chapters: ${mergedChapters.size}" }
+
+        return mergedChapters
+    }
+
+    /**
+     * Merges two lists of BackupCategory objects, using UID and name matching with version-based conflict resolution.
+     *
+     * @param localCategoriesList The list of local BackupCategory objects.
+     * @param remoteCategoriesList The list of remote BackupCategory objects.
+     * @return The merged list of BackupCategory objects.
+     */
+    private fun mergeCategoriesLists(
+        localCategoriesList: List<BackupCategory>?,
+        remoteCategoriesList: List<BackupCategory>?,
+    ): List<BackupCategory> {
+        val logTag = "MergeCategories"
+        if (localCategoriesList == null) return remoteCategoriesList ?: emptyList()
+        if (remoteCategoriesList == null) return localCategoriesList
+
+        val result = mutableListOf<BackupCategory>()
+        val processedLocals = mutableSetOf<BackupCategory>()
+
+        val localMapByUid = localCategoriesList.filter { it.uid != 0L }.associateBy { it.uid }
+        val localMapByName = localCategoriesList.associateBy { it.name }
+
+        val lastSyncTime = syncPreferences.lastSyncTimestamp.get()
+
+        remoteCategoriesList.forEach { remote ->
+            var localMatch: BackupCategory? = null
+
+            // 1. Try match by UID
+            if (remote.uid != 0L) {
+                localMatch = localMapByUid[remote.uid]
+            }
+
+            // 2. Try match by Name (fallback)
+            if (localMatch == null) {
+                localMatch = localMapByName[remote.name]
+            }
+
+            if (localMatch != null) {
+                processedLocals.add(localMatch)
+                // Conflict resolution
+                if (localMatch.version >= remote.version) {
+                    logcat(LogPriority.DEBUG, logTag) {
+                        "Keeping local category: ${localMatch.name} (UID: ${localMatch.uid})"
+                    }
+                    result.add(localMatch)
+                } else {
+                    logcat(LogPriority.DEBUG, logTag) { "Keeping remote category: ${remote.name} (UID: ${remote.uid})" }
+                    // Preserve Local UID if Remote was 0
+                    if (remote.uid == 0L) {
+                        remote.uid = localMatch.uid
+                    }
+                    result.add(remote)
+                }
+            } else {
+                val remoteModifiedTimeMillis = remote.lastModifiedAt.seconds.inWholeMilliseconds
+                if (lastSyncTime == 0L || remoteModifiedTimeMillis > lastSyncTime) {
+                    logcat(LogPriority.DEBUG, logTag) {
+                        "Adding new remote category: ${remote.name} (UID: ${remote.uid})"
+                    }
+                    result.add(remote)
+                } else {
+                    logcat(LogPriority.DEBUG, logTag) {
+                        "Dropping deleted remote category: ${remote.name} (UID: ${remote.uid})"
+                    }
+                }
+            }
+        }
+
+        // Add remaining Local Categories
+        localCategoriesList.forEach { local ->
+            if (local !in processedLocals) {
+                val localModifiedTimeMillis = local.lastModifiedAt.seconds.inWholeMilliseconds
+                if (lastSyncTime == 0L || localModifiedTimeMillis > lastSyncTime) {
+                    logcat(LogPriority.DEBUG, logTag) {
+                        "Keeping local only category: ${local.name} (UID: ${local.uid})"
+                    }
+                    result.add(local)
+                } else {
+                    logcat(LogPriority.DEBUG, logTag) {
+                        "Dropping local category deleted on remote: ${local.name} (UID: ${local.uid})"
+                    }
+                }
+            }
+        }
+
+        return result.sortedBy { it.order }
+    }
+
+    private fun mergeSourcesLists(
+        localSources: List<BackupSource>?,
+        remoteSources: List<BackupSource>?,
+    ): List<BackupSource> {
+        val logTag = "MergeSources"
+
+        // Create maps using sourceId as key
+        val localSourceMap = localSources?.associateBy { it.sourceId } ?: emptyMap()
+        val remoteSourceMap = remoteSources?.associateBy { it.sourceId } ?: emptyMap()
+
+        // Merge both source maps
+        val mergedSources = (localSourceMap.keys + remoteSourceMap.keys).distinct().mapNotNull { sourceId ->
+            val localSource = localSourceMap[sourceId]
+            val remoteSource = remoteSourceMap[sourceId]
+
+            when {
+                localSource != null && remoteSource == null -> localSource
+                remoteSource != null && localSource == null -> remoteSource
+                else -> localSource
+            }
+        }
+
+        logcat(LogPriority.DEBUG, logTag) { "Source merge completed. Total merged sources: ${mergedSources.size}" }
+
+        return mergedSources
+    }
+
+    private fun mergePreferencesLists(
+        localPreferences: List<BackupPreference>?,
+        remotePreferences: List<BackupPreference>?,
+    ): List<BackupPreference> {
+        val logTag = "MergePreferences"
+
+        // Create maps using key as the unique identifier
+        val localPreferencesMap = localPreferences?.associateBy { it.key } ?: emptyMap()
+        val remotePreferencesMap = remotePreferences?.associateBy { it.key } ?: emptyMap()
+
+        // Merge both preferences maps
+        val mergedPreferences = (localPreferencesMap.keys + remotePreferencesMap.keys).distinct().mapNotNull { key ->
+            val localPreference = localPreferencesMap[key]
+            val remotePreference = remotePreferencesMap[key]
+
+            when {
+                localPreference != null && remotePreference == null -> localPreference
+                remotePreference != null && localPreference == null -> remotePreference
+                else -> localPreference
+            }
+        }
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Preferences merge completed. Total merged preferences: ${mergedPreferences.size}"
+        }
+
+        return mergedPreferences
+    }
+
+    private fun mergeSourcePreferencesLists(
+        localPreferences: List<BackupSourcePreferences>?,
+        remotePreferences: List<BackupSourcePreferences>?,
+    ): List<BackupSourcePreferences> {
+        val logTag = "MergeSourcePreferences"
+
+        // Create maps using sourceKey as the unique identifier
+        val localPreferencesMap = localPreferences?.associateBy { it.sourceKey } ?: emptyMap()
+        val remotePreferencesMap = remotePreferences?.associateBy { it.sourceKey } ?: emptyMap()
+
+        // Merge both source preferences maps
+        val mergedSourcePreferences = (localPreferencesMap.keys + remotePreferencesMap.keys).distinct()
+            .mapNotNull { sourceKey ->
+                val localSourcePreference = localPreferencesMap[sourceKey]
+                val remoteSourcePreference = remotePreferencesMap[sourceKey]
+
+                when {
+                    localSourcePreference != null && remoteSourcePreference == null -> localSourcePreference
+                    remoteSourcePreference != null && localSourcePreference == null -> remoteSourcePreference
+                    localSourcePreference != null && remoteSourcePreference != null -> {
+                        // Merge the individual preferences within the source preferences
+                        val mergedPrefs =
+                            mergeIndividualPreferences(localSourcePreference.prefs, remoteSourcePreference.prefs)
+                        BackupSourcePreferences(sourceKey, mergedPrefs)
+                    }
+                    else -> null
+                }
+            }
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Source preferences merge completed. Total merged source preferences: ${mergedSourcePreferences.size}"
+        }
+
+        return mergedSourcePreferences
+    }
+
+    private fun mergeIndividualPreferences(
+        localPrefs: List<BackupPreference>,
+        remotePrefs: List<BackupPreference>,
+    ): List<BackupPreference> {
+        val mergedPrefsMap = (localPrefs + remotePrefs).associateBy { it.key }
+        return mergedPrefsMap.values.toList()
+    }
+
+    private fun mergeExtensionStoresLists(
+        localStores: List<BackupExtensionStore>?,
+        remoteStores: List<BackupExtensionStore>?,
+    ): List<BackupExtensionStore> {
+        val logTag = "MergeExtensionStores"
+
+        // Create maps using indexUrl as the unique identifier
+        val localStoreMap = localStores?.associateBy { it.indexUrl } ?: emptyMap()
+        val remoteStoreMap = remoteStores?.associateBy { it.indexUrl } ?: emptyMap()
+
+        val mergedStores = (localStoreMap.keys + remoteStoreMap.keys).distinct().mapNotNull { indexUrl ->
+            val localStore = localStoreMap[indexUrl]
+            val remoteStore = remoteStoreMap[indexUrl]
+
+            when {
+                localStore != null && remoteStore == null -> localStore
+                remoteStore != null && localStore == null -> remoteStore
+                else -> localStore
+            }
+        }
+
+        logcat(LogPriority.DEBUG, logTag) {
+            "Extension store merge completed. Total merged extension stores: ${mergedStores.size}"
+        }
+
+        return mergedStores
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
@@ -1,0 +1,253 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.content.Context
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.sync.SyncNotifier
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.PUT
+import eu.kanade.tachiyomi.network.await
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
+import logcat.LogPriority
+import logcat.logcat
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class SyncYomiSyncService(
+    context: Context,
+    json: Json,
+    syncPreferences: SyncPreferences,
+    private val notifier: SyncNotifier,
+
+    private val protoBuf: ProtoBuf = Injekt.get(),
+) : SyncService(context, json, syncPreferences) {
+
+    private class SyncYomiException(message: String?) : Exception(message)
+
+    @Serializable
+    private data class SyncEvent(
+        val event: SyncEventStatus,
+        @SerialName("device_name")
+        val deviceName: String? = null,
+        val message: String? = null,
+    )
+
+    @Serializable
+    private enum class SyncEventStatus {
+        SYNC_STARTED,
+        SYNC_SUCCESS,
+        SYNC_FAILED,
+        SYNC_ERROR,
+        SYNC_CANCELLED,
+    }
+
+    override suspend fun doSync(syncData: SyncData): Backup? {
+        reportSyncEvent(SyncEventStatus.SYNC_STARTED)
+
+        try {
+            val (remoteData, etag) = pullSyncData()
+
+            val finalSyncData = if (remoteData != null) {
+                assert(etag.isNotEmpty()) { "ETag should never be empty if remote data is not null" }
+                logcat(LogPriority.DEBUG, "SyncService") {
+                    "Try update remote data with ETag($etag)"
+                }
+                mergeSyncData(syncData, remoteData)
+            } else {
+                // init or overwrite remote data
+                logcat(LogPriority.DEBUG) {
+                    "Try overwrite remote data with ETag($etag)"
+                }
+                syncData
+            }
+
+            val success = pushSyncData(finalSyncData, etag)
+
+            if (success) {
+                reportSyncEvent(SyncEventStatus.SYNC_SUCCESS)
+            } else {
+                reportSyncEvent(SyncEventStatus.SYNC_FAILED, "Failed to push sync data")
+            }
+
+            return finalSyncData.backup
+        } catch (e: Exception) {
+            if (e is CancellationException) {
+                reportSyncEvent(SyncEventStatus.SYNC_CANCELLED, e.message)
+                throw e
+            }
+            logcat(LogPriority.ERROR) { "Error syncing: ${e.message}" }
+            notifier.showSyncError(e.message)
+            reportSyncEvent(SyncEventStatus.SYNC_ERROR, e.message)
+            return null
+        }
+    }
+
+    private suspend fun pullSyncData(): Pair<SyncData?, String> {
+        val host = syncPreferences.clientHost.get()
+        val apiKey = syncPreferences.clientAPIKey.get()
+        val downloadUrl = "$host/api/sync/content"
+
+        val headersBuilder = Headers.Builder().add("X-API-Token", apiKey)
+        val lastETag = syncPreferences.lastSyncEtag.get()
+        if (lastETag != "") {
+            headersBuilder.add("If-None-Match", lastETag)
+        }
+        val headers = headersBuilder.build()
+
+        val downloadRequest = GET(
+            url = downloadUrl,
+            headers = headers,
+        )
+
+        val client = OkHttpClient()
+        val response = client.newCall(downloadRequest).await()
+
+        if (response.code == HTTP_NOT_MODIFIED) {
+            // not modified
+            assert(lastETag.isNotEmpty())
+            logcat(LogPriority.INFO) {
+                "Remote server not modified"
+            }
+            return Pair(null, lastETag)
+        } else if (response.code == HTTP_NOT_FOUND) {
+            // maybe got deleted from remote
+            return Pair(null, "")
+        }
+
+        if (response.isSuccessful) {
+            val newETag = response.headers["ETag"]
+                .takeIf { it?.isNotEmpty() == true } ?: throw SyncYomiException("Missing ETag")
+
+            val byteArray = response.body.byteStream().use {
+                return@use it.readBytes()
+            }
+
+            return try {
+                val backup = protoBuf.decodeFromByteArray(Backup.serializer(), byteArray)
+                return Pair(SyncData(backup = backup), newETag)
+            } catch (_: SerializationException) {
+                logcat(LogPriority.INFO) {
+                    "Bad content responded from server"
+                }
+                // the body is invalid
+                // return default value so we can overwrite it
+                Pair(null, "")
+            }
+        } else {
+            val responseBody = response.body.string()
+            notifier.showSyncError("Failed to download sync data: $responseBody")
+            logcat(LogPriority.ERROR) { "SyncError: $responseBody" }
+            throw SyncYomiException("Failed to download sync data: $responseBody")
+        }
+    }
+
+    /**
+     * Return true if update success
+     */
+    private suspend fun pushSyncData(syncData: SyncData, eTag: String): Boolean {
+        val backup = syncData.backup ?: return true
+
+        val host = syncPreferences.clientHost.get()
+        val apiKey = syncPreferences.clientAPIKey.get()
+        val uploadUrl = "$host/api/sync/content"
+        val timeout = 30L
+
+        val headersBuilder = Headers.Builder().add("X-API-Token", apiKey)
+        if (eTag.isNotEmpty()) {
+            headersBuilder.add("If-Match", eTag)
+        }
+        val headers = headersBuilder.build()
+
+        // Set timeout to 30 seconds
+        val client = OkHttpClient.Builder()
+            .connectTimeout(timeout, TimeUnit.SECONDS)
+            .readTimeout(timeout, TimeUnit.SECONDS)
+            .writeTimeout(timeout, TimeUnit.SECONDS)
+            .build()
+
+        val byteArray = protoBuf.encodeToByteArray(Backup.serializer(), backup)
+        if (byteArray.isEmpty()) {
+            throw IllegalStateException(context.stringResource(MR.strings.empty_backup_error))
+        }
+        val body = byteArray.toRequestBody("application/octet-stream".toMediaType())
+
+        val uploadRequest = PUT(
+            url = uploadUrl,
+            headers = headers,
+            body = body,
+        )
+
+        val response = client.newCall(uploadRequest).await()
+
+        if (response.isSuccessful) {
+            val newETag = response.headers["ETag"]
+                .takeIf { it?.isNotEmpty() == true } ?: throw SyncYomiException("Missing ETag")
+            syncPreferences.lastSyncEtag.set(newETag)
+            logcat(LogPriority.DEBUG) { "SyncYomi sync completed" }
+            return true
+        } else if (response.code == HTTP_PRECONDITION_FAILED) {
+            // other clients updated remote data, will try next time
+            logcat(LogPriority.DEBUG) { "SyncYomi sync failed with 412" }
+            return false
+        } else {
+            val responseBody = response.body.string()
+            notifier.showSyncError("Failed to upload sync data: $responseBody")
+            logcat(LogPriority.ERROR) { "SyncError: $responseBody" }
+            return false
+        }
+    }
+
+    private suspend fun reportSyncEvent(event: SyncEventStatus, message: String? = null) {
+        withContext(NonCancellable) {
+            try {
+                val host = syncPreferences.clientHost.get()
+                val apiKey = syncPreferences.clientAPIKey.get()
+                val url = "$host/api/sync/event"
+
+                val headersBuilder = Headers.Builder().add("X-API-Token", apiKey)
+                val headers = headersBuilder.build()
+
+                val bodyObj = SyncEvent(
+                    event = event,
+                    deviceName = android.os.Build.MODEL,
+                    message = message,
+                )
+
+                val jsonBody = json.encodeToString(SyncEvent.serializer(), bodyObj)
+                val requestBody = jsonBody.toRequestBody("application/json; charset=utf-8".toMediaType())
+
+                val request = POST(
+                    url = url,
+                    headers = headers,
+                    body = requestBody,
+                )
+
+                val client = OkHttpClient()
+                client.newCall(request).await().close()
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Failed to report sync event: ${e.message}" }
+            }
+        }
+    }
+
+    companion object {
+        private const val HTTP_NOT_MODIFIED = 304
+        private const val HTTP_NOT_FOUND = 404
+        private const val HTTP_PRECONDITION_FAILED = 412
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.di
 import android.app.Application
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.tachiyomi.core.security.PrivacyPreferences
@@ -73,6 +74,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             BasePreferences(app, get())
+        }
+        addSingletonFactory {
+            SyncPreferences(get())
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -37,6 +37,7 @@ import eu.kanade.presentation.more.onboarding.GETTING_STARTED_URL
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
+import eu.kanade.tachiyomi.data.sync.SyncDataJob
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
@@ -130,6 +131,17 @@ data object LibraryTab : Tab {
                             } else {
                                 snackbarHostState.showSnackbar(
                                     context.stringResource(MR.strings.information_no_entries_found),
+                                )
+                            }
+                        }
+                    },
+                    onClickSyncNow = {
+                        if (!SyncDataJob.isRunning(context)) {
+                            SyncDataJob.startNow(context)
+                        } else {
+                            scope.launch {
+                                snackbarHostState.showSnackbar(
+                                    context.stringResource(MR.strings.sync_in_progress),
                                 )
                             }
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -13,6 +13,7 @@ import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.model.readerOrientation
 import eu.kanade.domain.manga.model.readingMode
 import eu.kanade.domain.source.interactor.GetIncognitoState
+import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.database.models.toDomainChapter
@@ -22,6 +23,7 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.saver.Image
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.saver.Location
+import eu.kanade.tachiyomi.data.sync.SyncDataJob
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
@@ -99,6 +101,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private val upsertHistory: UpsertHistory = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
+    private val syncPreferences: SyncPreferences = Injekt.get(),
     private val getIncognitoState: GetIncognitoState = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
 ) : ViewModel() {
@@ -554,6 +557,14 @@ class ReaderViewModel @JvmOverloads constructor(
                     lastPageRead = readerChapter.chapter.last_page_read.toLong(),
                 ),
             )
+
+            // Check if syncing is enabled for chapter open
+            if (syncPreferences.isSyncEnabled() &&
+                syncPreferences.getSyncTriggerOptions().syncOnChapterOpen &&
+                readerChapter.chapter.last_page_read == 0
+            ) {
+                SyncDataJob.startNow(Injekt.get<Application>())
+            }
         }
     }
 
@@ -561,6 +572,11 @@ class ReaderViewModel @JvmOverloads constructor(
         readerChapter.chapter.read = true
         updateTrackChapterRead(readerChapter)
         deleteChapterIfNeeded(readerChapter)
+
+        // Check if syncing is enabled for chapter read
+        if (syncPreferences.isSyncEnabled() && syncPreferences.getSyncTriggerOptions().syncOnChapterRead) {
+            SyncDataJob.startNow(Injekt.get<Application>())
+        }
 
         val markDuplicateAsRead = libraryPreferences.markDuplicateReadChapterAsRead.get()
             .contains(LibraryPreferences.MARK_DUPLICATE_CHAPTER_READ_EXISTING)

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -48,6 +48,9 @@ class CategoryRepositoryImpl(
             name = category.name,
             order = category.order,
             flags = category.flags,
+            version = category.version,
+            uid = category.uid,
+            lastModifiedAt = category.lastModifiedAt,
         )
     }
 
@@ -56,6 +59,10 @@ class CategoryRepositoryImpl(
             name = update.name,
             order = update.order,
             flags = update.flags,
+            version = update.version,
+            uid = update.uid,
+            lastModifiedAt = update.lastModifiedAt,
+            isSyncing = null,
             categoryId = update.id,
         )
     }
@@ -79,12 +86,18 @@ class CategoryRepositoryImpl(
         name: String,
         order: Long,
         flags: Long,
+        version: Long,
+        uid: Long,
+        lastModifiedAt: Long,
     ): Category {
         return Category(
             id = id,
             name = name,
             order = order,
             flags = flags,
+            version = version,
+            uid = uid,
+            lastModifiedAt = lastModifiedAt,
         )
     }
 }

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -2,11 +2,15 @@ CREATE TABLE categories(
     _id INTEGER NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
     sort INTEGER NOT NULL,
-    flags INTEGER NOT NULL
+    flags INTEGER NOT NULL,
+    version INTEGER NOT NULL DEFAULT 0,
+    uid INTEGER NOT NULL DEFAULT 0,
+    last_modified_at INTEGER NOT NULL DEFAULT 0,
+    is_syncing INTEGER NOT NULL DEFAULT 0
 );
 
 -- Insert system category
-INSERT OR IGNORE INTO categories(_id, name, sort, flags) VALUES (0, "", -1, 0);
+INSERT OR IGNORE INTO categories(_id, name, sort, flags, version, uid, last_modified_at, is_syncing) VALUES (0, "", -1, 0, 0, 0, 0, 0);
 -- Disallow deletion of default category
 CREATE TRIGGER IF NOT EXISTS system_category_delete_trigger BEFORE DELETE
 ON categories
@@ -16,8 +20,29 @@ BEGIN SELECT CASE
     END;
 END;
 
+CREATE TRIGGER update_category_version AFTER UPDATE ON categories
+WHEN new.is_syncing = 0 AND (
+    new.name != old.name OR
+    new.sort != old.sort OR
+    new.flags != old.flags
+)
+BEGIN
+    UPDATE categories
+    SET version = version + 1,
+        last_modified_at = strftime('%s', 'now')
+    WHERE _id = new._id;
+END;
+
+CREATE TRIGGER insert_category_uid AFTER INSERT ON categories
+BEGIN
+    UPDATE categories
+    SET uid = CASE WHEN uid = 0 THEN abs(random()) ELSE uid END,
+        last_modified_at = CASE WHEN last_modified_at = 0 THEN strftime('%s', 'now') ELSE last_modified_at END
+    WHERE _id = new._id;
+END;
+
 getCategory:
-SELECT *
+SELECT _id AS id, name, sort AS `order`, flags, version, uid, last_modified_at
 FROM categories
 WHERE _id = :id
 LIMIT 1;
@@ -27,7 +52,10 @@ SELECT
 _id AS id,
 name,
 sort AS `order`,
-flags
+flags,
+version,
+uid,
+last_modified_at
 FROM categories
 ORDER BY sort;
 
@@ -36,15 +64,18 @@ SELECT
 C._id AS id,
 C.name,
 C.sort AS `order`,
-C.flags
+C.flags,
+C.version,
+C.uid,
+C.last_modified_at
 FROM categories C
 JOIN mangas_categories MC
 ON C._id = MC.category_id
 WHERE MC.manga_id = :mangaId;
 
 insert:
-INSERT INTO categories(name, sort, flags)
-VALUES (:name, :order, :flags);
+INSERT INTO categories(name, sort, flags, version, uid, last_modified_at)
+VALUES (:name, :order, :flags, :version, :uid, :lastModifiedAt);
 
 delete:
 DELETE FROM categories
@@ -54,8 +85,17 @@ update:
 UPDATE categories
 SET name = coalesce(:name, name),
     sort = coalesce(:order, sort),
-    flags = coalesce(:flags, flags)
+    flags = coalesce(:flags, flags),
+    version = coalesce(:version, version),
+    uid = coalesce(:uid, uid),
+    last_modified_at = coalesce(:lastModifiedAt, last_modified_at),
+    is_syncing = coalesce(:isSyncing, is_syncing)
 WHERE _id = :categoryId;
+
+resetIsSyncing:
+UPDATE categories
+SET is_syncing = 0
+WHERE is_syncing = 1;
 
 updateAllFlags:
 UPDATE categories SET

--- a/data/src/main/sqldelight/tachiyomi/migrations/14.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/14.sqm
@@ -1,0 +1,27 @@
+ALTER TABLE categories ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE categories ADD COLUMN uid INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE categories ADD COLUMN last_modified_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE categories ADD COLUMN is_syncing INTEGER NOT NULL DEFAULT 0;
+
+UPDATE categories SET uid = abs(random());
+
+CREATE TRIGGER insert_category_uid AFTER INSERT ON categories
+BEGIN
+    UPDATE categories
+    SET uid = CASE WHEN uid = 0 THEN abs(random()) ELSE uid END,
+        last_modified_at = CASE WHEN last_modified_at = 0 THEN strftime('%s', 'now') ELSE last_modified_at END
+    WHERE _id = new._id;
+END;
+
+CREATE TRIGGER update_category_version AFTER UPDATE ON categories
+WHEN new.is_syncing = 0 AND (
+    new.name != old.name OR
+    new.sort != old.sort OR
+    new.flags != old.flags
+)
+BEGIN
+    UPDATE categories
+    SET version = version + 1,
+        last_modified_at = strftime('%s', 'now')
+    WHERE _id = new._id;
+END;

--- a/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
@@ -7,6 +7,9 @@ data class Category(
     val name: String,
     val order: Long,
     val flags: Long,
+    val version: Long = 0,
+    val uid: Long = 0,
+    val lastModifiedAt: Long = 0,
 ) : Serializable {
 
     val isSystemCategory: Boolean = id == UNCATEGORIZED_ID

--- a/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
@@ -5,4 +5,7 @@ data class CategoryUpdate(
     val name: String? = null,
     val order: Long? = null,
     val flags: Long? = null,
+    val version: Long? = null,
+    val uid: Long? = null,
+    val lastModifiedAt: Long? = null,
 )

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1060,4 +1060,35 @@
     <string name="donationCampaign.paragraph3">Regardless, Mihon will continue to be maintained by me and the volunteers, and it will stay open source.</string>
     <string name="donationCampaign.contactPlatform">Discord</string>
     <string name="donationCampaign.dismiss">Dismiss</string>
+
+    <!-- Sync -->
+    <string name="syncing_library">Syncing library</string>
+    <string name="sync_library">Sync library</string>
+    <string name="sync_error">Syncing library failed</string>
+    <string name="sync_complete">Syncing library complete</string>
+    <string name="sync_in_progress">Sync is already in progress</string>
+    <string name="syncyomi">SyncYomi</string>
+    <string name="pref_sync_service_category">Sync</string>
+    <string name="pref_sync_service">Service</string>
+    <string name="pref_sync_host">Host</string>
+    <string name="pref_sync_host_summ">Enter the host address for synchronizing your library</string>
+    <string name="pref_sync_api_key">API key</string>
+    <string name="pref_sync_api_key_summ">Enter the API key to synchronize your library</string>
+    <string name="pref_sync_now_group_title">Sync actions</string>
+    <string name="pref_sync_now">Sync now</string>
+    <string name="pref_sync_now_subtitle">Initiate immediate synchronization of your data</string>
+    <string name="pref_sync_options">Create sync triggers</string>
+    <string name="pref_sync_options_summ">Can be used to set sync triggers</string>
+    <string name="pref_sync_automatic_category">Automatic synchronization</string>
+    <string name="pref_sync_interval">Synchronization frequency</string>
+    <string name="pref_choose_what_to_sync">Choose what to sync</string>
+    <string name="last_synchronization">Last synchronization: %1$s</string>
+    <string name="label_triggers">Triggers</string>
+    <string name="sync_on_chapter_read">Sync on chapter read</string>
+    <string name="sync_on_chapter_open">Sync on chapter open</string>
+    <string name="sync_on_app_start">Sync on app start</string>
+    <string name="sync_on_app_resume">Sync on app resume</string>
+    <string name="update_30min">Every 30 minutes</string>
+    <string name="update_1hour">Every hour</string>
+    <string name="update_3hour">Every 3 hours</string>
 </resources>


### PR DESCRIPTION
## Summary

This adds **SyncYomi** cross-device library sync. It is essentially a **direct port from TachiyomiSY**, where the feature has lived for a while, consolidated from jobobby04/TachiyomiSY#1005 (initial cross-device sync), #1155 (ETag syncing + improvements), #1558 (sync events), and #1559 (improved category merging). The core (`SyncManager`, the `SyncService` merge/conflict-resolution engine, `SyncYomiSyncService`, `SyncDataJob`, `SyncNotifier`, `SyncPreferences`, settings UI, and triggers) is copied as-is from TachiyomiSY's current state with only the adaptations required to fit Mihon's codebase.

## What it does

- Self-hosted [SyncYomi](https://github.com/SyncYomi/SyncYomi) backend over HTTP with ETag-based optimistic concurrency.
- Settings → Data & storage → **Sync**: service selector, host/API-key fields, a "choose what to sync" selector, and sync-trigger options.
- Triggers: sync on chapter read/open, app start/resume, manual "Sync library" from the library overflow menu, and a periodic background job.
- Category versioning (uid/version/last_modified_at) for UID-based category merging.

## Differences from the TachiyomiSY original

It's a faithful port, but a few things differ:

- **SyncYomi only** — the Google Drive backend from the original PRs is intentionally omitted, so this adds no `google-api-client`/Play Services dependencies, no bundled OAuth `client_secrets.json`, and no `GoogleDriveLoginActivity` or manifest entries.
- **Extension repos → extension stores** — adapted to Mihon's `backupExtensionStores` (TachiyomiSY uses `backupExtensionRepo`), and extension stores are now carried through the merge (keyed by `indexUrl`).
- **SY-only sync targets stripped** — saved searches, custom manga info, and EH/read-entry specifics that don't exist in Mihon were removed.
- **Backup models made `data class`** — `BackupManga`/`BackupChapter`/`BackupCategory`/`BackupExtensionStore` are now data classes, which the merger relies on for structural equality and `copy()` (TachiyomiSY's equivalents already are).
- **No new dependency for HTTP status codes** — `org.apache.http.HttpStatus` constants replaced with plain `Int` literals (304/404/412).
- **Category versioning migration** is `14.sqm` here (vs `39.sqm` upstream) and omits SY's `manga_order` column.
- **No library-update sync trigger** — current TachiyomiSY `master` already dropped it, so it's not included.

## Testing

- Compiles (`:app:compileDebugKotlin`) and passes `spotlessCheck`.
- Verified on a physical device (Pixel 8): a manual sync pushes the library to a fresh SyncYomi key and returns an ETag; a fresh reinstall pulls and merges it back. No errors in logs.
