### PR TITLE
Fix incorrect progress when resuming downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 - Support resumable image downloads if supported by source ([@xMohnad](https://github.com/xMohnad)) ([#3167](https://github.com/mihonapp/mihon/pull/3167))
   - Fix HTTP Error 416 not being handled properly ([@AntsyLich](https://github.com/AntsyLich)) ([#3563](https://github.com/mihonapp/mihon/pull/3563))
+  - Fix incorrect progress when resuming downloads ([@xMohnad](https://github.com/xMohnad)) ([#3616](https://github.com/mihonapp/mihon/pull/3616))
 
 ### Changed
 - Detect Shizuku with permission check ([@Small-Ku](https://github.com/Small-Ku)) ([#3565](https://github.com/mihonapp/mihon/pull/3565))

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -136,8 +136,9 @@ fun OkHttpClient.newCachelessCallWithProgress(
                 .build()
 
             val originalResponse = chain.proceed(request)
+            val actualExistingSize = if (originalResponse.code == 206) existingSize else 0L
             originalResponse.newBuilder()
-                .body(ProgressResponseBody(originalResponse.body, listener, existingSize))
+                .body(ProgressResponseBody(originalResponse.body, listener, actualExistingSize))
                 .build()
         }
         .build()

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/ProgressResponseBody.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/ProgressResponseBody.kt
@@ -40,9 +40,15 @@ class ProgressResponseBody(
                 val bytesRead = super.read(sink, byteCount)
                 // read() returns the number of bytes read, or -1 if this source is exhausted.
                 totalBytesRead += if (bytesRead != -1L) bytesRead else 0
+
+                // contentLength() returns -1L if Content-Length is missing
+                val totalLength = responseBody.contentLength().let {
+                    if (it != -1L) it + existingSize else -1L
+                }
+
                 progressListener.update(
                     totalBytesRead,
-                    responseBody.contentLength(),
+                    totalLength,
                     bytesRead == -1L,
                 )
                 return bytesRead


### PR DESCRIPTION
When resuming a partially downloaded file, the progress calculation was incorrect.

This happened because:
- `contentLength()` returns only the remaining bytes for HTTP 206 responses, not the total file size. As a result, `totalBytesRead` (which already includes `existingSize`) was being divided by only the remaining size.
- `existingSize` was always added to the total, even in cases where the server ignored the Range request and returned a full `200 OK` response instead of `206 Partial Content`.
