### PR TITLE
Enable parallel sync for Gradle 9.4+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,6 @@ org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Today, my freshly updated Android Studio Quail 2 2026.1.2 RC 2 showed me this:

<img width="568" height="210" alt="image" src="https://github.com/user-attachments/assets/c3a4fe03-7ec3-4119-ac0c-4ccb60435496" />

Enabling that seems to be a non-brainer to me, and clicking the button added this line to the `gradle.properties` file.