### PR TITLE
Fix underscore in Hikka media types

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/dto/HKManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/dto/HKManga.kt
@@ -16,7 +16,7 @@ data class HKManga(
     @SerialName("title_original")
     val titleOriginal: String,
     @SerialName("media_type")
-    val mediaType: String,
+    val mediaType: String?,
     @SerialName("title_ua")
     val titleUa: String? = null,
     @SerialName("title_en")
@@ -45,7 +45,7 @@ data class HKManga(
             score = this@HKManga.score
             tracking_url = "${HikkaApi.BASE_URL}/manga/${this@HKManga.slug}"
             publishing_status = this@HKManga.status
-            publishing_type = this@HKManga.mediaType
+            publishing_type = this@HKManga.mediaType?.replace("_", " ").orEmpty()
 
             startDate?.takeIf { it != 0L }?.let {
                 val outputDf = SimpleDateFormat("yyyy-MM-dd", Locale.US)


### PR DESCRIPTION
Currently, media types like "one_shot" will turn into "One_shot" in the search display due to Mihon capitalising the `publishing_type` attribute of `Track` for display.

It is common for other tracker implementations to replace the underscore with a space which results in "One shot".

This makes Hikka more consistent with other trackers.

I added the nullability check since the docs do say `string | null` but that's neither here nor there.

### Images
| Before | After |
| ------- | ------- |
| <img width="1336" height="323" alt="image" src="https://github.com/user-attachments/assets/31b9739c-89ff-4cca-9358-903b4dbc7414" /> | <img width="1336" height="323" alt="image" src="https://github.com/user-attachments/assets/aed27a0e-7261-4fe0-86ba-1c112e0a942f" /> |

Didn't add a changelog since it's so trivial