### PR TITLE
Fix delete-after-read exclusion categories not respected on manual mark as read

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -48,6 +48,9 @@ class SetReadStatus(
 
         if (read && downloadPreferences.removeAfterMarkedAsRead.get()) {
             chaptersToUpdate
+                // Chapters here still carry their pre-update read state; downstream
+                // deletion filtering (excluded categories) relies on the new state.
+                .map { it.copy(read = true) }
                 .groupBy { it.mangaId }
                 .forEach { (mangaId, chapters) ->
                     deleteDownload.awaitAll(


### PR DESCRIPTION
When a chapter is manually marked as read (from the manga screen, library, or updates screen), the delete-after-read step passed the pre-update Chapter objects, still carrying read = false, into the deletion pipeline. DownloadManager's excluded-category check relies on the chapter's read state to decide whether to protect it, so it never triggered and the chapter was deleted regardless of the manga's excluded category.

Pass chapters with the updated read state instead so the exclusion check sees the correct value.

Fixes #1521.