### PR TITLE
fix: resolve variable shadowing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -606,7 +606,7 @@ class Downloader(
      * @param pagePrefix Expected page prefix (e.g., "001")
      */
     private fun isDownloadedPageImage(fileName: String, pagePrefix: String): Boolean =
-       !fileName.endsWith(".tmp") || fileName.startsWith("$pagePrefix.") ||
+        !fileName.endsWith(".tmp") || fileName.startsWith("$pagePrefix.") ||
             fileName.startsWith("${pagePrefix}__001.")
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -439,7 +439,7 @@ class Downloader(
 
         // Try to find the image file
         val imageFile = tmpDir.listFiles()?.firstOrNull {
-            isDownloadedPageImage(it.name, filename)
+            isDownloadedPageImage(it.name ?: return false, filename)
         }
 
         try {
@@ -605,10 +605,9 @@ class Downloader(
      * @param fileName Name of the file to check
      * @param pagePrefix Expected page prefix (e.g., "001")
      */
-    private fun isDownloadedPageImage(fileName: String?, pagePrefix: String): Boolean {
-        if (fileName == null || fileName.endsWith(".tmp")) return false
-        return fileName.startsWith("$pagePrefix.") || fileName.startsWith("${pagePrefix}__001.")
-    }
+    private fun isDownloadedPageImage(fileName: String, pagePrefix: String): Boolean =
+       !fileName.endsWith(".tmp") || fileName.startsWith("$pagePrefix.") ||
+            fileName.startsWith("${pagePrefix}__001.")
 
     /**
      * Archive the chapter pages as a CBZ.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -439,9 +439,7 @@ class Downloader(
 
         // Try to find the image file
         val imageFile = tmpDir.listFiles()?.firstOrNull {
-            val filename = it.name
-            if (filename == null || filename.endsWith(".tmp")) return@firstOrNull false
-            filename.startsWith("$filename.") || filename.startsWith("${filename}__001")
+            isDownloadedPageImage(it.name, filename)
         }
 
         try {
@@ -599,6 +597,17 @@ class Downloader(
             }
         }
         return downloadedImagesCount == downloadPageCount
+    }
+
+    /**
+     * Checks if the file name matches a downloaded page image.
+     *
+     * @param fileName Name of the file to check
+     * @param pagePrefix Expected page prefix (e.g., "001")
+     */
+    private fun isDownloadedPageImage(fileName: String?, pagePrefix: String): Boolean {
+        if (fileName == null || fileName.endsWith(".tmp")) return false
+        return fileName.startsWith("$pagePrefix.") || fileName.startsWith("${pagePrefix}__001.")
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -439,7 +439,7 @@ class Downloader(
 
         // Try to find the image file
         val imageFile = tmpDir.listFiles()?.firstOrNull {
-            isDownloadedPageImage(it.name ?: return false, filename)
+            isDownloadedPageImage(it.name ?: return@firstOrNull false, filename)
         }
 
         try {


### PR DESCRIPTION
The inner `val filename = it.name` shadows the outer filename variable, so the comparison ends up comparing the current file's name against itself instead of the target filename. This makes the condition always evaluate to false, so the file is never matched. 

Bug introduced in #3167