### PR TITLE
Add cross-device sync through Google Drive

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,8 @@ android {
     namespace = "eu.kanade.tachiyomi"
 
     defaultConfig {
-        applicationId = "app.mihon"
+        // Distinct from upstream Mihon so both apps can be installed side by side
+        applicationId = "app.mihon.sync"
 
         versionCode = 29
         versionName = "0.20.4"

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -54,7 +54,10 @@ import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
 import eu.kanade.tachiyomi.data.cache.ChapterCache
 import eu.kanade.tachiyomi.data.export.LibraryExporter
 import eu.kanade.tachiyomi.data.export.LibraryExporter.ExportOptions
+import eu.kanade.tachiyomi.data.sync.SyncJob
+import eu.kanade.tachiyomi.data.sync.service.GoogleDriveAuthenticator
 import eu.kanade.tachiyomi.util.system.DeviceUtil
+import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -69,6 +72,7 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetFavorites
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.storage.service.StoragePreferences
+import tachiyomi.domain.sync.service.SyncPreferences
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.TextButton
 import tachiyomi.presentation.core.i18n.stringResource
@@ -80,6 +84,7 @@ object SettingsDataScreen : SearchableSettings {
 
     val restorePreferenceKeyString = MR.strings.label_backup
     const val HELP_URL = "https://mihon.app/docs/faq/storage"
+    const val SYNC_SETUP_URL = "https://github.com/nkoziel/mihon/blob/main/docs/google-drive-sync.md"
 
     @ReadOnlyComposable
     @Composable
@@ -100,12 +105,14 @@ object SettingsDataScreen : SearchableSettings {
     override fun getPreferences(): List<Preference> {
         val backupPreferences = Injekt.get<BackupPreferences>()
         val storagePreferences = Injekt.get<StoragePreferences>()
+        val syncPreferences = Injekt.get<SyncPreferences>()
 
         return listOf(
             getStorageLocationPref(storagePreferences = storagePreferences),
             Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.pref_storage_location_info)),
 
             getBackupAndRestoreGroup(backupPreferences = backupPreferences),
+            getSyncGroup(syncPreferences = syncPreferences),
             getDataGroup(),
             getExportGroup(),
         )
@@ -270,6 +277,108 @@ object SettingsDataScreen : SearchableSettings {
                 Preference.PreferenceItem.InfoPreference(
                     stringResource(MR.strings.backup_info) + "\n\n" +
                         stringResource(MR.strings.last_auto_backup_info, relativeTimeSpanString(lastAutoBackup)),
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getSyncGroup(syncPreferences: SyncPreferences): Preference.PreferenceGroup {
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+
+        val lastSync by syncPreferences.lastSyncTimestamp.collectAsState()
+        val refreshToken by syncPreferences.googleDriveRefreshToken.collectAsState()
+        val clientId by syncPreferences.googleDriveClientId.collectAsState()
+        val clientSecret by syncPreferences.googleDriveClientSecret.collectAsState()
+
+        val loggedIn = refreshToken.isNotBlank()
+        val hasCredentials = clientId.isNotBlank() && clientSecret.isNotBlank()
+
+        val accountPref = if (loggedIn) {
+            Preference.PreferenceItem.TextPreference(
+                title = stringResource(MR.strings.pref_sync_google_drive_logout),
+                onClick = {
+                    syncPreferences.logoutGoogleDrive()
+                    SyncJob.setupTask(context, 0)
+                },
+            )
+        } else {
+            Preference.PreferenceItem.TextPreference(
+                title = stringResource(MR.strings.pref_sync_google_drive_login),
+                subtitle = stringResource(MR.strings.pref_sync_google_drive_login_summary),
+                enabled = hasCredentials,
+                onClick = {
+                    scope.launch {
+                        try {
+                            GoogleDriveAuthenticator(context).signIn()
+                            withUIContext { context.toast(MR.strings.sync_login_success) }
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR, e)
+                            withUIContext { context.toast(MR.strings.sync_login_failed) }
+                        }
+                    }
+                },
+            )
+        }
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_sync),
+            preferenceItems = listOf(
+                Preference.PreferenceItem.EditTextPreference(
+                    preference = syncPreferences.googleDriveClientId,
+                    title = stringResource(MR.strings.pref_sync_client_id),
+                    subtitle = clientId.ifBlank { stringResource(MR.strings.pref_sync_credential_unset) },
+                    enabled = !loggedIn,
+                ),
+                Preference.PreferenceItem.EditTextPreference(
+                    preference = syncPreferences.googleDriveClientSecret,
+                    title = stringResource(MR.strings.pref_sync_client_secret),
+                    subtitle = if (clientSecret.isBlank()) {
+                        stringResource(MR.strings.pref_sync_credential_unset)
+                    } else {
+                        stringResource(MR.strings.pref_sync_credential_set)
+                    },
+                    enabled = !loggedIn,
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_sync_setup_guide),
+                    subtitle = stringResource(MR.strings.pref_sync_setup_guide_summary),
+                    onClick = { context.openInBrowser(SYNC_SETUP_URL) },
+                ),
+                accountPref,
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_sync_now),
+                    enabled = loggedIn,
+                    onClick = {
+                        if (SyncJob.isRunning(context)) {
+                            context.toast(MR.strings.sync_in_progress)
+                        } else {
+                            SyncJob.startNow(context)
+                            context.toast(MR.strings.sync_started)
+                        }
+                    },
+                ),
+                Preference.PreferenceItem.ListPreference(
+                    preference = syncPreferences.syncInterval,
+                    entries = mapOf(
+                        0 to stringResource(MR.strings.off),
+                        6 to stringResource(MR.strings.update_6hour),
+                        12 to stringResource(MR.strings.update_12hour),
+                        24 to stringResource(MR.strings.update_24hour),
+                        48 to stringResource(MR.strings.update_48hour),
+                        168 to stringResource(MR.strings.update_weekly),
+                    ),
+                    title = stringResource(MR.strings.pref_sync_interval),
+                    enabled = loggedIn,
+                    onValueChanged = {
+                        SyncJob.setupTask(context, it)
+                        true
+                    },
+                ),
+                Preference.PreferenceItem.InfoPreference(
+                    stringResource(MR.strings.sync_info) + "\n\n" +
+                        stringResource(MR.strings.last_sync_info, relativeTimeSpanString(lastSync)),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -77,17 +77,7 @@ class BackupCreator(
                 throw IllegalStateException(context.stringResource(MR.strings.create_backup_file_error))
             }
 
-            val nonFavoriteManga = if (options.readEntries) mangaRepository.getReadMangaNotInLibrary() else emptyList()
-            val backupManga = backupMangas(getFavorites.await() + nonFavoriteManga, options)
-
-            val backup = Backup(
-                backupManga = backupManga,
-                backupCategories = backupCategories(options),
-                backupSources = backupSources(backupManga),
-                backupPreferences = backupAppPreferences(options),
-                backupExtensionStores = backupExtensionStores(options),
-                backupSourcePreferences = backupSourcePreferences(options),
-            )
+            val backup = createBackup(options)
 
             val byteArray = parser.encodeToByteArray(Backup.serializer(), backup)
             if (byteArray.isEmpty()) {
@@ -117,6 +107,24 @@ class BackupCreator(
             file?.delete()
             throw e
         }
+    }
+
+    /**
+     * Builds an in-memory snapshot of the library. Used by [backup] and by sync, which needs the
+     * model rather than a file so it can be merged with a remote snapshot.
+     */
+    suspend fun createBackup(options: BackupOptions): Backup {
+        val nonFavoriteManga = if (options.readEntries) mangaRepository.getReadMangaNotInLibrary() else emptyList()
+        val backupManga = backupMangas(getFavorites.await() + nonFavoriteManga, options)
+
+        return Backup(
+            backupManga = backupManga,
+            backupCategories = backupCategories(options),
+            backupSources = backupSources(backupManga),
+            backupPreferences = backupAppPreferences(options),
+            backupExtensionStores = backupExtensionStores(options),
+            backupSourcePreferences = backupSourcePreferences(options),
+        )
     }
 
     private suspend fun backupCategories(options: BackupOptions): List<BackupCategory> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncJob.kt
@@ -1,0 +1,117 @@
+package eu.kanade.tachiyomi.data.sync
+
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkerParameters
+import eu.kanade.tachiyomi.data.backup.BackupNotifier
+import eu.kanade.tachiyomi.data.backup.create.BackupCreateJob
+import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
+import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.util.system.cancelNotification
+import eu.kanade.tachiyomi.util.system.isRunning
+import eu.kanade.tachiyomi.util.system.setForegroundSafely
+import eu.kanade.tachiyomi.util.system.workManager
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.sync.service.SyncPreferences
+import tachiyomi.domain.sync.service.SyncService
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class SyncJob(private val context: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(context, workerParams) {
+
+    private val notifier = BackupNotifier(context)
+
+    override suspend fun doWork(): Result {
+        val syncPreferences = Injekt.get<SyncPreferences>()
+        if (SyncService.fromInt(syncPreferences.syncService.get()) == SyncService.NONE) return Result.failure()
+
+        // Restoring or backing up at the same time would read a library that is mid-write
+        if (BackupRestoreJob.isRunning(context) || BackupCreateJob.isManualJobRunning(context)) return Result.retry()
+
+        setForegroundSafely()
+
+        return try {
+            SyncManager(context).sync()
+            Result.success()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            notifier.showRestoreError(e.message)
+            Result.failure()
+        } finally {
+            context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+        }
+    }
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        return ForegroundInfo(
+            Notifications.ID_RESTORE_PROGRESS,
+            notifier.showRestoreProgress(sync = true).build(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        fun isRunning(context: Context): Boolean {
+            return context.workManager.isRunning(TAG_AUTO) || context.workManager.isRunning(TAG_MANUAL)
+        }
+
+        fun setupTask(context: Context, prefInterval: Int? = null) {
+            val syncPreferences = Injekt.get<SyncPreferences>()
+            val interval = prefInterval ?: syncPreferences.syncInterval.get()
+
+            if (interval > 0 && SyncService.fromInt(syncPreferences.syncService.get()) != SyncService.NONE) {
+                val constraints = Constraints(
+                    requiredNetworkType = NetworkType.CONNECTED,
+                    requiresBatteryNotLow = true,
+                )
+
+                val request = PeriodicWorkRequestBuilder<SyncJob>(
+                    interval.toLong(),
+                    TimeUnit.HOURS,
+                    10,
+                    TimeUnit.MINUTES,
+                )
+                    .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.MINUTES)
+                    .addTag(TAG_AUTO)
+                    .setConstraints(constraints)
+                    .build()
+
+                context.workManager.enqueueUniquePeriodicWork(TAG_AUTO, ExistingPeriodicWorkPolicy.UPDATE, request)
+            } else {
+                context.workManager.cancelUniqueWork(TAG_AUTO)
+            }
+        }
+
+        fun startNow(context: Context) {
+            val request = OneTimeWorkRequestBuilder<SyncJob>()
+                .addTag(TAG_MANUAL)
+                .setConstraints(Constraints(requiredNetworkType = NetworkType.CONNECTED))
+                .build()
+            context.workManager.enqueueUniqueWork(TAG_MANUAL, ExistingWorkPolicy.KEEP, request)
+        }
+
+        fun stop(context: Context) {
+            context.workManager.cancelUniqueWork(TAG_MANUAL)
+        }
+    }
+}
+
+private const val TAG_AUTO = "SyncJob"
+private const val TAG_MANUAL = "$TAG_AUTO:manual"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -1,0 +1,103 @@
+package eu.kanade.tachiyomi.data.sync
+
+import android.content.Context
+import androidx.core.net.toUri
+import eu.kanade.tachiyomi.data.backup.BackupDecoder
+import eu.kanade.tachiyomi.data.backup.BackupNotifier
+import eu.kanade.tachiyomi.data.backup.create.BackupCreator
+import eu.kanade.tachiyomi.data.backup.create.BackupOptions
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.restore.BackupRestorer
+import eu.kanade.tachiyomi.data.backup.restore.RestoreOptions
+import eu.kanade.tachiyomi.data.sync.service.GoogleDriveApi
+import eu.kanade.tachiyomi.util.system.createFileInCacheDir
+import kotlinx.serialization.protobuf.ProtoBuf
+import okio.buffer
+import okio.gzip
+import okio.sink
+import tachiyomi.domain.sync.service.SyncPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import kotlin.time.Clock
+
+/**
+ * Pulls the remote snapshot, merges it with the local library, pushes the result back and applies
+ * it locally, so every device converges on the same state.
+ */
+class SyncManager(
+    private val context: Context,
+    private val syncPreferences: SyncPreferences = Injekt.get(),
+    private val parser: ProtoBuf = Injekt.get(),
+    private val driveApi: GoogleDriveApi = GoogleDriveApi(),
+) {
+
+    suspend fun sync() {
+        val local = BackupCreator(context, isAutoBackup = false).createBackup(SYNC_OPTIONS)
+        val remote = driveApi.downloadSnapshot()?.let { decode(it) }
+
+        val merged = if (remote == null) local else SyncMerger.merge(local, remote)
+
+        driveApi.uploadSnapshot(encode(merged))
+
+        // Nothing to apply when this device is the only source of data yet
+        if (remote != null) {
+            applyLocally(merged)
+        }
+
+        syncPreferences.lastSyncTimestamp.set(Clock.System.now().toEpochMilliseconds())
+    }
+
+    private fun decode(content: ByteArray): Backup {
+        val file = context.createFileInCacheDir(REMOTE_SNAPSHOT_FILENAME)
+        file.writeBytes(content)
+        return BackupDecoder(context, parser).decode(file.toUri())
+    }
+
+    private fun encode(backup: Backup): ByteArray {
+        val file = context.createFileInCacheDir(UPLOAD_SNAPSHOT_FILENAME)
+        file.sink().gzip().buffer().use { it.write(parser.encodeToByteArray(Backup.serializer(), backup)) }
+        return file.readBytes()
+    }
+
+    /**
+     * The restorer only reads from a file, so the merged snapshot takes a detour through the cache
+     * directory rather than duplicating the whole restore logic for an in-memory backup.
+     */
+    private suspend fun applyLocally(backup: Backup) {
+        val file = context.createFileInCacheDir(MERGED_SNAPSHOT_FILENAME)
+        file.sink().gzip().buffer().use { it.write(parser.encodeToByteArray(Backup.serializer(), backup)) }
+
+        BackupRestorer(context, BackupNotifier(context), isSync = true)
+            .restore(file.toUri(), RESTORE_OPTIONS)
+
+        file.delete()
+    }
+
+    companion object {
+        // App and source settings are deliberately left out: they describe this device, not the library
+        private val SYNC_OPTIONS = BackupOptions(
+            libraryEntries = true,
+            categories = true,
+            chapters = true,
+            tracking = true,
+            history = true,
+            readEntries = true,
+            appSettings = false,
+            extensionStores = true,
+            sourceSettings = false,
+            privateSettings = false,
+        )
+
+        private val RESTORE_OPTIONS = RestoreOptions(
+            libraryEntries = true,
+            categories = true,
+            appSettings = false,
+            extensionStores = true,
+            sourceSettings = false,
+        )
+
+        private const val REMOTE_SNAPSHOT_FILENAME = "sync_remote.tachibk"
+        private const val UPLOAD_SNAPSHOT_FILENAME = "sync_upload.tachibk"
+        private const val MERGED_SNAPSHOT_FILENAME = "sync_merged.tachibk"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncMerger.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncMerger.kt
@@ -1,0 +1,212 @@
+package eu.kanade.tachiyomi.data.sync
+
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupHistory
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.models.BackupTracking
+
+/**
+ * Combines the local snapshot with the one stored on the remote so no device loses data.
+ *
+ * Conflicts are settled per record with the `lastModifiedAt` timestamps the app already maintains,
+ * so un-marking a chapter as read on one device is not undone by the other device's stale state.
+ * Falling back to a union (rather than to whole-snapshot last-write-wins) is what keeps a device
+ * that has been offline for a while from wiping entries added elsewhere.
+ */
+object SyncMerger {
+
+    fun merge(local: Backup, remote: Backup): Backup {
+        val categories = mergeCategories(local.backupCategories, remote.backupCategories)
+        val remoteCategoryOrders = remoteCategoryOrderMapping(remote.backupCategories, categories)
+
+        return Backup(
+            backupManga = mergeManga(local.backupManga, remote.backupManga, remoteCategoryOrders),
+            backupCategories = categories,
+            // Sources are just a id/name lookup table for error messages, a union is enough
+            backupSources = (local.backupSources + remote.backupSources).distinctBy { it.sourceId },
+            // App and source settings stay device-local on purpose: syncing them would carry over
+            // things like the storage location or reader layout picked for another screen size
+            backupPreferences = local.backupPreferences,
+            backupSourcePreferences = local.backupSourcePreferences,
+            backupExtensionStores = (local.backupExtensionStores + remote.backupExtensionStores)
+                .distinctBy { it.indexUrl },
+        )
+    }
+
+    private fun mergeCategories(local: List<BackupCategory>, remote: List<BackupCategory>): List<BackupCategory> {
+        val merged = local.toMutableList()
+        var nextOrder = (local.maxOfOrNull { it.order } ?: -1L) + 1
+
+        val localNames = local.mapTo(mutableSetOf()) { it.name }
+        remote.sortedBy { it.order }
+            .filter { it.name !in localNames }
+            .forEach { merged += BackupCategory(name = it.name, order = nextOrder++, flags = it.flags) }
+
+        return merged
+    }
+
+    /**
+     * Manga reference categories by order, and the same order can mean a different category on
+     * each device, so remote orders have to be translated into the merged numbering.
+     */
+    private fun remoteCategoryOrderMapping(
+        remote: List<BackupCategory>,
+        merged: List<BackupCategory>,
+    ): Map<Long, Long> {
+        val mergedOrderByName = merged.associate { it.name to it.order }
+        return remote.mapNotNull { category ->
+            mergedOrderByName[category.name]?.let { category.order to it }
+        }.toMap()
+    }
+
+    private fun mergeManga(
+        local: List<BackupManga>,
+        remote: List<BackupManga>,
+        remoteCategoryOrders: Map<Long, Long>,
+    ): List<BackupManga> {
+        val remoteByKey = remote.associateBy { it.source to it.url }
+        val merged = mutableListOf<BackupManga>()
+
+        local.forEach { localManga ->
+            val remoteManga = remoteByKey[localManga.source to localManga.url]
+            merged += if (remoteManga == null) {
+                localManga
+            } else {
+                mergeManga(localManga, remoteManga, remoteCategoryOrders)
+            }
+        }
+
+        val localKeys = local.mapTo(mutableSetOf()) { it.source to it.url }
+        remote.filter { (it.source to it.url) !in localKeys }
+            .forEach { merged += it.remapCategories(remoteCategoryOrders) }
+
+        return merged
+    }
+
+    private fun mergeManga(
+        local: BackupManga,
+        remote: BackupManga,
+        remoteCategoryOrders: Map<Long, Long>,
+    ): BackupManga {
+        val newest = if (local.lastModifiedAt >= remote.lastModifiedAt) local else remote
+        val oldest = if (newest === local) remote else local
+
+        // Favorite state carries its own timestamp, so it is resolved independently of the metadata
+        val favoriteWinner = when {
+            local.favoriteModifiedAt == null -> remote
+            remote.favoriteModifiedAt == null -> local
+            local.favoriteModifiedAt!! >= remote.favoriteModifiedAt!! -> local
+            else -> remote
+        }
+
+        val remoteCategories = remote.categories.mapNotNull { remoteCategoryOrders[it] }
+
+        return BackupManga(
+            source = newest.source,
+            url = newest.url,
+            title = newest.title,
+            artist = newest.artist,
+            author = newest.author,
+            description = newest.description,
+            genre = newest.genre,
+            status = newest.status,
+            thumbnailUrl = newest.thumbnailUrl ?: oldest.thumbnailUrl,
+            dateAdded = minOfNonZero(local.dateAdded, remote.dateAdded),
+            viewer = newest.viewer,
+            chapters = mergeChapters(local.chapters, remote.chapters),
+            categories = (local.categories + remoteCategories).distinct(),
+            tracking = mergeTracking(local.tracking, remote.tracking),
+            favorite = favoriteWinner.favorite,
+            chapterFlags = newest.chapterFlags,
+            viewer_flags = newest.viewer_flags ?: oldest.viewer_flags,
+            history = mergeHistory(local.history, remote.history),
+            updateStrategy = newest.updateStrategy,
+            lastModifiedAt = maxOf(local.lastModifiedAt, remote.lastModifiedAt),
+            favoriteModifiedAt = favoriteWinner.favoriteModifiedAt,
+            excludedScanlators = (local.excludedScanlators + remote.excludedScanlators).distinct(),
+            version = maxOf(local.version, remote.version),
+            notes = newest.notes.ifBlank { oldest.notes },
+            initialized = local.initialized || remote.initialized,
+            memo = newest.memo,
+        )
+    }
+
+    private fun mergeChapters(local: List<BackupChapter>, remote: List<BackupChapter>): List<BackupChapter> {
+        val remoteByUrl = remote.associateBy { it.url }
+        val merged = local.map { localChapter ->
+            val remoteChapter = remoteByUrl[localChapter.url] ?: return@map localChapter
+            mergeChapter(localChapter, remoteChapter)
+        }
+
+        val localUrls = local.mapTo(mutableSetOf()) { it.url }
+        return merged + remote.filter { it.url !in localUrls }
+    }
+
+    private fun mergeChapter(local: BackupChapter, remote: BackupChapter): BackupChapter {
+        // Read state is only meaningful as a whole: taking `read` from one side and `lastPageRead`
+        // from the other would resurrect progress the user deliberately cleared
+        val newest = if (local.lastModifiedAt >= remote.lastModifiedAt) local else remote
+        val oldest = if (newest === local) remote else local
+
+        return BackupChapter(
+            url = newest.url,
+            name = newest.name,
+            scanlator = newest.scanlator ?: oldest.scanlator,
+            read = newest.read,
+            bookmark = newest.bookmark,
+            lastPageRead = newest.lastPageRead,
+            dateFetch = minOfNonZero(local.dateFetch, remote.dateFetch),
+            dateUpload = maxOf(local.dateUpload, remote.dateUpload),
+            chapterNumber = newest.chapterNumber,
+            sourceOrder = newest.sourceOrder,
+            lastModifiedAt = maxOf(local.lastModifiedAt, remote.lastModifiedAt),
+            version = maxOf(local.version, remote.version),
+            memo = newest.memo,
+        )
+    }
+
+    private fun mergeHistory(local: List<BackupHistory>, remote: List<BackupHistory>): List<BackupHistory> {
+        val remoteByUrl = remote.associateBy { it.url }
+        val merged = local.map { localHistory ->
+            val remoteHistory = remoteByUrl[localHistory.url] ?: return@map localHistory
+            BackupHistory(
+                url = localHistory.url,
+                lastRead = maxOf(localHistory.lastRead, remoteHistory.lastRead),
+                // Reading time is cumulative per device, so the larger total is the closest to truth
+                readDuration = maxOf(localHistory.readDuration, remoteHistory.readDuration),
+            )
+        }
+
+        val localUrls = local.mapTo(mutableSetOf()) { it.url }
+        return merged + remote.filter { it.url !in localUrls }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun mergeTracking(local: List<BackupTracking>, remote: List<BackupTracking>): List<BackupTracking> {
+        val key = { track: BackupTracking ->
+            track.syncId to (track.mediaId.takeIf { it != 0L } ?: track.mediaIdInt.toLong())
+        }
+        val remoteByKey = remote.associateBy(key)
+
+        val merged = local.map { localTrack ->
+            val remoteTrack = remoteByKey[key(localTrack)] ?: return@map localTrack
+            if (localTrack.lastChapterRead >= remoteTrack.lastChapterRead) localTrack else remoteTrack
+        }
+
+        val localKeys = local.mapTo(mutableSetOf(), key)
+        return merged + remote.filter { key(it) !in localKeys }
+    }
+
+    private fun BackupManga.remapCategories(remoteCategoryOrders: Map<Long, Long>) = apply {
+        categories = categories.mapNotNull { remoteCategoryOrders[it] }
+    }
+
+    /** Creation timestamps should keep the earliest known value, ignoring unset ones. */
+    private fun minOfNonZero(first: Long, second: Long): Long = when {
+        first == 0L -> second
+        second == 0L -> first
+        else -> minOf(first, second)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/GoogleDriveDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/models/GoogleDriveDto.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.data.sync.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GoogleDriveOAuthResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("expires_in") val expiresIn: Long = 0,
+)
+
+@Serializable
+data class GoogleDriveFileList(
+    val files: List<GoogleDriveFile> = emptyList(),
+)
+
+@Serializable
+data class GoogleDriveFile(
+    val id: String,
+    val name: String = "",
+    val modifiedTime: String? = null,
+)
+
+@Serializable
+data class GoogleDriveFileMetadata(
+    val name: String,
+    val parents: List<String>,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveApi.kt
@@ -1,0 +1,241 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.net.Uri
+import androidx.core.net.toUri
+import eu.kanade.tachiyomi.data.sync.models.GoogleDriveFile
+import eu.kanade.tachiyomi.data.sync.models.GoogleDriveFileList
+import eu.kanade.tachiyomi.data.sync.models.GoogleDriveFileMetadata
+import eu.kanade.tachiyomi.data.sync.models.GoogleDriveOAuthResponse
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.NetworkHelper
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.util.PkceUtil
+import kotlinx.serialization.json.Json
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.sync.service.SyncPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Minimal Google Drive client scoped to the application data folder, a hidden per-app folder in
+ * the user's Drive. Only the sync snapshot lives there; no other Drive file is reachable.
+ *
+ * The OAuth client credentials come from the sync settings rather than from the build, so the app
+ * can be configured entirely from the device.
+ */
+class GoogleDriveApi(
+    private val syncPreferences: SyncPreferences = Injekt.get(),
+    private val json: Json = Injekt.get(),
+    baseClient: OkHttpClient = Injekt.get<NetworkHelper>().client,
+) {
+
+    // The snapshot can get large and Drive is not always fast
+    private val client = baseClient.newBuilder().callTimeout(5.minutes).build()
+
+    private val clientId: String
+        get() = syncPreferences.googleDriveClientId.get().trim()
+
+    private val clientSecret: String
+        get() = syncPreferences.googleDriveClientSecret.get().trim()
+
+    /**
+     * Consent screen to send the user to. [redirectUri] is the loopback address the app listens on.
+     */
+    fun authUrl(redirectUri: String, codeChallenge: String): Uri = AUTH_URL.toUri().buildUpon()
+        .appendQueryParameter("client_id", clientId)
+        .appendQueryParameter("redirect_uri", redirectUri)
+        .appendQueryParameter("response_type", "code")
+        .appendQueryParameter("scope", SCOPE)
+        .appendQueryParameter("code_challenge", codeChallenge)
+        .appendQueryParameter("code_challenge_method", "S256")
+        .appendQueryParameter("access_type", "offline")
+        // Without this Google skips the refresh token on repeat sign-ins
+        .appendQueryParameter("prompt", "consent")
+        .build()
+
+    /**
+     * Exchanges the authorization code for a token pair and persists it. The refresh token is only
+     * handed out once, hence the forced consent prompt.
+     */
+    suspend fun exchangeAuthorizationCode(
+        authCode: String,
+        codeVerifier: String,
+        redirectUri: String,
+    ) = withIOContext {
+        val body = FormBody.Builder()
+            .add("client_id", clientId)
+            .add("client_secret", clientSecret)
+            .add("code", authCode)
+            .add("code_verifier", codeVerifier)
+            .add("redirect_uri", redirectUri)
+            .add("grant_type", "authorization_code")
+            .build()
+
+        val oauth = with(json) {
+            client.newCall(POST(TOKEN_URL, body = body)).awaitSuccess().parseAs<GoogleDriveOAuthResponse>()
+        }
+
+        val refreshToken = oauth.refreshToken
+            ?: throw SyncAuthException("Google did not return a refresh token, try signing in again")
+
+        syncPreferences.googleDriveRefreshToken.set(refreshToken)
+        storeAccessToken(oauth)
+    }
+
+    /**
+     * Returns the snapshot stored in the app data folder, or null when nothing was synced yet.
+     */
+    suspend fun downloadSnapshot(): ByteArray? = withIOContext {
+        val fileId = findSnapshotId() ?: return@withIOContext null
+
+        client.newCall(GET("$DRIVE_URL/$fileId?alt=media", headers = authHeaders()))
+            .awaitSuccess()
+            .body
+            .use { it.bytes() }
+    }
+
+    /**
+     * Overwrites the snapshot in the app data folder, creating it if it does not exist yet.
+     */
+    suspend fun uploadSnapshot(content: ByteArray) = withIOContext {
+        val fileId = findSnapshotId() ?: createSnapshotFile()
+
+        val request = patch(
+            url = "$UPLOAD_URL/$fileId?uploadType=media",
+            headers = authHeaders(),
+            body = content.toRequestBody(OCTET_STREAM),
+        )
+        client.newCall(request).awaitSuccess().close()
+    }
+
+    /**
+     * Drops the remote snapshot so the next sync starts over from this device's library.
+     */
+    suspend fun deleteSnapshot() = withIOContext {
+        val fileId = findSnapshotId() ?: return@withIOContext
+
+        val request = Request.Builder()
+            .url("$DRIVE_URL/$fileId")
+            .delete()
+            .headers(authHeaders())
+            .build()
+        client.newCall(request).awaitSuccess().close()
+
+        syncPreferences.googleDriveFileId.delete()
+    }
+
+    private suspend fun findSnapshotId(): String? {
+        syncPreferences.googleDriveFileId.get().takeIf { it.isNotBlank() }?.let { return it }
+
+        val query = Uri.encode("name = '$SNAPSHOT_NAME' and trashed = false")
+        val url = "$DRIVE_URL?spaces=appDataFolder&fields=files(id,name)&q=$query"
+
+        val fileId = with(json) {
+            client.newCall(GET(url, headers = authHeaders()))
+                .awaitSuccess()
+                .parseAs<GoogleDriveFileList>()
+                .files
+                .firstOrNull()
+                ?.id
+        }
+
+        return fileId?.also { syncPreferences.googleDriveFileId.set(it) }
+    }
+
+    private suspend fun createSnapshotFile(): String {
+        val metadata = json.encodeToString(
+            GoogleDriveFileMetadata.serializer(),
+            GoogleDriveFileMetadata(name = SNAPSHOT_NAME, parents = listOf(APP_DATA_FOLDER)),
+        )
+
+        val fileId = with(json) {
+            client.newCall(POST(DRIVE_URL, headers = authHeaders(), body = metadata.toRequestBody(JSON_MEDIA_TYPE)))
+                .awaitSuccess()
+                .parseAs<GoogleDriveFile>()
+                .id
+        }
+
+        syncPreferences.googleDriveFileId.set(fileId)
+        return fileId
+    }
+
+    private fun patch(url: String, headers: Headers, body: RequestBody): Request = Request.Builder()
+        .url(url)
+        .patch(body)
+        .headers(headers)
+        .build()
+
+    private suspend fun authHeaders(): Headers = Headers.Builder()
+        .add("Authorization", "Bearer ${accessToken()}")
+        .build()
+
+    private suspend fun accessToken(): String {
+        val cached = syncPreferences.googleDriveAccessToken.get()
+        val expiry = syncPreferences.googleDriveTokenExpiry.get()
+        if (cached.isNotBlank() && Clock.System.now().toEpochMilliseconds() < expiry) return cached
+
+        return refreshAccessToken()
+    }
+
+    private suspend fun refreshAccessToken(): String {
+        val refreshToken = syncPreferences.googleDriveRefreshToken.get()
+        if (refreshToken.isBlank()) throw SyncAuthException("Not signed in to Google Drive")
+
+        val body = FormBody.Builder()
+            .add("client_id", clientId)
+            .add("client_secret", clientSecret)
+            .add("refresh_token", refreshToken)
+            .add("grant_type", "refresh_token")
+            .build()
+
+        val oauth = try {
+            with(json) {
+                client.newCall(POST(TOKEN_URL, body = body)).awaitSuccess().parseAs<GoogleDriveOAuthResponse>()
+            }
+        } catch (e: Exception) {
+            // A revoked or expired refresh token can only be recovered by signing in again
+            syncPreferences.logoutGoogleDrive()
+            throw SyncAuthException("Google Drive session expired, sign in again", e)
+        }
+
+        storeAccessToken(oauth)
+        return oauth.accessToken
+    }
+
+    private fun storeAccessToken(oauth: GoogleDriveOAuthResponse) {
+        syncPreferences.googleDriveAccessToken.set(oauth.accessToken)
+        syncPreferences.googleDriveTokenExpiry.set(
+            Clock.System.now().toEpochMilliseconds() + (oauth.expiresIn - EXPIRY_MARGIN_SECONDS) * 1000,
+        )
+    }
+
+    companion object {
+        const val SNAPSHOT_NAME = "mihon_sync.tachibk"
+
+        private const val AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+        private const val TOKEN_URL = "https://oauth2.googleapis.com/token"
+        private const val DRIVE_URL = "https://www.googleapis.com/drive/v3/files"
+        private const val UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files"
+        private const val SCOPE = "https://www.googleapis.com/auth/drive.appdata"
+        private const val APP_DATA_FOLDER = "appDataFolder"
+        private const val EXPIRY_MARGIN_SECONDS = 60
+
+        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+        private val OCTET_STREAM = "application/octet-stream".toMediaType()
+
+        fun generatePkceCodes() = PkceUtil.generateS256Codes()
+    }
+}
+
+class SyncAuthException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveAuthenticator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/GoogleDriveAuthenticator.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.content.Context
+import eu.kanade.tachiyomi.util.system.openInBrowser
+import tachiyomi.domain.sync.service.SyncPreferences
+import tachiyomi.domain.sync.service.SyncService
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Drives the whole sign-in: opens the consent screen, catches the redirect on a loopback port and
+ * trades the authorization code for tokens.
+ */
+class GoogleDriveAuthenticator(
+    private val context: Context,
+    private val syncPreferences: SyncPreferences = Injekt.get(),
+    private val api: GoogleDriveApi = GoogleDriveApi(),
+) {
+
+    suspend fun signIn() {
+        if (!syncPreferences.hasGoogleDriveCredentials()) {
+            throw SyncAuthException("Enter the OAuth client ID and secret first")
+        }
+
+        // The listener has to be up before the browser opens, and torn down whatever happens
+        LoopbackRedirectServer().use { server ->
+            val codes = GoogleDriveApi.generatePkceCodes()
+
+            context.openInBrowser(
+                api.authUrl(redirectUri = server.redirectUri, codeChallenge = codes.codeChallenge),
+                forceDefaultBrowser = true,
+            )
+
+            val authCode = server.awaitAuthorizationCode()
+            api.exchangeAuthorizationCode(
+                authCode = authCode,
+                codeVerifier = codes.codeVerifier,
+                redirectUri = server.redirectUri,
+            )
+        }
+
+        syncPreferences.syncService.set(SyncService.GOOGLE_DRIVE.ordinal)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/LoopbackRedirectServer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/LoopbackRedirectServer.kt
@@ -1,0 +1,83 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.net.Uri
+import androidx.core.net.toUri
+import tachiyomi.core.common.util.lang.withIOContext
+import java.io.Closeable
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * A one-shot HTTP listener on the loopback interface, used as the OAuth redirect target.
+ *
+ * Google only accepts a loopback address or a custom scheme for installed apps. The loopback form
+ * is what lets a single "desktop" OAuth client work on every device and every build, since it is
+ * not tied to a package name or a signing certificate.
+ */
+class LoopbackRedirectServer : Closeable {
+
+    private val serverSocket = ServerSocket(0, 1, InetAddress.getByName(LOOPBACK_ADDRESS))
+
+    val redirectUri: String = "http://$LOOPBACK_ADDRESS:${serverSocket.localPort}"
+
+    /**
+     * Blocks until the browser is redirected here, and returns the authorization code.
+     *
+     * @throws SyncAuthException if the user denied consent or nothing arrived in time.
+     */
+    suspend fun awaitAuthorizationCode(timeout: Duration = DEFAULT_TIMEOUT): String = withIOContext {
+        serverSocket.soTimeout = timeout.inWholeMilliseconds.toInt()
+
+        val requestUri = try {
+            serverSocket.accept().use { socket ->
+                val reader = socket.getInputStream().bufferedReader()
+                val requestLine = reader.readLine()
+                    ?: throw SyncAuthException("Empty request on the redirect listener")
+
+                // Answer before parsing so the browser always shows something instead of hanging
+                socket.getOutputStream().writer().apply {
+                    write(RESPONSE)
+                    flush()
+                }
+
+                // "GET /?code=... HTTP/1.1" — the path is the only part that carries the result
+                val path = requestLine.split(" ").getOrNull(1)
+                    ?: throw SyncAuthException("Malformed request on the redirect listener")
+                "$redirectUri$path".toUri()
+            }
+        } catch (e: java.net.SocketTimeoutException) {
+            throw SyncAuthException("Timed out waiting for the Google sign-in to complete", e)
+        }
+
+        readCode(requestUri)
+    }
+
+    private fun readCode(uri: Uri): String {
+        uri.getQueryParameter("error")?.let { throw SyncAuthException("Google refused the sign-in: $it") }
+
+        return uri.getQueryParameter("code")
+            ?: throw SyncAuthException("Google did not return an authorization code")
+    }
+
+    override fun close() {
+        runCatching { serverSocket.close() }
+    }
+
+    companion object {
+        private const val LOOPBACK_ADDRESS = "127.0.0.1"
+        private val DEFAULT_TIMEOUT = 5.minutes
+
+        private val RESPONSE = buildString {
+            append("HTTP/1.1 200 OK\r\n")
+            append("Content-Type: text/html; charset=utf-8\r\n")
+            append("Connection: close\r\n")
+            append("\r\n")
+            append("<!doctype html><html><head><meta charset=\"utf-8\">")
+            append("<title>Sync</title></head><body style=\"font-family:sans-serif;text-align:center;padding:3em\">")
+            append("<h2>You can close this tab</h2><p>Go back to the app to finish setting up sync.</p>")
+            append("</body></html>")
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -17,6 +17,7 @@ import tachiyomi.domain.backup.service.BackupPreferences
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.storage.service.StoragePreferences
+import tachiyomi.domain.sync.service.SyncPreferences
 import tachiyomi.domain.upcoming.service.UpcomingPreferences
 import tachiyomi.domain.updates.service.UpdatesPreferences
 import uy.kohesive.injekt.api.InjektModule
@@ -65,6 +66,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             BackupPreferences(get())
+        }
+        addSingletonFactory {
+            SyncPreferences(get())
         }
         addSingletonFactory {
             StoragePreferences(

--- a/docs/google-drive-sync.md
+++ b/docs/google-drive-sync.md
@@ -1,0 +1,89 @@
+# Cross-device sync via Google Drive
+
+The library, categories, chapters, reading progress, history and tracking are merged between
+devices through a single snapshot file stored in the **application data folder** of your Google
+Drive — a hidden, per-app folder. The app cannot see any other file in your Drive.
+
+App settings and source settings are deliberately **not** synced: they describe a device (storage
+location, reader layout, screen size) rather than the library.
+
+Everything is configured from inside the app. Nothing is set at build time.
+
+## Setup
+
+Google does not let any app reach a Drive without an OAuth client, so you have to create one —
+once, for all your devices.
+
+### 1. Create the OAuth client (once, ~2 minutes)
+
+1. Open the [Google Cloud console](https://console.cloud.google.com/) and create a project.
+2. **APIs & Services → Library** → enable **Google Drive API**.
+3. **APIs & Services → OAuth consent screen**:
+   - user type *External*, fill in the app name and your email;
+   - add the scope `https://www.googleapis.com/auth/drive.appdata`;
+   - add your own Google account under **Test users** — while the app stays in testing mode no
+     Google verification is needed.
+4. **APIs & Services → Credentials → Create credentials → OAuth client ID**:
+   - application type **Desktop app**;
+   - copy the **client ID** and the **client secret**.
+
+Application type *Desktop app* is what makes a single client usable everywhere: unlike an *Android*
+client it is not bound to a package name or to a signing certificate, so the same two values work
+on every phone and every build you install.
+
+The client secret of a desktop client is not a real secret — Google documents it as
+non-confidential for installed apps, since it necessarily ships inside them. It only identifies
+your project.
+
+### 2. Enter them in the app (per device)
+
+**More → Settings → Data and storage → Sync**
+
+1. Paste the **OAuth client ID** and the **OAuth client secret**.
+2. Tap **Connect Google Drive**. The consent screen opens in your browser; approve it and the tab
+   tells you to go back to the app.
+3. Set **Automatic sync frequency** if you want background syncs, or use **Sync now**.
+
+Repeat on each device with the same two values and the same Google account.
+
+## How a sync runs
+
+1. A snapshot of the local library is built with the existing backup creator (`BackupCreator`).
+2. The remote snapshot is downloaded, if there is one.
+3. Both are merged record by record (`SyncMerger`), settling conflicts with the `lastModifiedAt`
+   timestamps the app already maintains. Nothing is dropped: an entry added on device A and an
+   entry added on device B both survive.
+4. The merged snapshot is uploaded back.
+5. The merged snapshot is applied to the local database with the existing backup restorer.
+
+Because a device merges rather than overwrites, a phone that has been offline for weeks cannot
+wipe what happened elsewhere. Un-marking a chapter as read is also preserved, since read state is
+taken as a whole from whichever side was modified last.
+
+The snapshot is a regular `.tachibk` file, so it can be downloaded from Drive and restored by hand.
+
+## How sign-in works
+
+Google accepts two redirect styles for an installed app: a custom scheme tied to the package name
+and signing certificate, or a **loopback address**. This app uses the loopback form.
+
+While you are on the consent screen, `LoopbackRedirectServer` listens on `127.0.0.1` on an
+ephemeral port and Google redirects your browser there with the authorization code. The listener
+is open only for the duration of the sign-in (5 minutes at most), accepts a single connection, and
+is closed whatever happens. The exchange uses PKCE.
+
+That is what removes the package name, the SHA-1 fingerprint and the rebuild from the setup.
+
+**Disconnect Google Drive** clears the stored tokens but keeps the client ID and secret, since
+those belong to your Cloud project rather than to the session. The remote snapshot is left in
+place, so reconnecting picks up where you left off.
+
+## Installing next to upstream Mihon
+
+The application ID is `app.mihon.sync` and the app name is *Mihon Sync*, so this build installs
+side by side with the official `app.mihon` without touching its data. The two apps share nothing:
+migrating means exporting a backup from one and restoring it in the other.
+
+Note the `debug` build type appends `.dev` to the application ID — irrelevant to sync now that the
+OAuth client is not bound to a package name, but it does mean a debug and a release build are two
+separate installs with separate libraries.

--- a/domain/src/main/java/tachiyomi/domain/sync/service/SyncPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/sync/service/SyncPreferences.kt
@@ -1,0 +1,78 @@
+package tachiyomi.domain.sync.service
+
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class SyncPreferences(
+    preferenceStore: PreferenceStore,
+) {
+
+    val syncService: Preference<Int> = preferenceStore.getInt("sync_service", SyncService.NONE.ordinal)
+
+    val syncInterval: Preference<Int> = preferenceStore.getInt("sync_interval", 0)
+
+    val lastSyncTimestamp: Preference<Long> = preferenceStore.getLong(
+        Preference.appStateKey("last_sync_timestamp"),
+        0L,
+    )
+
+    /**
+     * Credentials of the Google OAuth client, entered by the user in the sync settings. Google has
+     * no way to reach a Drive without one, but it does not have to be known at build time.
+     */
+    val googleDriveClientId: Preference<String> = preferenceStore.getString(
+        Preference.privateKey("google_drive_client_id"),
+        "",
+    )
+
+    val googleDriveClientSecret: Preference<String> = preferenceStore.getString(
+        Preference.privateKey("google_drive_client_secret"),
+        "",
+    )
+
+    val googleDriveAccessToken: Preference<String> = preferenceStore.getString(
+        Preference.privateKey("google_drive_access_token"),
+        "",
+    )
+
+    val googleDriveRefreshToken: Preference<String> = preferenceStore.getString(
+        Preference.privateKey("google_drive_refresh_token"),
+        "",
+    )
+
+    /** Epoch millis at which [googleDriveAccessToken] stops being valid. */
+    val googleDriveTokenExpiry: Preference<Long> = preferenceStore.getLong(
+        Preference.privateKey("google_drive_token_expiry"),
+        0L,
+    )
+
+    /** Drive file id of the remote snapshot, cached to avoid a lookup on every sync. */
+    val googleDriveFileId: Preference<String> = preferenceStore.getString(
+        Preference.appStateKey("google_drive_file_id"),
+        "",
+    )
+
+    fun hasGoogleDriveCredentials(): Boolean =
+        googleDriveClientId.get().isNotBlank() && googleDriveClientSecret.get().isNotBlank()
+
+    fun isGoogleDriveLoggedIn(): Boolean = googleDriveRefreshToken.get().isNotBlank()
+
+    /** Signs out but keeps the OAuth client credentials, which are not tied to an account. */
+    fun logoutGoogleDrive() {
+        googleDriveAccessToken.delete()
+        googleDriveRefreshToken.delete()
+        googleDriveTokenExpiry.delete()
+        googleDriveFileId.delete()
+        syncService.set(SyncService.NONE.ordinal)
+    }
+}
+
+enum class SyncService {
+    NONE,
+    GOOGLE_DRIVE,
+    ;
+
+    companion object {
+        fun fromInt(value: Int) = entries.getOrElse(value) { NONE }
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Mihon</string>
+    <string name="app_name" translatable="false">Mihon Sync</string>
 
     <!-- Generic strings -->
     <string name="on">On</string>
@@ -584,6 +584,27 @@
     <string name="restoring_backup_canceled">Canceled restore</string>
     <string name="backup_info">You should keep copies of backups in other places as well. Backups may contain sensitive data including any stored passwords; be careful if sharing.</string>
     <string name="last_auto_backup_info">Last automatically backed up: %s</string>
+
+    <!-- Cross-device sync -->
+    <string name="pref_sync">Sync</string>
+    <string name="pref_sync_client_id">OAuth client ID</string>
+    <string name="pref_sync_client_secret">OAuth client secret</string>
+    <string name="pref_sync_credential_unset">Not set</string>
+    <string name="pref_sync_credential_set">Set</string>
+    <string name="pref_sync_setup_guide">How to get these</string>
+    <string name="pref_sync_setup_guide_summary">Create a "Desktop app" OAuth client in the Google Cloud console. One client works on all your devices.</string>
+    <string name="pref_sync_google_drive_login">Connect Google Drive</string>
+    <string name="pref_sync_google_drive_login_summary">Opens the Google consent screen in your browser</string>
+    <string name="pref_sync_google_drive_logout">Disconnect Google Drive</string>
+    <string name="pref_sync_now">Sync now</string>
+    <string name="pref_sync_interval">Automatic sync frequency</string>
+    <string name="sync_info">Merges your library, categories, reading progress, history and tracking with your other devices through a private folder in your Google Drive. App and source settings stay on this device.</string>
+    <string name="last_sync_info">Last synced: %s</string>
+    <string name="sync_login_success">Connected to Google Drive</string>
+    <string name="sync_login_failed">Could not connect to Google Drive</string>
+    <string name="sync_in_progress">Sync is already in progress</string>
+    <string name="sync_started">Sync started</string>
+
     <string name="label_data">Data</string>
     <string name="pref_storage_usage">Storage usage</string>
     <string name="available_disk_space_info">Available: %1$s / Total: %2$s</string>


### PR DESCRIPTION
Mihon only ships manual and automatic .tachibk backups, so moving a library between devices is a manual export/import. This adds a sync that converges devices on the same state, built on top of the existing backup pipeline rather than beside it.

A sync builds a local snapshot, downloads the remote one from the hidden application data folder of the user's Drive, merges them and uploads the result before applying it locally. The merge settles conflicts per record with the lastModifiedAt timestamps the app already maintains, so a device that has been offline cannot wipe entries added elsewhere, and un-marking a chapter as read is not undone by the other device's stale state. App and source settings are left out on purpose: they describe a device rather than a library.

The OAuth client credentials are entered in the sync settings instead of being baked in at build time, and sign-in uses a loopback redirect. A "desktop" OAuth client is not bound to a package name or a signing certificate, so one client works on every device and every build without a rebuild or a SHA-1 fingerprint.

The application ID becomes app.mihon.sync so this build installs alongside upstream Mihon. Kotlin packages are left untouched to keep rebases cheap.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
