### PR TITLE
fix(telemetry): replace GoogleApiAvailability with PackageManager to avoid Google Play Services class-loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Invalidate download cache after backup restore ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3096](https://github.com/mihonapp/mihon/pull/3096))
 
 ### Changed
-- Use PackageManager instead of GoogleApiAvailability for GPS availability check ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3525](https://github.com/mihonapp/mihon/pull/3525))
+- Don't use GMS to detect if GMS is available ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3525](https://github.com/mihonapp/mihon/pull/3525))
 
 ### Fixed
 - Fix Shikimori tracking not working ([@MajorTanya](https://github.com/MajorTanya)) ([#3497](https://github.com/mihonapp/mihon/pull/3497))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Display authors and description in Shikimori search results ([@MajorTanya](https://github.com/MajorTanya)) ([#3499](https://github.com/mihonapp/mihon/pull/3499))
 - Invalidate download cache after backup restore ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3096](https://github.com/mihonapp/mihon/pull/3096))
 
+### Changed
+- Use PackageManager instead of GoogleApiAvailability for GPS availability check ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3525](https://github.com/mihonapp/mihon/pull/3525))
+
 ### Fixed
 - Fix Shikimori tracking not working ([@MajorTanya](https://github.com/MajorTanya)) ([#3497](https://github.com/mihonapp/mihon/pull/3497))
 - Fix crash trying to select text in notes screen ([@AntsyLich](https://github.com/AntsyLich)) ([#3516](https://github.com/mihonapp/mihon/pull/3516))

--- a/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
+++ b/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
@@ -1,8 +1,7 @@
 package mihon.telemetry
 
 import android.content.Context
-import com.google.android.gms.common.ConnectionResult
-import com.google.android.gms.common.GoogleApiAvailability
+import android.content.pm.PackageManager
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
@@ -32,13 +31,18 @@ object TelemetryConfig {
         }
     }
 
+    /**
+     * Checks if Google Play Services is installed and enabled.
+     * Uses PackageManager instead of GoogleApiAvailability to avoid loading
+     * any Google Play Services client library classes, which can itself
+     * trigger system notifications on devices where GPS is unavailable.
+     */
     private fun isGooglePlayServicesAvailable(context: Context): Boolean {
         return try {
-            val availability = GoogleApiAvailability.getInstance()
-            val resultCode = availability.isGooglePlayServicesAvailable(context)
-            resultCode == ConnectionResult.SUCCESS
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) { "Unable to check Google Play Services availability" }
+            val pm = context.packageManager
+            val info = pm.getPackageInfo("com.google.android.gms", PackageManager.GET_META_DATA)
+            info.applicationInfo?.enabled == true
+        } catch (e: PackageManager.NameNotFoundException) {
             false
         }
     }

--- a/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
+++ b/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
@@ -37,7 +37,6 @@ object TelemetryConfig {
                 .getPackageInfo("com.google.android.gms", PackageManager.GET_META_DATA)
                 .applicationInfo
                 ?.enabled == true
-            info.applicationInfo?.enabled == true
         } catch (e: PackageManager.NameNotFoundException) {
             false
         }

--- a/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
+++ b/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
@@ -31,16 +31,12 @@ object TelemetryConfig {
         }
     }
 
-    /**
-     * Checks if Google Play Services is installed and enabled.
-     * Uses PackageManager instead of GoogleApiAvailability to avoid loading
-     * any Google Play Services client library classes, which can itself
-     * trigger system notifications on devices where GPS is unavailable.
-     */
     private fun isGooglePlayServicesAvailable(context: Context): Boolean {
         return try {
-            val pm = context.packageManager
-            val info = pm.getPackageInfo("com.google.android.gms", PackageManager.GET_META_DATA)
+            context.packageManager
+                .getPackageInfo("com.google.android.gms", PackageManager.GET_META_DATA)
+                .applicationInfo
+                ?.enabled == true
             info.applicationInfo?.enabled == true
         } catch (e: PackageManager.NameNotFoundException) {
             false


### PR DESCRIPTION
Fixes #3511

Google Play Services notifications have reappeared on v0.20.0 when Google Play Services is disabled or unavailable on non-FOSS builds. The previous fix (#3152) added a Google Play Services availability check using `GoogleApiAvailability`, but this class is itself a Google Play Services client library — loading it can trigger the Google Play Services APK to show system notifications on devices where it's not available.

## Changes

- **Replace `GoogleApiAvailability` check with `PackageManager` API**: Uses `packageManager.getPackageInfo("com.google.android.gms", ...)` to check if Google Play Services is installed and enabled without loading any Google Play Services client library classes.

- **Remove `com.google.android.gms.common.*` imports**: No longer needed.

## Why this works

The previous fix was circular — using a Google Play Services library to check if Google Play Services is available. Between v0.19.9 and v0.20.0, the Firebase BOM was bumped from 34.11.0 to 34.15.0, pulling in newer `play-services-base` transitively. These newer versions changed internal class-loading behavior, causing `GoogleApiAvailability` initialization itself to trigger the Google Play Services notification.

The `PackageManager` approach uses only standard Android APIs — no Google Play Services classes are ever loaded on devices without Google Play Services, preventing the notification entirely.

## Testing

- ✅ Compiles successfully (`telemetry:compileDebugKotlin`)
- ✅ Passes formatting check (`spotlessKotlinCheck`)
- ✅ FOSS build unaffected (uses noop implementation)

Checklist:
- [x] Follows project coding standards
- [x] No breaking changes
- [x] Graceful degradation when Google Play Services unavailable
- [x] Preserves existing functionality when Google Play Services available