### PR TITLE
fix: resolve variable shadowing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -439,9 +439,7 @@ class Downloader(
 
         // Try to find the image file
         val imageFile = tmpDir.listFiles()?.firstOrNull {
-            val filename = it.name
-            if (filename == null || filename.endsWith(".tmp")) return@firstOrNull false
-            filename.startsWith("$filename.") || filename.startsWith("${filename}__001")
+            isDownloadedPageImage(it.name, filename)
         }
 
         try {
@@ -599,6 +597,17 @@ class Downloader(
             }
         }
         return downloadedImagesCount == downloadPageCount
+    }
+
+    /**
+     * Checks if the file name matches a downloaded page image.
+     *
+     * @param fileName Name of the file to check
+     * @param pagePrefix Expected page prefix (e.g., "001")
+     */
+    private fun isDownloadedPageImage(fileName: String?, pagePrefix: String): Boolean {
+        if (fileName == null || fileName.endsWith(".tmp")) return false
+        return fileName.startsWith("$pagePrefix.") || fileName.startsWith("${pagePrefix}__001.")
     }
 
     /**


### PR DESCRIPTION
There was a variable shadowing issue inside the `tmpDir.listFiles()?.firstOrNull` block.

The code was defining a local variable named `filename` and then mistakenly referencing it inside the same scope, causing confusion between the outer and inner variables.