### PR TITLE
Do not count Android SAF collision as valid pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -590,6 +590,8 @@ class Downloader(
                 fileName.endsWith(".tmp") -> false
                 // Only count the first split page and not the others
                 fileName.contains("__") && !fileName.endsWith("__001.jpg") -> false
+                // Ignore SAF collision copies like "001 (1).jpg"
+                fileName.contains(" (") -> false
                 else -> true
             }
         }


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

A recent GrapheneOS SAF bug "corrupted" part of the content of Mihon's downloaded folder by creating duplicate files.
This PR fixes a bug in how Mihon counts chapter pages when Android SAF create duplicates, preventing similar scenarios in the future.

In particular when Mihon is downloading a chapter's page it renames the file https://github.com/mihonapp/mihon/blob/55be95dd5df7ac985bbc68ea62a5a525611a732f/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt#L494 however if the file already exists SAF creates a duplicate named `$filename (1).$extension` with increasing numbers.

Those duplicated files are counted for determining if a download succeed or not thus always triggering unsuccessful downloads when files already exists.
https://github.com/mihonapp/mihon/blob/55be95dd5df7ac985bbc68ea62a5a525611a732f/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt#L585-L596

Since `isDownloadSuccessful` is never true ^, the downloaded chapter is never promoted to successful so it keeps the `_tmp` suffix, thus re-indexing the downloads from Mihon settings never pick up this chapters.