### PR TITLE
fix(onboarding): offer all-files access when the folder picker is unavailable

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,13 @@
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
+    <!-- Optional escape hatch for devices where the SAF folder picker refuses to grant access
+         to any folder ("Can't use this folder, to protect your privacy"). Lets the user opt in to
+         writing the storage folder directly to shared storage. Only requested explicitly from the
+         onboarding storage step. -->
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <!-- For background jobs -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
@@ -1,6 +1,12 @@
 package eu.kanade.presentation.more.onboarding
 
 import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Environment
+import android.provider.Settings
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,6 +15,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,9 +25,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.kanade.presentation.more.settings.screen.SettingsDataScreen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.collectLatest
+import tachiyomi.core.common.storage.AndroidStorageFolderProvider
 import tachiyomi.domain.storage.service.StoragePreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Button
@@ -32,8 +43,13 @@ import uy.kohesive.injekt.api.get
 internal class StorageStep : OnboardingStep {
 
     private val storagePref = Injekt.get<StoragePreferences>().baseStorageDirectory
+    private val folderProvider = Injekt.get<AndroidStorageFolderProvider>()
 
     private var _isComplete by mutableStateOf(false)
+
+    // Whether the user opened the all-files-access settings screen from this step. Used to set the
+    // default location automatically once they return having granted it.
+    private var allFilesAccessRequested = false
 
     override val isComplete: Boolean
         get() = _isComplete
@@ -44,6 +60,29 @@ internal class StorageStep : OnboardingStep {
         val handler = LocalUriHandler.current
 
         val pickStorageLocation = SettingsDataScreen.storageLocationPicker(storagePref)
+
+        // The all-files-access escape hatch only exists on Android 11+. On older versions the
+        // legacy storage permission already covers the default shared-storage folder.
+        val allFilesAccessSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+
+        if (allFilesAccessSupported) {
+            val lifecycleOwner = LocalLifecycleOwner.current
+            DisposableEffect(lifecycleOwner.lifecycle) {
+                val observer = object : DefaultLifecycleObserver {
+                    override fun onResume(owner: LifecycleOwner) {
+                        if (allFilesAccessRequested &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                            Environment.isExternalStorageManager()
+                        ) {
+                            allFilesAccessRequested = false
+                            useDefaultStorageLocation()
+                        }
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+            }
+        }
 
         Column(
             modifier = Modifier.padding(16.dp),
@@ -70,23 +109,30 @@ internal class StorageStep : OnboardingStep {
                 Text(stringResource(MR.strings.onboarding_storage_action_select))
             }
 
-            // Fallback for devices where the system folder picker won't grant access to any
-            // folder ("Can't use this folder"). The app-specific external storage directory is
-            // always writable without any permission or SAF grant.
-            Text(
-                stringResource(
-                    MR.strings.onboarding_storage_fallback_info,
-                    stringResource(MR.strings.app_name),
-                ),
-            )
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                onClick = {
-                    val defaultDir = context.getExternalFilesDir(null) ?: context.filesDir
-                    storagePref.set(defaultDir.toUri().toString())
-                },
-            ) {
-                Text(stringResource(MR.strings.onboarding_storage_action_use_default))
+            // Fallback for devices where the system folder picker won't grant access to any folder
+            // ("Can't use this folder"). With all-files access the app can write to shared storage
+            // directly, so it falls back to its default folder there.
+            if (allFilesAccessSupported) {
+                Text(
+                    stringResource(
+                        MR.strings.onboarding_storage_all_files_info,
+                        stringResource(MR.strings.app_name),
+                    ),
+                )
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                            if (Environment.isExternalStorageManager()) {
+                                useDefaultStorageLocation()
+                            } else {
+                                requestAllFilesAccess(context)
+                            }
+                        }
+                    },
+                ) {
+                    Text(stringResource(MR.strings.onboarding_storage_action_all_files))
+                }
             }
 
             HorizontalDivider(
@@ -107,5 +153,31 @@ internal class StorageStep : OnboardingStep {
             storagePref.changes()
                 .collectLatest { _isComplete = storagePref.isSet() }
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun requestAllFilesAccess(context: Context) {
+        allFilesAccessRequested = true
+        val packageUri = "package:${context.packageName}".toUri()
+        try {
+            context.startActivity(
+                Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, packageUri),
+            )
+        } catch (e: ActivityNotFoundException) {
+            // Some OEMs don't expose the per-app screen; fall back to the global list.
+            try {
+                context.startActivity(Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION))
+            } catch (e: ActivityNotFoundException) {
+                allFilesAccessRequested = false
+                context.toast(MR.strings.file_picker_error)
+            }
+        }
+    }
+
+    private fun useDefaultStorageLocation() {
+        // Ensure the folder exists before pointing the app at it, since StorageManager only creates
+        // its subdirectories when the base directory already resolves.
+        folderProvider.directory().mkdirs()
+        storagePref.set(folderProvider.path())
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import eu.kanade.presentation.more.settings.screen.SettingsDataScreen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.collectLatest
@@ -67,6 +68,25 @@ internal class StorageStep : OnboardingStep {
                 },
             ) {
                 Text(stringResource(MR.strings.onboarding_storage_action_select))
+            }
+
+            // Fallback for devices where the system folder picker won't grant access to any
+            // folder ("Can't use this folder"). The app-specific external storage directory is
+            // always writable without any permission or SAF grant.
+            Text(
+                stringResource(
+                    MR.strings.onboarding_storage_fallback_info,
+                    stringResource(MR.strings.app_name),
+                ),
+            )
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    val defaultDir = context.getExternalFilesDir(null) ?: context.filesDir
+                    storagePref.set(defaultDir.toUri().toString())
+                },
+            ) {
+                Text(stringResource(MR.strings.onboarding_storage_action_use_default))
             }
 
             HorizontalDivider(

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -186,8 +186,8 @@
     <string name="onboarding_storage_info">Select a folder where %1$s will store chapter downloads, backups, and more.\n\nA dedicated folder is recommended.\n\nSelected folder: %2$s</string>
     <string name="onboarding_storage_action_select">Select a folder</string>
     <string name="onboarding_storage_selection_required">A folder must be selected</string>
-    <string name="onboarding_storage_fallback_info">If your device won\'t let you select a folder, you can use %1$s\'s default app storage instead. Note that this data is removed if the app is uninstalled.</string>
-    <string name="onboarding_storage_action_use_default">Use default app storage</string>
+    <string name="onboarding_storage_all_files_info">If your device won\'t let you select a folder, you can grant %1$s all-files access instead. It will then store its data in a folder in your shared storage.</string>
+    <string name="onboarding_storage_action_all_files">Grant all-files access</string>
     <string name="onboarding_storage_help_info">Updating from an older version and not sure what to select? Refer to the storage guide for more information.</string>
     <string name="onboarding_storage_help_action">Storage guide</string>
     <string name="onboarding_permission_install_apps">Install apps permission</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -186,6 +186,8 @@
     <string name="onboarding_storage_info">Select a folder where %1$s will store chapter downloads, backups, and more.\n\nA dedicated folder is recommended.\n\nSelected folder: %2$s</string>
     <string name="onboarding_storage_action_select">Select a folder</string>
     <string name="onboarding_storage_selection_required">A folder must be selected</string>
+    <string name="onboarding_storage_fallback_info">If your device won\'t let you select a folder, you can use %1$s\'s default app storage instead. Note that this data is removed if the app is uninstalled.</string>
+    <string name="onboarding_storage_action_use_default">Use default app storage</string>
     <string name="onboarding_storage_help_info">Updating from an older version and not sure what to select? Refer to the storage guide for more information.</string>
     <string name="onboarding_storage_help_action">Storage guide</string>
     <string name="onboarding_permission_install_apps">Install apps permission</string>


### PR DESCRIPTION
## Problem

On some devices and Android versions the system folder picker (`ACTION_OPEN_DOCUMENT_TREE`) refuses to grant access to any directory — it shows an empty list or "Can't use this folder, to protect your privacy, choose another folder", even for a freshly created folder. Because the onboarding storage step only completes once a folder tree has been granted, and Mihon does not request all-files access, affected users are stuck on onboarding with no way to finish setup. See #1919 and the same report against TachiyomiSY (jobobby04/TachiyomiSY#1514).

## Fix

Add an opt-in **"Grant all-files access"** button to the onboarding storage step (Android 11+). Tapping it sends the user to the system all-files-access screen (`ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION`, falling back to the global list on OEMs that lack the per-app screen). Once `MANAGE_EXTERNAL_STORAGE` is granted, the app points its storage at its **default folder in shared storage** (`AndroidStorageFolderProvider`, e.g. `/storage/emulated/0/Mihon`) directly via a `file://` path — no SAF grant required. `StorageManager` then creates its `downloads`/`autobackup`/`local` subdirectories there as usual, so the app is fully functional.

The system folder picker remains the recommended primary path and is unaffected; this is only an escape hatch for users the picker leaves stuck. Unlike the app-specific external directory, the shared-storage folder persists across uninstalls.

On Android 10 and below the legacy storage permission already covers the default shared-storage folder, so the button is only shown on API 30+.

## Notes

This declares `MANAGE_EXTERNAL_STORAGE` in the manifest. It is never requested silently — only via explicit user action on this onboarding step — but it is a [policy-restricted permission on Google Play](https://support.google.com/googleplay/android-developer/answer/10467955) and may require a declaration/justification for Play distribution. Flagging for maintainer awareness.

## Testing

Verified on a physical device (Pixel 8, Android 16, where the picker rejected every folder): tapping "Grant all-files access", enabling it in system settings, and returning to the app sets the storage location, enables Next, and lets onboarding complete into the library. Existing folder-picker selection still works as before.
