### PR TITLE
Fix downloads not working due to wrong file check

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -606,8 +606,10 @@ class Downloader(
      * @param pagePrefix Expected page prefix (e.g., "001")
      */
     private fun isDownloadedPageImage(fileName: String, pagePrefix: String): Boolean =
-        !fileName.endsWith(".tmp") || fileName.startsWith("$pagePrefix.") ||
-            fileName.startsWith("${pagePrefix}__001.")
+        !fileName.endsWith(".tmp") && (
+            fileName.startsWith("$pagePrefix.") ||
+                fileName.startsWith("${pagePrefix}__001.")
+            )
 
     /**
      * Archive the chapter pages as a CBZ.


### PR DESCRIPTION
The code as-is accepts _any_ non-.tmp file as a match for the given page file.
Changing the condition to "not .tmp" AND (either page prefix pattern) results in the correct behaviour and chapters download again.

Fixes #3512.

@AntsyLich do you want a Changelog entry for this?

Example of logic before (with logging lines for each part of the boolean expression):
```log
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  filename=005.png
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  pagePrefix=082
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  extant file does not end in tmp? true
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  extant file starts with the page prefix? false
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  extant file starts with page prefix dunder 001? false
2026-07-03 15:50:00.138  8490-8680  Downloader  app.mihon.dev  D  isDownloadedPageImage check says: true
```

Example of logic now:
```log
2026-07-03 15:52:12.187  8830-8860  Downloader  app.mihon.dev  D  filename=005.png
2026-07-03 15:52:12.192  8830-8860  Downloader  app.mihon.dev  D  pagePrefix=082
2026-07-03 15:52:12.192  8830-8860  Downloader  app.mihon.dev  D  extant file does not end in tmp? true
2026-07-03 15:52:12.192  8830-8860  Downloader  app.mihon.dev  D  extant file starts with the page prefix? false
2026-07-03 15:52:12.192  8830-8860  Downloader  app.mihon.dev  D  extant file starts with page prefix dunder 001? false
2026-07-03 15:52:12.194  8830-8860  Downloader  app.mihon.dev  D  isDownloadedPageImage check says: false
```