### PR TITLE
Fix filtered chapters showing as missing

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -422,8 +422,8 @@ private fun MangaScreenSmallImpl(
                         key = MangaScreenItem.CHAPTER_HEADER,
                         contentType = MangaScreenItem.CHAPTER_HEADER,
                     ) {
-                        val missingChapterCount = remember(chapters) {
-                            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                        val missingChapterCount = remember(state.chapters) {
+                            state.chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
                         }
                         ChapterHeader(
                             enabled = !isAnySelected,
@@ -659,8 +659,8 @@ fun MangaScreenLargeImpl(
                                 key = MangaScreenItem.CHAPTER_HEADER,
                                 contentType = MangaScreenItem.CHAPTER_HEADER,
                             ) {
-                                val missingChapterCount = remember(chapters) {
-                                    chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                                val missingChapterCount = remember(state.chapters) {
+                                    state.chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
                                 }
                                 ChapterHeader(
                                     enabled = !isAnySelected,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -67,7 +67,6 @@ import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.model.NoChaptersException
-import tachiyomi.domain.chapter.service.calculateChapterGap
 import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
@@ -1124,6 +1123,16 @@ class MangaScreenModel(
                 chapters.fastAny { it.selected }
             }
 
+            // Chapter numbers that actually exist on the source, regardless of the
+            // active read/downloaded/bookmarked view filters. Used so chapters hidden
+            // by those filters aren't mistaken for chapters missing from the source.
+            private val existingChapterNumbers by lazy {
+                chapters
+                    .filter { it.chapter.isRecognizedNumber }
+                    .map { floor(it.chapter.chapterNumber).toInt() }
+                    .toSet()
+            }
+
             val chapterListItems by lazy {
                 if (hideMissingChapters) {
                     return@lazy processedChapters
@@ -1135,16 +1144,18 @@ class MangaScreenModel(
                     } else {
                         before to after
                     }
-                    if (higherChapter == null) return@insertSeparators null
-
-                    if (lowerChapter == null) {
-                        floor(higherChapter.chapter.chapterNumber)
-                            .toInt()
-                            .minus(1)
-                            .coerceAtLeast(0)
-                    } else {
-                        calculateChapterGap(higherChapter.chapter, lowerChapter.chapter)
+                    if (higherChapter == null || !higherChapter.chapter.isRecognizedNumber) {
+                        return@insertSeparators null
                     }
+                    if (lowerChapter != null && !lowerChapter.chapter.isRecognizedNumber) {
+                        return@insertSeparators null
+                    }
+
+                    val lowerBound = lowerChapter?.let { floor(it.chapter.chapterNumber).toInt() } ?: 0
+                    val upperBound = floor(higherChapter.chapter.chapterNumber).toInt()
+
+                    ((lowerBound + 1) until upperBound)
+                        .count { it !in existingChapterNumbers }
                         .takeIf { it > 0 }
                         ?.let { missingCount ->
                             ChapterList.MissingCount(


### PR DESCRIPTION
Missing chapter counts (both the header badge and inline separators) were computed from the filtered chapter list, so any chapter hidden by an active filter (read, downloaded, bookmarked, scanlator) was mistaken for a chapter missing from the source.

The header count now uses the full unfiltered chapter list, and the inline separator logic checks filtered-out gaps against the set of chapter numbers that actually exist before reporting them as missing.

Fixes #35.