### PR TITLE
Fix backup restore dropping library entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fixed app bars remaining visible after changing pages by tapping in the paged reader after using the chapter navigator slider ([@AntsyLich](https://github.com/AntsyLich)) ([#3567](https://github.com/mihonapp/mihon/pull/3567))
 - Fixed MangaBaka User Agent string ([@MajorTanya](https://github.com/MajorTanya)) ([#3578](https://github.com/mihonapp/mihon/pull/3578))
 - Fixed extension installation with shizuku installer ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#3630](https://github.com/mihonapp/mihon/pull/3630))
+- Fixed backup restore dropping library entries when the backup contains duplicate chapters ([@na-ji](https://github.com/na-ji)) ([#3667](https://github.com/mihonapp/mihon/pull/3667))
 
 ## [v0.20.1] - 2026-07-09
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -148,13 +148,30 @@ class BackupRestorer(
         mangaRestorer.sortByNew(backupMangas)
             .chunked(100)
             .forEach { chunk ->
-                database.transaction {
+                val restoredAsBatch = try {
+                    database.transaction {
+                        chunk.forEach {
+                            ensureActive()
+                            mangaRestorer.restore(it, backupCategories)
+                        }
+                    }
+                    true
+                } catch (e: Exception) {
+                    ensureActive()
+                    logcat(LogPriority.WARN, e) { "Batch restore failed, retrying entry by entry" }
+                    false
+                }
+
+                if (restoredAsBatch) {
+                    restoreProgress.addAndFetch(chunk.size)
+                } else {
                     chunk.forEach {
                         ensureActive()
 
                         try {
                             mangaRestorer.restore(it, backupCategories)
                         } catch (e: Exception) {
+                            ensureActive()
                             val sourceName = sourceMapping[it.source] ?: it.source.toString()
                             errors.add(Date() to "${it.title} [$sourceName]: ${e.message}")
                         }
@@ -162,6 +179,7 @@ class BackupRestorer(
                         restoreProgress.incrementAndFetch()
                     }
                 }
+
                 notifier.showRestoreProgress(chunk.last().title, restoreProgress.load(), restoreAmount, isSync)
             }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -284,7 +284,7 @@ class MangaRestorer(
         restoreCategories(manga, categories, backupCategories)
         restoreChapters(manga, chapters)
         restoreTracking(manga, tracks)
-        restoreHistory(history)
+        restoreHistory(manga, history)
         restoreExcludedScanlators(manga, excludedScanlators)
         updateManga.awaitUpdateFetchInterval(manga, now, currentFetchWindow)
         return manga
@@ -324,16 +324,16 @@ class MangaRestorer(
         }
     }
 
-    private suspend fun restoreHistory(backupHistory: List<BackupHistory>) {
+    private suspend fun restoreHistory(manga: Manga, backupHistory: List<BackupHistory>) {
         val toUpdate = backupHistory.mapNotNull { history ->
             val dbHistory = database.historyQueries
-                .getHistoryByChapterUrl(history.url)
+                .getHistoryByChapterUrlAndMangaId(history.url, manga.id)
                 .awaitAsOneOrNull()
             val item = history.getHistoryImpl()
 
             if (dbHistory == null) {
                 val chapter = database.chaptersQueries
-                    .getChapterByUrl(history.url)
+                    .getChapterByUrlAndMangaId(history.url, manga.id)
                     .awaitAsOneOrNull()
                 return@mapNotNull if (chapter == null) {
                     // Chapter doesn't exist; skip

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -88,7 +88,8 @@ getChapterByUrlAndMangaId:
 SELECT *
 FROM chapters
 WHERE url = :chapterUrl
-AND manga_id = :mangaId;
+AND manga_id = :mangaId
+LIMIT 1;
 
 removeChaptersWithIds:
 DELETE FROM chapters

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -23,7 +23,7 @@ JOIN chapters C
 ON H.chapter_id = C._id
 WHERE C.manga_id = :mangaId AND C._id = H.chapter_id;
 
-getHistoryByChapterUrl:
+getHistoryByChapterUrlAndMangaId:
 SELECT
 H._id,
 H.chapter_id,
@@ -32,7 +32,8 @@ H.time_read
 FROM history H
 JOIN chapters C
 ON H.chapter_id = C._id
-WHERE C.url = :chapterUrl AND C._id = H.chapter_id;
+WHERE C.url = :chapterUrl AND C.manga_id = :mangaId AND C._id = H.chapter_id
+LIMIT 1;
 
 resetHistoryById:
 UPDATE history


### PR DESCRIPTION
Restoring a backup silently discarded most of the library. 123 entries → 23 rows, 2 in library.

Two causes:

**Unscoped chapter lookup.** `restoreHistory` resolved chapters by URL alone (`chapters.sq:getChapterByUrl`, `history.sq:getHistoryByChapterUrl`). A backup holding the same entry twice under one source matches multiple chapter rows, so `awaitAsOneOrNull()` throws `ResultSet returned more than 1 row`. Same error as #120, which was closed pointing at #647. Now scoped to the entry, with `LIMIT 1` so a duplicate can't crash restore again. This doesn't fix the duplication issue, but prevent the backup restore from crashing. 

**A failed entry rolled back 99 good ones.** Entries restore in chunks of 100 sharing one transaction (#3267). SQLDelight fails the enclosing transaction when a nested one fails, so the per-entry `try`/`catch` never contained the failure and the whole chunk rolled back. Only chunks with zero failures survived. The batched fast path is kept; on failure the chunk is retried entry by entry so only the bad entries are lost.

Verified on device, clean install, full restore of a 123-entry backup:

| | backup | before | after |
| --- | --- | --- | --- |
| entries | 123 | 23 | 123 |
| favorites | 86 | 2 | 86 |
| chapters | 21880 | 2756 | 21880 |
| history | 13773 | 1596 | 13773 |

Refs #647, but doesn't close it. The underlying issue of duplicate entries is not fixed. But since it's already in production, we need to work around it in the backup restore path. 

I can split the two changes if wanted.