### PR TITLE
Add optional tracker score badge to library

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -282,6 +282,10 @@ private fun ColumnScope.DisplayPage(
         pref = screenModel.libraryPreferences.languageBadge,
     )
     CheckboxItem(
+        label = stringResource(MR.strings.action_display_tracker_score_badge),
+        pref = screenModel.libraryPreferences.trackerScoreBadge,
+    )
+    CheckboxItem(
         label = stringResource(MR.strings.action_display_show_continue_reading_button),
         pref = screenModel.libraryPreferences.showContinueReadingButton,
     )

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryBadges.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryBadges.kt
@@ -5,9 +5,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 import tachiyomi.presentation.core.components.Badge
+import kotlin.math.roundToInt
 
 @Composable
 internal fun DownloadsBadge(count: Int) {
@@ -25,6 +27,24 @@ internal fun UnreadBadge(count: Long) {
     if (count > 0) {
         Badge(text = "$count")
     }
+}
+
+@Composable
+internal fun TrackerScoreBadge(score: Double?) {
+    if (score == null || score <= 0.0) return
+
+    val scoreInTenths = (score * 10).roundToInt()
+    val text = if (scoreInTenths % 10 == 0) {
+        (scoreInTenths / 10).toString()
+    } else {
+        "${scoreInTenths / 10}.${scoreInTenths % 10}"
+    }
+
+    Badge(
+        text = text,
+        color = Color(0xFFFFB300),
+        textColor = Color.Black,
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
@@ -48,6 +48,7 @@ internal fun LibraryComfortableGrid(
                     UnreadBadge(count = libraryItem.badges.unreadCount)
                 },
                 coverBadgeEnd = {
+                    TrackerScoreBadge(score = libraryItem.badges.trackerScore)
                     LanguageBadge(
                         isLocal = libraryItem.badges.isLocal,
                         sourceLanguage = libraryItem.badges.sourceLanguage,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
@@ -49,6 +49,7 @@ internal fun LibraryCompactGrid(
                     UnreadBadge(count = libraryItem.badges.unreadCount)
                 },
                 coverBadgeEnd = {
+                    TrackerScoreBadge(score = libraryItem.badges.trackerScore)
                     LanguageBadge(
                         isLocal = libraryItem.badges.isLocal,
                         sourceLanguage = libraryItem.badges.sourceLanguage,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
@@ -56,6 +56,7 @@ internal fun LibraryList(
                 badge = {
                     DownloadsBadge(count = libraryItem.badges.downloadCount)
                     UnreadBadge(count = libraryItem.badges.unreadCount)
+                    TrackerScoreBadge(score = libraryItem.badges.trackerScore)
                     LanguageBadge(
                         isLocal = libraryItem.badges.isLocal,
                         sourceLanguage = libraryItem.badges.sourceLanguage,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -71,5 +71,6 @@ data class LibraryItem(
         val unreadCount: Long,
         val isLocal: Boolean,
         val sourceLanguage: String,
+        val trackerScore: Double?,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -97,10 +97,40 @@ class LibraryScreenModel(
                 combine(getTracksPerManga.subscribe(), getTrackingFiltersFlow(), ::Pair),
                 getLibraryItemPreferencesFlow(),
             ) { searchQuery, categories, favorites, (tracksMap, trackingFilters), itemPreferences ->
-                val showSystemCategory = favorites.any { it.libraryManga.categories.contains(0) }
-                val filteredFavorites = favorites
+                val loggedInTrackerIds = trackingFilters.keys
+
+                val trackerScores = if (itemPreferences.trackerScoreBadge) {
+                    getTrackerScores(tracksMap, loggedInTrackerIds)
+                } else {
+                    emptyMap()
+                }
+
+                val favoritesWithTrackerScores = if (trackerScores.isEmpty()) {
+                    favorites
+                } else {
+                    favorites.map { item ->
+                        item.copy(
+                            badges = item.badges.copy(
+                                trackerScore = trackerScores[item.id]?.takeIf { it > 0.0 },
+                            ),
+                        )
+                    }
+                }
+
+                val showSystemCategory =
+                    favoritesWithTrackerScores.any { it.libraryManga.categories.contains(0) }
+
+                val filteredFavorites = favoritesWithTrackerScores
                     .applyFilters(tracksMap, trackingFilters, itemPreferences)
-                    .let { if (searchQuery == null) it else it.filter { m -> m.matches(searchQuery, sourceManager) } }
+                    .let { favoritesList ->
+                        if (searchQuery == null) {
+                            favoritesList
+                        } else {
+                            favoritesList.filter { manga ->
+                                manga.matches(searchQuery, sourceManager)
+                            }
+                        }
+                    }
 
                 LibraryData(
                     isInitialized = true,
@@ -108,7 +138,7 @@ class LibraryScreenModel(
                     categories = categories,
                     favorites = filteredFavorites,
                     tracksMap = tracksMap,
-                    loggedInTrackerIds = trackingFilters.keys,
+                    loggedInTrackerIds = loggedInTrackerIds,
                 )
             }
                 .distinctUntilChanged()
@@ -249,6 +279,26 @@ class LibraryScreenModel(
         }
     }
 
+    private fun getTrackerScores(
+        trackMap: Map<Long, List<Track>>,
+        loggedInTrackerIds: Set<Long>,
+    ): Map<Long, Double> {
+        val trackersById = trackerManager
+            .getAll(loggedInTrackerIds)
+            .associateBy { it.id }
+
+        return trackMap.mapNotNull { (mangaId, tracks) ->
+            val scores = tracks.mapNotNull { track ->
+                trackersById[track.trackerId]?.get10PointScore(track)
+            }
+
+            scores
+                .takeIf { it.isNotEmpty() }
+                ?.average()
+                ?.let { mangaId to it }
+        }.toMap()
+    }
+
     private fun List<LibraryItem>.applyGrouping(
         categories: List<Category>,
         showSystemCategory: Boolean,
@@ -276,16 +326,7 @@ class LibraryScreenModel(
 
         val defaultTrackerScoreSortValue = -1.0
         val trackerScores by lazy {
-            val trackerMap = trackerManager.getAll(loggedInTrackerIds).associateBy { e -> e.id }
-            trackMap.mapValues { entry ->
-                when {
-                    entry.value.isEmpty() -> null
-                    else ->
-                        entry.value
-                            .mapNotNull { trackerMap[it.trackerId]?.get10PointScore(it) }
-                            .average()
-                }
-            }
+            getTrackerScores(trackMap, loggedInTrackerIds)
         }
 
         fun LibrarySort.comparator(): Comparator<LibraryItem> = Comparator { manga1, manga2 ->
@@ -350,6 +391,7 @@ class LibraryScreenModel(
             libraryPreferences.unreadBadge.changes(),
             libraryPreferences.localBadge.changes(),
             libraryPreferences.languageBadge.changes(),
+            libraryPreferences.trackerScoreBadge.changes(),
             libraryPreferences.autoUpdateMangaRestrictions.changes(),
 
             preferences.downloadedOnly.changes(),
@@ -365,14 +407,15 @@ class LibraryScreenModel(
                 unreadBadge = it[1] as Boolean,
                 localBadge = it[2] as Boolean,
                 languageBadge = it[3] as Boolean,
-                skipOutsideReleasePeriod = LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in (it[4] as Set<*>),
-                globalFilterDownloaded = it[5] as Boolean,
-                filterDownloaded = it[6] as TriState,
-                filterUnread = it[7] as TriState,
-                filterStarted = it[8] as TriState,
-                filterBookmarked = it[9] as TriState,
-                filterCompleted = it[10] as TriState,
-                filterIntervalCustom = it[11] as TriState,
+                trackerScoreBadge = it[4] as Boolean,
+                skipOutsideReleasePeriod = LibraryPreferences.MANGA_OUTSIDE_RELEASE_PERIOD in (it[5] as Set<*>),
+                globalFilterDownloaded = it[6] as Boolean,
+                filterDownloaded = it[7] as TriState,
+                filterUnread = it[8] as TriState,
+                filterStarted = it[9] as TriState,
+                filterBookmarked = it[10] as TriState,
+                filterCompleted = it[11] as TriState,
+                filterIntervalCustom = it[12] as TriState,
             )
         }
     }
@@ -410,6 +453,7 @@ class LibraryScreenModel(
                         } else {
                             ""
                         },
+                        trackerScore = null,
                     ),
                 )
             }
@@ -736,6 +780,7 @@ class LibraryScreenModel(
         val unreadBadge: Boolean,
         val localBadge: Boolean,
         val languageBadge: Boolean,
+        val trackerScoreBadge: Boolean,
         val skipOutsideReleasePeriod: Boolean,
 
         val globalFilterDownloaded: Boolean,

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -112,7 +112,11 @@ class LibraryPreferences(
 
     val languageBadge: Preference<Boolean> = preferenceStore.getBoolean("display_language_badge", false)
 
+    val trackerScoreBadge: Preference<Boolean> = preferenceStore.getBoolean("display_tracker_score_badge", false)
+
     val newShowUpdatesCount: Preference<Boolean> = preferenceStore.getBoolean("library_show_updates_count", true)
+
+
     val newUpdatesCount: Preference<Int> = preferenceStore.getInt(
         Preference.appStateKey("library_unseen_updates_count"),
         0,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -126,6 +126,7 @@
     <string name="action_display_unread_badge">Unread chapters</string>
     <string name="action_display_local_badge">Local source</string>
     <string name="action_display_language_badge">Language</string>
+    <string name="action_display_tracker_score_badge">Tracker score</string>
     <string name="action_display_show_tabs">Show category tabs</string>
     <string name="action_display_show_number_of_items">Show number of items</string>
     <string name="action_display_show_continue_reading_button">Continue reading button</string>


### PR DESCRIPTION
## Summary

Adds an optional tracker score badge to library entries.

- Adds a new **Tracker score** option under Library → Display → Overlay.
- Displays the user's locally stored tracker score on library covers.
- Reuses Mihon's existing normalized 10-point tracker score calculation.
- Uses the mean score when an entry is linked to multiple trackers, consistent with tracker score sorting.
- Supports compact grid, comfortable grid, cover-only grid, and list views.
- Does not perform any additional network requests.
- Does not display a badge for untracked or unrated entries.
- The option is disabled by default.

Closes #3568

## Testing

Tested on a Xiaomi Redmi Note 9S.

- [x] Project builds successfully.
- [x] App launches successfully on a physical device.
- [x] Enabling the option displays the tracker score badge.
- [x] Disabling the option immediately hides the badge.
- [x] Untracked and unrated entries do not display a badge.
- [x] Updating a tracker score updates the badge when returning to the library.
- [x] The badge displays correctly with the language badge enabled.
- [x] The badge displays correctly when the language badge is disabled.
- [x] Checked compact grid, comfortable grid, cover-only grid, and list views.
- [x] Performed a self-review of the changes.

## Images

| Tracker score with language badge | Display setting |
| --- | --- |
| ![Library score badge](https://github.com/user-attachments/assets/3e172a12-4271-4b3f-a93e-91d1b8cd0dea) | ![Tracker score setting](https://github.com/user-attachments/assets/ed07bb7b-da2b-4ede-a0c5-8bec039965fc)