### PR TITLE
Open the series by pressing a download queue entry

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadAdapter.kt
@@ -23,5 +23,6 @@ class DownloadAdapter(val downloadItemListener: DownloadItemListener) : Flexible
     interface DownloadItemListener {
         fun onItemReleased(position: Int)
         fun onMenuItemClick(position: Int, menuItem: MenuItem)
+        fun onItemClick(position: Int)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadHolder.kt
@@ -23,6 +23,9 @@ class DownloadHolder(private val view: View, val adapter: DownloadAdapter) :
     init {
         setDragHandleView(binding.reorder)
         binding.menu.setOnClickListener { it.post { showPopupMenu(it) } }
+        binding.container.setOnClickListener {
+            adapter.downloadItemListener.onItemClick(bindingAdapterPosition)
+        }
     }
 
     private lateinit var download: Download

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.animateFloatingActionButton
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -51,6 +52,8 @@ import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.presentation.components.NestedMenuItem
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.databinding.DownloadListBinding
+import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import kotlinx.coroutines.flow.collectLatest
 import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.Pill
@@ -69,6 +72,14 @@ object DownloadQueueScreen : Screen() {
         val downloadList by viewModel.state.collectAsState()
         val downloadCount by remember {
             derivedStateOf { downloadList.sumOf { it.subItems.size } }
+        }
+
+        LaunchedEffect(Unit) {
+            viewModel.events.collectLatest { event ->
+                when (event) {
+                    is DownloadQueueViewModel.Event.OpenManga -> navigator.push(MangaScreen(event.mangaId))
+                }
+            }
         }
 
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadQueueViewModel.kt
@@ -9,7 +9,9 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.databinding.DownloadListBinding
 import eu.kanade.tachiyomi.source.model.Page
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -31,6 +34,9 @@ class DownloadQueueViewModel(
 
     private val _state = MutableStateFlow(emptyList<DownloadHeaderItem>())
     val state = _state.asStateFlow()
+
+    private val _events: Channel<Event> = Channel(Channel.UNLIMITED)
+    val events: Flow<Event> = _events.receiveAsFlow()
 
     lateinit var controllerBinding: DownloadListBinding
 
@@ -58,6 +64,16 @@ class DownloadQueueViewModel(
                 }
             }
             reorder(downloads)
+        }
+
+        /**
+         * Called when a download is tapped.
+         *
+         * @param position The position of the item
+         */
+        override fun onItemClick(position: Int) {
+            val item = adapter?.getItem(position) as? DownloadItem ?: return
+            viewModelScope.launch { _events.send(Event.OpenManga(item.download.manga.id)) }
         }
 
         /**
@@ -266,5 +282,9 @@ class DownloadQueueViewModel(
      */
     private fun getHolder(download: Download): DownloadHolder? {
         return controllerBinding.root.findViewHolderForItemId(download.chapter.id) as? DownloadHolder
+    }
+
+    sealed interface Event {
+        data class OpenManga(val mangaId: Long) : Event
     }
 }


### PR DESCRIPTION
Would solve feature request #1129. If the previous refusal was architectural, against the Composable scoping, this implementation resolves that.
If it was on principle (e.g. because this is the only screen still using FlexibleAdapter and not worth investing in), fair enough and I'll just keep this one locally.

I find myself reaching for this almost daily to deal with stuck paywalled chapters - so I can check if a different, previously paywalled chapter is now available to read.
