### PR TITLE
Show clock and battery in the fullscreen reader

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -107,6 +107,12 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = readerPreferences.showPageNumber,
                     title = stringResource(MR.strings.pref_show_page_number),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.showStatusBar,
+                    title = stringResource(MR.strings.pref_show_status_bar),
+                    subtitle = stringResource(MR.strings.pref_show_status_bar_summary),
+                    enabled = fullscreen,
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -108,9 +108,15 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_show_page_number),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.showStatusBar,
-                    title = stringResource(MR.strings.pref_show_status_bar),
-                    subtitle = stringResource(MR.strings.pref_show_status_bar_summary),
+                    preference = readerPreferences.showClock,
+                    title = stringResource(MR.strings.pref_show_clock),
+                    subtitle = stringResource(MR.strings.pref_show_clock_summary),
+                    enabled = fullscreen,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.showBattery,
+                    title = stringResource(MR.strings.pref_show_battery),
+                    subtitle = stringResource(MR.strings.pref_show_battery_summary),
                     enabled = fullscreen,
                 ),
             ),

--- a/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
@@ -1,0 +1,288 @@
+package eu.kanade.presentation.reader
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.PowerManager
+import android.text.format.DateFormat
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.displayCutoutPadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
+import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import java.util.Date
+
+private const val LOW_BATTERY_THRESHOLD = 40
+private const val CRITICAL_BATTERY_THRESHOLD = 10
+
+private val normalBatteryColor = Color(0xFF4CAF50)
+private val warnBatteryColor = Color(0xFFFFC107)
+private val criticalBatteryColor = Color(0xFFFF5252)
+private val powerSaveColor = Color(0xFF00C853)
+
+private data class BatteryUiState(
+    val percentage: Int = 100,
+    val isCharging: Boolean = false,
+    val isPowerSaveMode: Boolean = false,
+)
+
+/**
+ * Overlay shown at the top of the reader while it's in immersive fullscreen (system status bar
+ * hidden), so the clock and battery level remain visible while reading.
+ */
+@Composable
+fun ReaderImmersiveStatusBar(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (!visible) return
+
+    val context = LocalContext.current
+    val time by rememberCurrentTime(context)
+    val battery by rememberBatteryState(context)
+
+    val batteryColor = when {
+        battery.percentage < CRITICAL_BATTERY_THRESHOLD -> criticalBatteryColor
+        battery.percentage < LOW_BATTERY_THRESHOLD -> warnBatteryColor
+        else -> normalBatteryColor
+    }
+    val isCritical = battery.percentage < CRITICAL_BATTERY_THRESHOLD
+
+    val textStyle = TextStyle(
+        color = Color.White,
+        fontSize = MaterialTheme.typography.labelMedium.fontSize,
+        fontWeight = FontWeight.SemiBold,
+        shadow = Shadow(color = Color.Black.copy(alpha = 0.7f), blurRadius = 6f),
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .displayCutoutPadding()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(text = time, style = textStyle)
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            if (battery.isPowerSaveMode) {
+                PowerSaveGlyph()
+            }
+            Text(text = "${battery.percentage}%", style = textStyle)
+            BatteryGlyph(
+                percentage = battery.percentage,
+                isCharging = battery.isCharging,
+                blink = isCritical,
+                color = batteryColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun rememberCurrentTime(context: Context) = run {
+    val timeState = remember { mutableStateOf(formatCurrentTime(context)) }
+    DisposableEffect(context) {
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_TIME_TICK)
+            addAction(Intent.ACTION_TIME_CHANGED)
+            addAction(Intent.ACTION_TIMEZONE_CHANGED)
+        }
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(receiverContext: Context, intent: Intent) {
+                timeState.value = formatCurrentTime(context)
+            }
+        }
+        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        onDispose { context.unregisterReceiver(receiver) }
+    }
+    timeState
+}
+
+private fun formatCurrentTime(context: Context): String {
+    return DateFormat.getTimeFormat(context).format(Date())
+}
+
+@Composable
+private fun rememberBatteryState(context: Context) = run {
+    val batteryState = remember { mutableStateOf(readBatteryState(context)) }
+    DisposableEffect(context) {
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_BATTERY_CHANGED)
+            addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+        }
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(receiverContext: Context, intent: Intent) {
+                val sticky = intent.takeIf { it.action == Intent.ACTION_BATTERY_CHANGED }
+                batteryState.value = readBatteryState(context, sticky)
+            }
+        }
+        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        onDispose { context.unregisterReceiver(receiver) }
+    }
+    batteryState
+}
+
+private fun readBatteryState(context: Context, stickyIntent: Intent? = null): BatteryUiState {
+    val intent = stickyIntent
+        ?: context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+    val level = intent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+    val scale = intent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+    val percentage = if (level >= 0 && scale > 0) (level * 100 / scale) else 100
+    val status = intent?.getIntExtra(BatteryManager.EXTRA_STATUS, -1) ?: -1
+    val isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+        status == BatteryManager.BATTERY_STATUS_FULL
+    val isPowerSaveMode = context.getSystemService<PowerManager>()?.isPowerSaveMode == true
+    return BatteryUiState(percentage = percentage, isCharging = isCharging, isPowerSaveMode = isPowerSaveMode)
+}
+
+@Composable
+private fun BatteryGlyph(
+    percentage: Int,
+    isCharging: Boolean,
+    blink: Boolean,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "battery_blink")
+    val blinkAlpha by if (blink) {
+        infiniteTransition.animateFloat(
+            initialValue = 1f,
+            targetValue = 0.25f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(600, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "battery_blink_alpha",
+        )
+    } else {
+        remember { mutableFloatStateOf(1f) }
+    }
+
+    Canvas(
+        modifier = modifier
+            .size(width = 22.dp, height = 11.dp)
+            .alpha(blinkAlpha),
+    ) {
+        val strokeWidth = 1.5.dp.toPx()
+        val nubWidth = size.height * 0.28f
+        val bodyWidth = size.width - nubWidth
+        val cornerRadius = CornerRadius(size.height * 0.2f, size.height * 0.2f)
+
+        drawRoundRect(
+            color = Color.White,
+            topLeft = Offset.Zero,
+            size = Size(bodyWidth, size.height),
+            cornerRadius = cornerRadius,
+            style = Stroke(width = strokeWidth),
+        )
+
+        val nubHeight = size.height * 0.5f
+        drawRoundRect(
+            color = Color.White,
+            topLeft = Offset(bodyWidth, (size.height - nubHeight) / 2f),
+            size = Size(nubWidth, nubHeight),
+            cornerRadius = CornerRadius(cornerRadius.x / 2, cornerRadius.y / 2),
+        )
+
+        val inset = strokeWidth * 1.5f
+        val fillMaxWidth = bodyWidth - inset * 2
+        val fillWidth = (fillMaxWidth * (percentage.coerceIn(0, 100) / 100f)).coerceAtLeast(0f)
+        if (fillWidth > 0f) {
+            drawRoundRect(
+                color = color,
+                topLeft = Offset(inset, inset),
+                size = Size(fillWidth, size.height - inset * 2),
+                cornerRadius = CornerRadius(cornerRadius.x / 2, cornerRadius.y / 2),
+            )
+        }
+
+        if (isCharging) {
+            val bolt = Path().apply {
+                moveTo(bodyWidth * 0.55f, size.height * 0.05f)
+                lineTo(bodyWidth * 0.30f, size.height * 0.58f)
+                lineTo(bodyWidth * 0.48f, size.height * 0.58f)
+                lineTo(bodyWidth * 0.40f, size.height * 0.95f)
+                lineTo(bodyWidth * 0.68f, size.height * 0.38f)
+                lineTo(bodyWidth * 0.50f, size.height * 0.38f)
+                close()
+            }
+            drawPath(bolt, color = Color.Black.copy(alpha = 0.75f))
+        }
+    }
+}
+
+@Composable
+private fun PowerSaveGlyph(modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier.size(12.dp)) {
+        val leaf = Path().apply {
+            moveTo(size.width * 0.8f, 0f)
+            cubicTo(
+                size.width * 0.2f, size.height * 0.1f,
+                0f, size.height * 0.6f,
+                size.width * 0.5f, size.height,
+            )
+            cubicTo(
+                size.width, size.height * 0.6f,
+                size.width * 0.85f, size.height * 0.15f,
+                size.width * 0.8f, 0f,
+            )
+            close()
+        }
+        drawPath(leaf, color = powerSaveColor)
+        drawLine(
+            color = Color.Black.copy(alpha = 0.4f),
+            start = Offset(size.width * 0.15f, size.height * 0.85f),
+            end = Offset(size.width * 0.75f, size.height * 0.15f),
+            strokeWidth = 1.dp.toPx(),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ReaderImmersiveStatusBarPreview() {
+    TachiyomiPreviewTheme {
+        ReaderImmersiveStatusBar(visible = true)
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.displayCutoutPadding
@@ -37,9 +38,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -82,7 +84,6 @@ fun ReaderImmersiveStatusBar(
         color = Color.White,
         fontSize = MaterialTheme.typography.labelMedium.fontSize,
         fontWeight = FontWeight.SemiBold,
-        shadow = Shadow(color = Color.Black.copy(alpha = 0.7f), blurRadius = 6f),
     )
 
     Row(
@@ -95,7 +96,7 @@ fun ReaderImmersiveStatusBar(
     ) {
         if (showClock) {
             val time by rememberCurrentTime(context)
-            Text(text = time, style = textStyle)
+            OutlinedText(text = time, style = textStyle)
         } else {
             Spacer(modifier = Modifier)
         }
@@ -116,7 +117,7 @@ fun ReaderImmersiveStatusBar(
                 if (battery.isPowerSaveMode) {
                     PowerSaveGlyph()
                 }
-                Text(text = "${battery.percentage}%", style = textStyle)
+                OutlinedText(text = "${battery.percentage}%", style = textStyle)
                 BatteryGlyph(
                     percentage = battery.percentage,
                     isCharging = battery.isCharging,
@@ -125,6 +126,26 @@ fun ReaderImmersiveStatusBar(
                 )
             }
         }
+    }
+}
+
+/**
+ * Text with a hairline outline in the inverse of [style]'s color, so it stays legible over any
+ * page background (white, black, or busy artwork) without needing a heavy stroke or blur.
+ */
+@Composable
+private fun OutlinedText(text: String, style: TextStyle, modifier: Modifier = Modifier) {
+    val outlineWidthPx = with(LocalDensity.current) { 0.5.dp.toPx() }
+    val outlineColor = if (style.color.luminance() > 0.5f) Color.Black else Color.White
+    Box(modifier = modifier) {
+        Text(
+            text = text,
+            style = style.copy(
+                color = outlineColor,
+                drawStyle = Stroke(width = outlineWidthPx),
+            ),
+        )
+        Text(text = text, style = style)
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReaderImmersiveStatusBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -69,20 +70,13 @@ private data class BatteryUiState(
 @Composable
 fun ReaderImmersiveStatusBar(
     visible: Boolean,
+    showClock: Boolean,
+    showBattery: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    if (!visible) return
+    if (!visible || (!showClock && !showBattery)) return
 
     val context = LocalContext.current
-    val time by rememberCurrentTime(context)
-    val battery by rememberBatteryState(context)
-
-    val batteryColor = when {
-        battery.percentage < CRITICAL_BATTERY_THRESHOLD -> criticalBatteryColor
-        battery.percentage < LOW_BATTERY_THRESHOLD -> warnBatteryColor
-        else -> normalBatteryColor
-    }
-    val isCritical = battery.percentage < CRITICAL_BATTERY_THRESHOLD
 
     val textStyle = TextStyle(
         color = Color.White,
@@ -99,22 +93,37 @@ fun ReaderImmersiveStatusBar(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = time, style = textStyle)
+        if (showClock) {
+            val time by rememberCurrentTime(context)
+            Text(text = time, style = textStyle)
+        } else {
+            Spacer(modifier = Modifier)
+        }
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            if (battery.isPowerSaveMode) {
-                PowerSaveGlyph()
+        if (showBattery) {
+            val battery by rememberBatteryState(context)
+            val batteryColor = when {
+                battery.percentage < CRITICAL_BATTERY_THRESHOLD -> criticalBatteryColor
+                battery.percentage < LOW_BATTERY_THRESHOLD -> warnBatteryColor
+                else -> normalBatteryColor
             }
-            Text(text = "${battery.percentage}%", style = textStyle)
-            BatteryGlyph(
-                percentage = battery.percentage,
-                isCharging = battery.isCharging,
-                blink = isCritical,
-                color = batteryColor,
-            )
+            val isCritical = battery.percentage < CRITICAL_BATTERY_THRESHOLD
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (battery.isPowerSaveMode) {
+                    PowerSaveGlyph()
+                }
+                Text(text = "${battery.percentage}%", style = textStyle)
+                BatteryGlyph(
+                    percentage = battery.percentage,
+                    isCharging = battery.isCharging,
+                    blink = isCritical,
+                    color = batteryColor,
+                )
+            }
         }
     }
 }
@@ -283,6 +292,6 @@ private fun PowerSaveGlyph(modifier: Modifier = Modifier) {
 @Composable
 private fun ReaderImmersiveStatusBarPreview() {
     TachiyomiPreviewTheme {
-        ReaderImmersiveStatusBar(visible = true)
+        ReaderImmersiveStatusBar(visible = true, showClock = true, showBattery = true)
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -63,8 +63,13 @@ internal fun ColumnScope.GeneralPage(viewModel: ReaderSettingsViewModel) {
     )
 
     CheckboxItem(
-        label = stringResource(MR.strings.pref_show_status_bar),
-        pref = viewModel.preferences.showStatusBar,
+        label = stringResource(MR.strings.pref_show_clock),
+        pref = viewModel.preferences.showClock,
+    )
+
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_show_battery),
+        pref = viewModel.preferences.showBattery,
     )
 
     val verticalNavigatorModes by viewModel.preferences.verticalNavigator.collectAsState()

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -62,6 +62,11 @@ internal fun ColumnScope.GeneralPage(viewModel: ReaderSettingsViewModel) {
         pref = viewModel.preferences.showPageNumber,
     )
 
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_show_status_bar),
+        pref = viewModel.preferences.showStatusBar,
+    )
+
     val verticalNavigatorModes by viewModel.preferences.verticalNavigator.collectAsState()
 
     SettingsChipRow(MR.strings.pref_vertical_navigator) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -253,7 +253,8 @@ class ReaderActivity : BaseActivity() {
     private fun ReaderActivityBinding.setComposeOverlay(): Unit = composeOverlay.setComposeContent {
         val state by viewModel.state.collectAsState()
         val showPageNumber by readerPreferences.showPageNumber.collectAsState()
-        val showStatusBar by readerPreferences.showStatusBar.collectAsState()
+        val showClock by readerPreferences.showClock.collectAsState()
+        val showBattery by readerPreferences.showBattery.collectAsState()
         val fullscreen by readerPreferences.fullscreen.collectAsState()
         val settingsviewModel = remember {
             ReaderSettingsViewModel(
@@ -275,7 +276,9 @@ class ReaderActivity : BaseActivity() {
             }
 
             ReaderImmersiveStatusBar(
-                visible = fullscreen && !state.menuVisible && showStatusBar,
+                visible = fullscreen && !state.menuVisible,
+                showClock = showClock,
+                showBattery = showBattery,
                 modifier = Modifier.align(Alignment.TopCenter),
             )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -30,9 +30,12 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -40,6 +43,7 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
 import androidx.core.net.toUri
 import androidx.core.transition.doOnEnd
+import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -256,6 +260,17 @@ class ReaderActivity : BaseActivity() {
         val showClock by readerPreferences.showClock.collectAsState()
         val showBattery by readerPreferences.showBattery.collectAsState()
         val fullscreen by readerPreferences.fullscreen.collectAsState()
+        var systemStatusBarVisible by remember { mutableStateOf(false) }
+        DisposableEffect(Unit) {
+            val listener = OnApplyWindowInsetsListener { _, windowInsets ->
+                systemStatusBarVisible = windowInsets.isVisible(WindowInsetsCompat.Type.statusBars())
+                windowInsets
+            }
+            ViewCompat.setOnApplyWindowInsetsListener(window.decorView, listener)
+            onDispose {
+                ViewCompat.setOnApplyWindowInsetsListener(window.decorView, null)
+            }
+        }
         val settingsviewModel = remember {
             ReaderSettingsViewModel(
                 readerState = viewModel.state,
@@ -276,7 +291,7 @@ class ReaderActivity : BaseActivity() {
             }
 
             ReaderImmersiveStatusBar(
-                visible = fullscreen && !state.menuVisible,
+                visible = fullscreen && !state.menuVisible && !systemStatusBarVisible,
                 showClock = showClock,
                 showBattery = showBattery,
                 modifier = Modifier.align(Alignment.TopCenter),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -52,6 +52,7 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.reader.DisplayRefreshHost
 import eu.kanade.presentation.reader.OrientationSelectDialog
 import eu.kanade.presentation.reader.ReaderContentOverlay
+import eu.kanade.presentation.reader.ReaderImmersiveStatusBar
 import eu.kanade.presentation.reader.ReaderPageActionsDialog
 import eu.kanade.presentation.reader.ReaderPageIndicator
 import eu.kanade.presentation.reader.ReadingModeSelectDialog
@@ -252,6 +253,8 @@ class ReaderActivity : BaseActivity() {
     private fun ReaderActivityBinding.setComposeOverlay(): Unit = composeOverlay.setComposeContent {
         val state by viewModel.state.collectAsState()
         val showPageNumber by readerPreferences.showPageNumber.collectAsState()
+        val showStatusBar by readerPreferences.showStatusBar.collectAsState()
+        val fullscreen by readerPreferences.fullscreen.collectAsState()
         val settingsviewModel = remember {
             ReaderSettingsViewModel(
                 readerState = viewModel.state,
@@ -270,6 +273,11 @@ class ReaderActivity : BaseActivity() {
                         .navigationBarsPadding(),
                 )
             }
+
+            ReaderImmersiveStatusBar(
+                visible = fullscreen && !state.menuVisible && showStatusBar,
+                modifier = Modifier.align(Alignment.TopCenter),
+            )
 
             ContentOverlay(state = state)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -29,7 +29,9 @@ class ReaderPreferences(
 
     val showPageNumber: Preference<Boolean> = preferenceStore.getBoolean("pref_show_page_number_key", true)
 
-    val showStatusBar: Preference<Boolean> = preferenceStore.getBoolean("pref_show_status_bar_key", true)
+    val showClock: Preference<Boolean> = preferenceStore.getBoolean("pref_show_clock_key", true)
+
+    val showBattery: Preference<Boolean> = preferenceStore.getBoolean("pref_show_battery_key", true)
 
     val verticalNavigator: Preference<Set<ReadingMode>> = preferenceStore.getEnumSet(
         "pref_vertical_navigator",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -29,6 +29,8 @@ class ReaderPreferences(
 
     val showPageNumber: Preference<Boolean> = preferenceStore.getBoolean("pref_show_page_number_key", true)
 
+    val showStatusBar: Preference<Boolean> = preferenceStore.getBoolean("pref_show_status_bar_key", true)
+
     val verticalNavigator: Preference<Set<ReadingMode>> = preferenceStore.getEnumSet(
         "pref_vertical_navigator",
         emptySet(),

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -400,6 +400,8 @@
     <string name="pref_flash_style_white_black">White and Black</string>
     <string name="pref_double_tap_anim_speed">Double tap animation speed</string>
     <string name="pref_show_page_number">Show page number</string>
+    <string name="pref_show_status_bar">Show clock and battery</string>
+    <string name="pref_show_status_bar_summary">Overlay the time and battery level while reading in fullscreen</string>
     <string name="pref_vertical_navigator">Use vertical chapter navigator in</string>
     <string name="pref_vertical_navigator_height">Vertical navigator height</string>
     <string name="pref_webtoon_vertical_navigator_on_left">Place vertical navigator on the left side</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -400,8 +400,10 @@
     <string name="pref_flash_style_white_black">White and Black</string>
     <string name="pref_double_tap_anim_speed">Double tap animation speed</string>
     <string name="pref_show_page_number">Show page number</string>
-    <string name="pref_show_status_bar">Show clock and battery</string>
-    <string name="pref_show_status_bar_summary">Overlay the time and battery level while reading in fullscreen</string>
+    <string name="pref_show_clock">Show clock</string>
+    <string name="pref_show_clock_summary">Overlay the time while reading in fullscreen</string>
+    <string name="pref_show_battery">Show battery</string>
+    <string name="pref_show_battery_summary">Overlay the battery level while reading in fullscreen</string>
     <string name="pref_vertical_navigator">Use vertical chapter navigator in</string>
     <string name="pref_vertical_navigator_height">Vertical navigator height</string>
     <string name="pref_webtoon_vertical_navigator_on_left">Place vertical navigator on the left side</string>


### PR DESCRIPTION
## Why

Reading in fullscreen hides the system status bar, so there's currently no way to check the time or battery level without leaving the reader. This adds a lightweight overlay — similar to the notification panel status bar — that shows the time and battery while reading in fullscreen.

## What's included

- Battery indicator changes color with charge level: green (normal), yellow (under 40%), red and blinking (under 10%)
- Shows a charging bolt when plugged in, and a small battery-saver badge when power saving mode is active
- Clock and battery text have a thin (0.5dp) hairline outline in the inverse of the text color, so they stay legible over any page background — white, black, or full-color art
- The overlay hides automatically whenever the real system status bar becomes visible, including the transient peek from swiping down from the top edge, so it never overlaps the notification shade
- "Show clock" and "Show battery" are separate, independently toggleable preferences (default on), available in both Settings > Reader > Display and the in-reader quick settings sheet

## Test plan

- [x] Built and installed a debug build on a physical device
- [x] Verified the overlay appears only when fullscreen and the menu is hidden, and disappears when the menu or real status bar is shown
- [x] Verified the two toggles are independent: turning off "Show battery" leaves only the clock, and vice versa
- [x] Verified outline legibility against a bright, busy manga panel
- [x] Verified the overlay hides during the swipe-down status bar peek and reappears after

-Mithun Hasan