### PR TITLE
Fix network requests hanging after app is backgrounded and reopened

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     api(libs.kotlinx.serialization.jsonOkio)
 
     api(libs.androidx.preference)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.webkit)
 
     implementation(libs.jsoup)

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -1,10 +1,17 @@
 package eu.kanade.tachiyomi.network
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.ProcessLifecycleOwner
 import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor
 import okhttp3.Cache
+import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
@@ -18,12 +25,15 @@ class NetworkHelper(
 
     val cookieJar = AndroidCookieJar()
 
+    private val connectionPool = ConnectionPool()
+
     private val clientBuilder: OkHttpClient.Builder = run {
         val builder = OkHttpClient.Builder()
             .cookieJar(cookieJar)
             .connectTimeout(30.seconds)
             .readTimeout(30.seconds)
             .callTimeout(2.minutes)
+            .connectionPool(connectionPool)
             .cache(
                 Cache(
                     directory = File(context.cacheDir, "network_cache"),
@@ -62,6 +72,47 @@ class NetworkHelper(
             CloudflareInterceptor(context, cookieJar, ::defaultUserAgentProvider),
         )
         .build()
+
+    init {
+        evictStaleConnections()
+    }
+
+    private fun evictStaleConnections() {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) ?: return
+        var wasOnline = false
+        connectivityManager.registerDefaultNetworkCallback(object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                evictConnections()
+            }
+
+            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+                val isOnline = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                if (isOnline != wasOnline) {
+                    wasOnline = isOnline
+                    evictConnections()
+                }
+            }
+
+            override fun onLost(network: Network) {
+                evictConnections()
+            }
+
+            override fun onUnavailable() {
+                evictConnections()
+            }
+        })
+        ProcessLifecycleOwner.get().lifecycle.addObserver(
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_START) {
+                    evictConnections()
+                }
+            },
+        )
+    }
+
+    private fun evictConnections() {
+        connectionPool.evictAll()
+    }
 
     /**
      * @deprecated Since extension-lib 1.5


### PR DESCRIPTION
After backgrounding the app and reopening it, network requests sometimes hang forever (manga pages keep spinning) until the app is force-stopped. This is the known OkHttp stale-connection issue: idle keep-alive connections in the connection pool die while the app is backgrounded (WiFi power-save, radio recycling, network switches) and requests routed to them hang silently until the 5-minute idle reap. With DNS-over-HTTPS enabled, the DoH resolver client builds its own client via `build()`, so it has a second, separate pool that nothing ever evicts.

Changes:
- Share a single `ConnectionPool` between the main client and the DoH resolver client (set on the builder before the DoH provider block), so one `evictAll()` clears both pools.
- Evict the pool on network transitions (internet lost/regained) via a `NetworkCallback` registered with `registerDefaultNetworkCallback`.
- Evict the pool when the app returns to the foreground (`ProcessLifecycleOwner` `ON_START`).

Testing:
1. Open a manga, background the app, toggle WiFi or let the device sleep, reopen.
2. Manga pages load without force-stopping the app.
