### PR TITLE
Add optional webtoon fling tap suppression setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
     defaultConfig {
         applicationId = "app.mihon"
 
-        versionCode = 26
-        versionName = "0.20.1"
+        versionCode = 27
+        versionName = "0.20.2"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -199,6 +199,10 @@ private fun ColumnScope.WebtoonViewerSettings(viewModel: ReaderSettingsViewModel
         pref = viewModel.preferences.webtoonDoubleTapZoomEnabled,
     )
     CheckboxItem(
+        label = stringResource(MR.strings.pref_webtoon_suppress_tap_on_fling),
+        pref = viewModel.preferences.webtoonSuppressTapOnFling,
+    )
+    CheckboxItem(
         label = stringResource(MR.strings.pref_webtoon_disable_zoom_out),
         pref = viewModel.preferences.webtoonDisableZoomOut,
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -103,6 +103,11 @@ class ReaderPreferences(
 
     val webtoonDisableZoomOut: Preference<Boolean> = preferenceStore.getBoolean("webtoon_disable_zoom_out", false)
 
+    val webtoonSuppressTapOnFling: Preference<Boolean> = preferenceStore.getBoolean(
+        "webtoon_suppress_tap_on_fling",
+        false,
+    )
+
     // endregion
 
     // region Split two-page spread

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -40,6 +40,11 @@ class WebtoonConfig(
     var doubleTapZoom = true
         private set
 
+    var suppressTapOnFling = false
+        private set
+
+    var suppressTapOnFlingChangedListener: ((Boolean) -> Unit)? = null
+
     var doubleTapZoomChangedListener: ((Boolean) -> Unit)? = null
 
     val theme = readerPreferences.readerTheme.get()
@@ -83,6 +88,12 @@ class WebtoonConfig(
             .register(
                 { zoomOutDisabled = it },
                 { zoomPropertyChangedListener?.invoke(it) },
+            )
+
+        readerPreferences.webtoonSuppressTapOnFling
+            .register(
+                { suppressTapOnFling = it },
+                { suppressTapOnFlingChangedListener?.invoke(it) },
             )
 
         readerPreferences.webtoonDoubleTapZoomEnabled

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
@@ -103,7 +103,6 @@ class WebtoonFrame(context: Context) : FrameLayout(context) {
             velocityX: Float,
             velocityY: Float,
         ): Boolean {
-            recycler?.onManualScroll()
             return recycler?.zoomFling(velocityX.toInt(), velocityY.toInt()) ?: false
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
@@ -92,6 +92,8 @@ class WebtoonFrame(context: Context) : FrameLayout(context) {
     /**
      * Fling listener used to delegate events to the recycler view.
      */
+    var suppressTapOnFling = false
+
     inner class FlingListener : GestureDetector.SimpleOnGestureListener() {
         override fun onDown(e: MotionEvent): Boolean {
             return true
@@ -103,6 +105,9 @@ class WebtoonFrame(context: Context) : FrameLayout(context) {
             velocityX: Float,
             velocityY: Float,
         ): Boolean {
+            if (suppressTapOnFling) {
+                recycler?.onManualScroll()
+            }
             return recycler?.zoomFling(velocityX.toInt(), velocityY.toInt()) ?: false
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -157,6 +157,12 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
             frame.zoomOutDisabled = it
         }
 
+        config.suppressTapOnFlingChangedListener = {
+            frame.suppressTapOnFling = it
+        }
+
+        frame.suppressTapOnFling = config.suppressTapOnFling
+
         config.navigationModeChangedListener = {
             val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
             activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -494,6 +494,7 @@
     <string name="pref_category_reading_mode">Reading mode</string>
     <string name="pref_category_reading">Reading</string>
     <string name="pref_webtoon_side_padding">Side padding</string>
+    <string name="pref_webtoon_suppress_tap_on_fling">Suppress tap zones after fling</string>
     <string name="pref_hide_threshold">Sensitivity for hiding menu on scroll</string>
     <string name="pref_highest">Highest</string>
     <string name="pref_high">High</string>


### PR DESCRIPTION
This PR adds a new webtoon reader setting to suppress tap zone actions after a fling. The regression was introduced in `v0.19.4` when `WebtoonFrame` began marking flings as manual scrolls, which changed tap behavior after scrolling and made taps behave differently than before.

This option keeps the old tap-zone behavior available for users who prefer it while still allowing the newer fling-suppression mode for those who want it. The preference is stored under `webtoon_suppress_tap_on_fling`, and `WebtoonFrame` only calls `WebtoonRecyclerView.onManualScroll()` when this option is enabled.