### PR TITLE
Fix tap navigation staying off after a cancelled button press

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderButton.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderButton.kt
@@ -21,7 +21,7 @@ class ReaderButton @JvmOverloads constructor(
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         viewer?.pager?.setGestureDetectorEnabled(false)
-        if (event.actionMasked == MotionEvent.ACTION_UP) {
+        if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
             viewer?.pager?.setGestureDetectorEnabled(true)
         }
         return super.onTouchEvent(event)


### PR DESCRIPTION
Touching a button in the reader turns the pager's gesture detector off for the duration of the press, and back on when the touch ends. It only turned it back on for `ACTION_UP`, so a touch that ended in `ACTION_CANCEL` left tap navigation switched off. It stays off until some later button press happens to end cleanly.

In the paged reader, press and hold one of the reader's buttons, drag away from it, then release. Tapping a navigation region afterwards does nothing.