### PR TITLE
Fix MangaBaka User-Agent using raw StringResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Fixed app bars remaining visible after changing pages by tapping in the paged reader after using the chapter navigator slider ([@AntsyLich](https://github.com/AntsyLich)) ([#3567](https://github.com/mihonapp/mihon/pull/3567))
+- Fixed MangaBaka User Agent string ([@MajorTanya](https://github.com/MajorTanya)) ([#3578](https://github.com/mihonapp/mihon/pull/3578))
 
 ## [v0.20.1] - 2026-07-09
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaApi.kt
@@ -52,7 +52,7 @@ class MangaBakaApi(
             .header(
                 "User-Agent",
                 buildString {
-                    append("${MR.strings.app_name}/v${BuildConfig.VERSION_NAME} ")
+                    append("Mihon/v${BuildConfig.VERSION_NAME} ")
                     append("(${BuildConfig.APPLICATION_ID} ${BuildConfig.COMMIT_SHA}) ")
                     append("(Android) (https://github.com/mihonapp/mihon)")
                 },


### PR DESCRIPTION
Using the hardcoded app name for the time being until a better solution can be found.

Apparently we've been identifying as

```txt
StringResource(resourceId=2131886239)/v0.20.1-7812 (app.mihon.debug 217b20123) (Android) (https://github.com/mihonapp/mihon)
```