### PR TITLE
Use Private installer to update Private extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Detect Shizuku with permission check ([@Small-Ku](https://github.com/Small-Ku)) ([#3565](https://github.com/mihonapp/mihon/pull/3565))
 
 ### Improved
-- Use Private installer to update privately installed extensions ([@MajorTanya](https://github.com/MajorTanya)) ([#3614](https://github.com/mihonapp/mihon/pull/3614))
+- Always use Private installer to update privately installed extensions ([@MajorTanya](https://github.com/MajorTanya)) ([#3614](https://github.com/mihonapp/mihon/pull/3614))
 
 ### Fixed
 - Fixed app bars remaining visible after changing pages by tapping in the paged reader after using the chapter navigator slider ([@AntsyLich](https://github.com/AntsyLich)) ([#3567](https://github.com/mihonapp/mihon/pull/3567))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Changed
 - Detect Shizuku with permission check ([@Small-Ku](https://github.com/Small-Ku)) ([#3565](https://github.com/mihonapp/mihon/pull/3565))
 
+### Improved
+- Use Private installer to update privately installed extensions ([@MajorTanya](https://github.com/MajorTanya)) ([#3614](https://github.com/mihonapp/mihon/pull/3614))
+
 ### Fixed
 - Fixed app bars remaining visible after changing pages by tapping in the paged reader after using the chapter navigator slider ([@AntsyLich](https://github.com/AntsyLich)) ([#3567](https://github.com/mihonapp/mihon/pull/3567))
 - Fixed MangaBaka User Agent string ([@MajorTanya](https://github.com/MajorTanya)) ([#3578](https://github.com/mihonapp/mihon/pull/3578))

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -240,7 +240,8 @@ class ExtensionManager(
      */
     fun updateExtension(extension: Extension.Installed): Flow<InstallStep> {
         val availableExt = availableExtensionMapFlow.value[extension.pkgName] ?: return emptyFlow()
-        return installExtension(availableExt)
+        val isUpdateForPrivatelyInstalled = !extension.isShared
+        return installer.downloadAndInstall(availableExt.apkUrl, availableExt, isUpdateForPrivatelyInstalled)
     }
 
     fun cancelInstallUpdateExtension(extension: Extension) {

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
@@ -49,8 +49,13 @@ internal class ExtensionInstaller(
      *
      * @param url The url of the apk.
      * @param extension The extension to install.
+     * @param isUpdateForPrivatelyInstalled If this is an update for a privately installed extension
      */
-    fun downloadAndInstall(url: String, extension: Extension): Flow<InstallStep> {
+    fun downloadAndInstall(
+        url: String,
+        extension: Extension,
+        isUpdateForPrivatelyInstalled: Boolean = false,
+    ): Flow<InstallStep> {
         val downloadId = extension.pkgName.hashCode().toLong()
         cancelInstall(extension.pkgName)
 
@@ -74,7 +79,7 @@ internal class ExtensionInstaller(
                 }
 
                 step.value = InstallStep.Installing
-                installApk(downloadId, tmpFile)
+                installApk(downloadId, tmpFile, isUpdateForPrivatelyInstalled)
             } catch (e: Exception) {
                 if (e is InterruptedException) {
                     // Canceled
@@ -99,8 +104,14 @@ internal class ExtensionInstaller(
      * Starts an intent to install the extension at the given uri.
      *
      * @param tempFile The file of the extension to install. Delete after use.
+     * @param isUpdateForPrivatelyInstalled If this install is an update for a privately installed extension
      */
-    private fun installApk(downloadId: Long, tempFile: File) {
+    private fun installApk(downloadId: Long, tempFile: File, isUpdateForPrivatelyInstalled: Boolean = false) {
+        if (isUpdateForPrivatelyInstalled) {
+            installApkPrivately(downloadId, tempFile)
+            return
+        }
+
         when (val installer = extensionInstaller.get()) {
             BasePreferences.ExtensionInstaller.LEGACY -> {
                 val intent = Intent(context, ExtensionInstallActivity::class.java)
@@ -110,20 +121,11 @@ internal class ExtensionInstaller(
 
                 context.startActivity(intent)
             }
-            BasePreferences.ExtensionInstaller.PRIVATE -> {
-                try {
-                    if (ExtensionLoader.installPrivateExtensionFile(context, tempFile)) {
-                        updateInstallStep(downloadId, InstallStep.Installed)
-                    } else {
-                        updateInstallStep(downloadId, InstallStep.Error)
-                    }
-                } catch (e: Exception) {
-                    logcat(LogPriority.ERROR, e) { "Failed to read downloaded extension file." }
-                    updateInstallStep(downloadId, InstallStep.Error)
-                }
 
-                tempFile.delete()
+            BasePreferences.ExtensionInstaller.PRIVATE -> {
+                installApkPrivately(downloadId, tempFile)
             }
+
             else -> {
                 val intent = ExtensionInstallService.getIntent(
                     context,
@@ -134,6 +136,21 @@ internal class ExtensionInstaller(
                 ContextCompat.startForegroundService(context, intent)
             }
         }
+    }
+
+    private fun installApkPrivately(downloadId: Long, tempFile: File) {
+        try {
+            if (ExtensionLoader.installPrivateExtensionFile(context, tempFile)) {
+                updateInstallStep(downloadId, InstallStep.Installed)
+            } else {
+                updateInstallStep(downloadId, InstallStep.Error)
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to read downloaded extension file." }
+            updateInstallStep(downloadId, InstallStep.Error)
+        }
+
+        tempFile.delete()
     }
 
     /**


### PR DESCRIPTION
Closes #3613.

This forces the Private installer for any extension which was installed privately, bypassing whichever setting the user selected in Settings > Advanced > Installer.

Demo:

[demo.webm](https://github.com/user-attachments/assets/df298956-1f0c-4c0e-872f-463347baa3d9)

Shows:
1. PackageInstaller is selected
2. PackageInstaller is used to install something non-privately (Kavita)
3. Also used to uninstall Kavita non-privately
4. Private installer is used to update the privately installed DummyExtension in-place
5. Proof that Kavita is still installed normally and the setting is respected for new installs.