### PR TITLE
feat: Added import option for local source

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceToolbar.kt
@@ -2,6 +2,7 @@ package eu.kanade.presentation.browse.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
+import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.ViewModule
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -34,6 +35,7 @@ fun BrowseSourceToolbar(
     onWebViewClick: () -> Unit,
     onHelpClick: () -> Unit,
     onSettingsClick: () -> Unit,
+    onImportClick: () -> Unit,
     onSearch: (String) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
@@ -66,6 +68,13 @@ fun BrowseSourceToolbar(
                         ),
                     )
                     if (isLocalSource) {
+                        add(
+                            AppBar.Action(
+                                title = stringResource(MR.strings.action_import_from_storage),
+                                icon = Icons.Filled.FileOpen,
+                                onClick = onImportClick,
+                            ),
+                        )
                         add(
                             AppBar.OverflowAction(
                                 title = stringResource(MR.strings.label_help),

--- a/app/src/main/java/eu/kanade/presentation/browse/components/LocalSourceImportDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/LocalSourceImportDialog.kt
@@ -1,0 +1,63 @@
+package eu.kanade.presentation.browse.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun LocalSourceImportDialog(
+    onDismissRequest: () -> Unit,
+    onImport: (String) -> Unit,
+    initialName: String = "",
+) {
+    var name by remember { mutableStateOf(initialName) }
+    val focusRequester = remember { FocusRequester() }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank(),
+                onClick = {
+                    onImport(name)
+                    onDismissRequest()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        title = {
+            Text(text = stringResource(MR.strings.import_local_source_title))
+        },
+        text = {
+            OutlinedTextField(
+                modifier = Modifier.focusRequester(focusRequester),
+                value = name,
+                onValueChange = { name = it },
+                label = { Text(text = stringResource(MR.strings.import_local_source_folder_placeholder)) },
+                singleLine = true,
+            )
+        },
+    )
+
+    LaunchedEffect(focusRequester) {
+        focusRequester.requestFocus()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -41,6 +41,13 @@ object Notifications {
     const val ID_DOWNLOAD_CHAPTER_ERROR = -202
 
     /**
+     * Notification channel and ids used by the local source import.
+     */
+    const val CHANNEL_LOCAL_SOURCE_IMPORT = "local_source_import_channel"
+    const val ID_LOCAL_SOURCE_IMPORT_PROGRESS = -601
+    const val ID_LOCAL_SOURCE_IMPORT_COMPLETE = -602
+
+    /**
      * Notification channel and ids used by the library updater.
      */
     const val CHANNEL_NEW_CHAPTERS = "new_chapters_channel"
@@ -143,6 +150,10 @@ object Notifications {
                 buildNotificationChannel(CHANNEL_DOWNLOADER_ERROR, IMPORTANCE_LOW) {
                     setName(context.stringResource(MR.strings.channel_errors))
                     setGroup(GROUP_DOWNLOADER)
+                    setShowBadge(false)
+                },
+                buildNotificationChannel(CHANNEL_LOCAL_SOURCE_IMPORT, IMPORTANCE_LOW) {
+                    setName(context.stringResource(MR.strings.channel_progress))
                     setShowBadge(false)
                 },
                 buildNotificationChannel(CHANNEL_BACKUP_RESTORE_PROGRESS, IMPORTANCE_LOW) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/local/LocalSourceImportJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/local/LocalSourceImportJob.kt
@@ -1,0 +1,97 @@
+package eu.kanade.tachiyomi.data.source.local
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.net.Uri
+import android.os.Build
+import androidx.core.net.toUri
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LocalSourceImportJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val notifier = LocalSourceImportNotifier(context)
+    private val storageManager: StorageManager = Injekt.get()
+
+    override suspend fun doWork(): Result {
+        val uris = inputData.getStringArray(URIS_KEY)?.map { it.toUri() } ?: return Result.failure()
+        val folderName = inputData.getString(FOLDER_NAME_KEY) ?: return Result.failure()
+
+        setForegroundSafely()
+
+        return try {
+            val localSourceDir = storageManager.getLocalSourceDirectory()
+                ?: throw Exception("Storage not set")
+            val mangaDir = localSourceDir.createDirectory(folderName)
+                ?: throw Exception("Could not create directory")
+
+            uris.forEachIndexed { index, uri ->
+                val sourceFile = UniFile.fromUri(context, uri) ?: return@forEachIndexed
+                val destFile = mangaDir.createFile(sourceFile.name) ?: return@forEachIndexed
+
+                notifier.showImportProgress(index + 1, uris.size, folderName)
+
+                context.contentResolver.openInputStream(uri)?.use { input ->
+                    destFile.openOutputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+
+            notifier.showImportComplete(folderName)
+            Result.success()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            notifier.showImportError(e.message)
+            Result.failure()
+        } finally {
+            context.cancelNotification(Notifications.ID_LOCAL_SOURCE_IMPORT_PROGRESS)
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        val folderName = inputData.getString(FOLDER_NAME_KEY) ?: ""
+        return ForegroundInfo(
+            Notifications.ID_LOCAL_SOURCE_IMPORT_PROGRESS,
+            notifier.showImportProgress(0, 100, folderName).build(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        fun start(context: Context, uris: List<Uri>, folderName: String) {
+            val inputData = workDataOf(
+                URIS_KEY to uris.map { it.toString() }.toTypedArray(),
+                FOLDER_NAME_KEY to folderName,
+            )
+            val request = OneTimeWorkRequestBuilder<LocalSourceImportJob>()
+                .addTag(TAG)
+                .setInputData(inputData)
+                .build()
+            context.workManager.enqueueUniqueWork(TAG + folderName, ExistingWorkPolicy.KEEP, request)
+        }
+    }
+}
+
+private const val TAG = "LocalSourceImport"
+private const val URIS_KEY = "uris"
+private const val FOLDER_NAME_KEY = "folder_name"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/source/local/LocalSourceImportNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/source/local/LocalSourceImportNotifier.kt
@@ -1,0 +1,71 @@
+package eu.kanade.tachiyomi.data.source.local
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import androidx.core.app.NotificationCompat
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.notificationBuilder
+import eu.kanade.tachiyomi.util.system.notify
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+
+class LocalSourceImportNotifier(private val context: Context) {
+
+    private val progressNotificationBuilder = context.notificationBuilder(
+        Notifications.CHANNEL_LOCAL_SOURCE_IMPORT,
+    ) {
+        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setSmallIcon(R.drawable.ic_mihon)
+        setAutoCancel(false)
+        setOngoing(true)
+        setOnlyAlertOnce(true)
+    }
+
+    private val completeNotificationBuilder = context.notificationBuilder(
+        Notifications.CHANNEL_LOCAL_SOURCE_IMPORT,
+    ) {
+        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setSmallIcon(R.drawable.ic_mihon)
+        setAutoCancel(true)
+    }
+
+    fun showImportProgress(
+        progress: Int,
+        maxAmount: Int,
+        folderName: String,
+    ): NotificationCompat.Builder {
+        val builder = with(progressNotificationBuilder) {
+            setContentTitle(folderName)
+            setContentText(context.stringResource(MR.strings.importing_local_source_progress, progress, maxAmount))
+            setProgress(maxAmount, progress, false)
+        }
+
+        context.notify(Notifications.ID_LOCAL_SOURCE_IMPORT_PROGRESS, builder.build())
+
+        return builder
+    }
+
+    fun showImportError(error: String?) {
+        context.cancelNotification(Notifications.ID_LOCAL_SOURCE_IMPORT_PROGRESS)
+
+        with(completeNotificationBuilder) {
+            setContentTitle(context.stringResource(MR.strings.import_local_source_error))
+            setContentText(error)
+
+            context.notify(Notifications.ID_LOCAL_SOURCE_IMPORT_COMPLETE, build())
+        }
+    }
+
+    fun showImportComplete(folderName: String) {
+        context.cancelNotification(Notifications.ID_LOCAL_SOURCE_IMPORT_PROGRESS)
+
+        with(completeNotificationBuilder) {
+            setContentTitle(context.stringResource(MR.strings.import_local_source_success, folderName))
+            setContentText(null)
+
+            context.notify(Notifications.ID_LOCAL_SOURCE_IMPORT_COMPLETE, build())
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -1,5 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -40,6 +42,7 @@ import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.MissingSourceScreen
 import eu.kanade.presentation.browse.components.BrowseSourceToolbar
+import eu.kanade.presentation.browse.components.LocalSourceImportDialog
 import eu.kanade.presentation.browse.components.RemoveMangaDialog
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.manga.DuplicateMangaDialog
@@ -112,6 +115,12 @@ data class BrowseSourceScreen(
         val uriHandler = LocalUriHandler.current
         val snackbarHostState = remember { SnackbarHostState() }
 
+        val pickFiles = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenMultipleDocuments(),
+        ) { uris ->
+            viewModel.onFilesSelected(uris)
+        }
+
         val onHelpClick = { uriHandler.openUri(LocalSource.HELP_URL) }
         val onWebViewClick = f@{
             val source = viewModel.source as? HttpSource ?: return@f
@@ -146,6 +155,21 @@ data class BrowseSourceScreen(
                         onHelpClick = onHelpClick,
                         onSettingsClick = { navigator.push(SourcePreferencesScreen(sourceId)) },
                         onSearch = viewModel::search,
+                        onImportClick = {
+                            pickFiles.launch(
+                                arrayOf(
+                                    "application/zip",
+                                    "application/x-cbz",
+                                    "application/x-rar-compressed",
+                                    "application/x-cbr",
+                                    "application/x-7z-compressed",
+                                    "application/x-cb7",
+                                    "application/x-tar",
+                                    "application/x-cbt",
+                                    "application/epub+zip",
+                                ),
+                            )
+                        },
                     )
 
                     Row(
@@ -235,6 +259,7 @@ data class BrowseSourceScreen(
                             duplicates.isNotEmpty() -> viewModel.setDialog(
                                 BrowseSourceViewModel.Dialog.AddDuplicateManga(manga, duplicates),
                             )
+
                             else -> viewModel.addFavorite(manga)
                         }
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -254,6 +279,7 @@ data class BrowseSourceScreen(
                     onUpdate = viewModel::setFilters,
                 )
             }
+
             is BrowseSourceViewModel.Dialog.AddDuplicateManga -> {
                 DuplicateMangaDialog(
                     duplicates = dialog.duplicates,
@@ -273,6 +299,7 @@ data class BrowseSourceScreen(
                     onDismissRequest = onDismissRequest,
                 )
             }
+
             is BrowseSourceViewModel.Dialog.RemoveManga -> {
                 RemoveMangaDialog(
                     onDismissRequest = onDismissRequest,
@@ -282,6 +309,7 @@ data class BrowseSourceScreen(
                     mangaToRemove = dialog.manga,
                 )
             }
+
             is BrowseSourceViewModel.Dialog.ChangeMangaCategory -> {
                 ChangeCategoryDialog(
                     initialSelection = dialog.initialSelection,
@@ -293,6 +321,17 @@ data class BrowseSourceScreen(
                     },
                 )
             }
+
+            is BrowseSourceViewModel.Dialog.Import -> {
+                LocalSourceImportDialog(
+                    onDismissRequest = onDismissRequest,
+                    onImport = { folderName ->
+                        viewModel.importFiles(dialog.uris, folderName)
+                    },
+                    initialName = dialog.defaultName,
+                )
+            }
+
             else -> {}
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceViewModel.kt
@@ -1,6 +1,8 @@
 package eu.kanade.tachiyomi.ui.browse.source.browse
 
+import android.app.Application
 import android.content.res.Configuration
+import android.net.Uri
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
@@ -15,12 +17,14 @@ import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import androidx.paging.filter
 import androidx.paging.map
+import com.hippo.unifile.UniFile
 import eu.kanade.core.preference.asState
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.data.source.local.LocalSourceImportJob
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.util.removeCovers
 import kotlinx.coroutines.flow.SharingStarted
@@ -309,6 +313,18 @@ class BrowseSourceViewModel(
         setDialog(Dialog.Filter)
     }
 
+    fun onFilesSelected(uris: List<Uri>) {
+        if (uris.isEmpty()) return
+        val defaultName = uris.first().let { uri ->
+            UniFile.fromUri(Injekt.get<Application>(), uri)?.name?.substringBeforeLast('.') ?: ""
+        }
+        setDialog(Dialog.Import(uris, defaultName))
+    }
+
+    fun importFiles(uris: List<Uri>, folderName: String) {
+        LocalSourceImportJob.start(Injekt.get<Application>(), uris, folderName)
+    }
+
     fun setDialog(dialog: Dialog?) {
         mutableState.update { it.copy(dialog = dialog) }
     }
@@ -344,7 +360,9 @@ class BrowseSourceViewModel(
             val manga: Manga,
             val initialSelection: List<CheckboxState.State<Category>>,
         ) : Dialog
+
         data class Migrate(val target: Manga, val current: Manga) : Dialog
+        data class Import(val uris: List<Uri>, val defaultName: String) : Dialog
     }
 
     @Immutable

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -693,6 +693,13 @@
     <string name="no_more_results">No more results</string>
     <string name="no_results_found">No results found</string>
     <string name="local_source">Local source</string>
+    <string name="action_import_from_storage">Import from storage</string>
+    <string name="import_local_source_title">Import to local source</string>
+    <string name="import_local_source_folder_placeholder">Folder name</string>
+    <string name="importing_local_source">Importing…</string>
+    <string name="importing_local_source_progress">Importing: %1$d/%2$d</string>
+    <string name="import_local_source_success">Successfully imported to %1$s</string>
+    <string name="import_local_source_error">Failed to import files</string>
     <string name="other_source">Other</string>
     <string name="last_used_source">Last used</string>
     <string name="pinned_sources">Pinned</string>


### PR DESCRIPTION
# What's this?

This is a new feature which lets you import from local sources directly from the app. The steps to use it are as follows :
1. Navigate to local source from the browse screen.
2.  Press the import from storage button in the toolbar.
3. Navigate to the file[s] you want to import.
4. Enter the name for the folder.
 
A new folder is created within the local source folder with the selected files and selected name.

## Preview

<div align="center">
  <table>
    <tr>
      <td><img width="300"  alt="local_source_toolbar" src="https://github.com/user-attachments/assets/e94a3ce6-c074-4011-9391-f5bd7e4f2d7f" /></td>
      <td><img width="300" alt="import_dialog" src="https://github.com/user-attachments/assets/b0464e55-a8f6-457a-bcc7-d9c228178390" />
</td>
    </tr>
  </table>
</div>

