### PR TITLE
Hikka: Set PLAN_TO_READ for manga with no progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix crash trying to select text in notes screen ([@AntsyLich](https://github.com/AntsyLich)) ([#3516](https://github.com/mihonapp/mihon/pull/3516))
 - Fix crash when putting app in background ([@AntsyLich](https://github.com/AntsyLich)) ([#3523](https://github.com/mihonapp/mihon/pull/3523))
 - Fix support for non-system SAF providers ([@AntsyLich](https://github.com/AntsyLich)) ([#3530](https://github.com/mihonapp/mihon/pull/3530))
+- Fix Hikka not defaulting to "Plan to Read" for unread titles ([@MajorTanya](https://github.com/MajorTanya)) ([#3534](https://github.com/mihonapp/mihon/pull/3534))
 
 ## [v0.20.0] - 2026-06-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Added
 - [Hikka](https://hikka.io/) tracker support ([@Lorg0n](https://github.com/Lorg0n)) ([#1386](https://github.com/mihonapp/mihon/pull/1386))
+  - Fix Hikka not defaulting to "Plan to Read" for unread titles ([@MajorTanya](https://github.com/MajorTanya)) ([#3534](https://github.com/mihonapp/mihon/pull/3534))
 - Support resumable image downloads if supported by source ([@xMohnad](https://github.com/xMohnad)) ([#3167](https://github.com/mihonapp/mihon/pull/3167))
 - Display authors and description in Shikimori search results ([@MajorTanya](https://github.com/MajorTanya)) ([#3499](https://github.com/mihonapp/mihon/pull/3499))
 - Invalidate download cache after backup restore ([@leodyversemilla07](https://github.com/leodyversemilla07)) ([#3096](https://github.com/mihonapp/mihon/pull/3096))
@@ -22,7 +23,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix crash trying to select text in notes screen ([@AntsyLich](https://github.com/AntsyLich)) ([#3516](https://github.com/mihonapp/mihon/pull/3516))
 - Fix crash when putting app in background ([@AntsyLich](https://github.com/AntsyLich)) ([#3523](https://github.com/mihonapp/mihon/pull/3523))
 - Fix support for non-system SAF providers ([@AntsyLich](https://github.com/AntsyLich)) ([#3530](https://github.com/mihonapp/mihon/pull/3530))
-- Fix Hikka not defaulting to "Plan to Read" for unread titles ([@MajorTanya](https://github.com/MajorTanya)) ([#3534](https://github.com/mihonapp/mihon/pull/3534))
 
 ## [v0.20.0] - 2026-06-27
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/Hikka.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/Hikka.kt
@@ -112,6 +112,7 @@ class Hikka(id: Long) : BaseTracker(id, "Hikka"), DeletableTracker {
             track.finished_reading_date = (readContent.endDate ?: 0L) * 1000
             update(track)
         } else {
+            track.status = if (hasReadChapters) READING else PLAN_TO_READ
             track.score = 0.0
             update(track)
         }


### PR DESCRIPTION
Currently, every title will be added as READING, even if no chapter has been read.

For consistency with every other tracker, I added the hasReadChapters check as seen in other tracker implementations.

AL: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt#L192

Bangumi: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt#L63

Kitsu: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt#L110

MU: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt#L56

MAL: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt#L107

Shikimori: https://github.com/mihonapp/mihon/blob/aa46039e6c47971520ba1100805ec8b0093c525a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt#L77