### PR TITLE
Fix wrong MangaBaka scores for step sizes > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Fixed app and extension update check running again on configuration change ([@AntsyLich](https://github.com/AntsyLich)) ([#3708](https://github.com/mihonapp/mihon/pull/3708))
 - Fixed MangaBaka user start/finish dates drifting in negative offset timezones ([@MajorTanya](https://github.com/MajorTanya)) ([#3711](https://github.com/mihonapp/mihon/pull/3711))
+- Fixed MangaBaka scores being wrong when score step size was set to > 1 ([@MajorTanya](https://github.com/MajorTanya)) ([#3740](https://github.com/mihonapp/mihon/pull/3740))
 
 ## [v0.20.4] - 2026-08-05
 ### Fixed

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBaka.kt
@@ -49,21 +49,12 @@ class MangaBaka(id: Long) : BaseTracker(id, "MangaBaka"), DeletableTracker {
 
     override fun getCompletionStatus(): Long = COMPLETED
 
-    override fun getScoreList(): ImmutableList<String> {
-        return when (scorePreference.get()) {
-            // 1, 2, ..., 99, 100
-            STEP_1 -> IntRange(0, 100).map(Int::toString).toImmutableList()
-            // 5, 10, ..., 95, 100
-            STEP_5 -> IntRange(0, 100).step(5).map(Int::toString).toImmutableList()
-            // 10, 20, ..., 90, 100
-            STEP_10 -> IntRange(0, 100).step(10).map(Int::toString).toImmutableList()
-            // 20, 40, ..., 80, 100
-            STEP_20 -> IntRange(0, 100).step(20).map(Int::toString).toImmutableList()
-            // 25, 50, 75, 100
-            STEP_25 -> IntRange(0, 100).step(25).map(Int::toString).toImmutableList()
-            else -> throw Exception("Unknown score type")
-        }
-    }
+    override fun getScoreList(): ImmutableList<String> = getScoreRange().map(Int::toString).toImmutableList()
+
+    // score preference only dictates step size, scores are always 0-100
+    override fun get10PointScore(track: DomainTrack): Double = track.score / 10.0
+
+    override fun indexToScore(index: Int): Double = getScoreRange().toList()[index].toDouble()
 
     override fun displayScore(track: DomainTrack): String = track.score.toInt().toString()
 
@@ -176,6 +167,15 @@ class MangaBaka(id: Long) : BaseTracker(id, "MangaBaka"), DeletableTracker {
         api.deleteLibManga(track)
     }
 
+    private fun getScoreRange(): IntProgression = when (scorePreference.get()) {
+        STEP_1 -> STEP_1_SCORES
+        STEP_5 -> STEP_5_SCORES
+        STEP_10 -> STEP_10_SCORES
+        STEP_20 -> STEP_20_SCORES
+        STEP_25 -> STEP_25_SCORES
+        else -> throw Exception("Unknown score type")
+    }
+
     companion object {
         const val READING = 1L
         const val COMPLETED = 2L
@@ -190,6 +190,21 @@ class MangaBaka(id: Long) : BaseTracker(id, "MangaBaka"), DeletableTracker {
         const val STEP_10 = "STEP_10"
         const val STEP_20 = "STEP_20"
         const val STEP_25 = "STEP_25"
+
+        // 1, 2, ..., 99, 100
+        private val STEP_1_SCORES = IntRange(0, 100)
+
+        // 5, 10, ..., 95, 100
+        private val STEP_5_SCORES = IntRange(0, 100).step(5)
+
+        // 10, 20, ..., 90, 100
+        private val STEP_10_SCORES = IntRange(0, 100).step(10)
+
+        // 20, 40, ..., 80, 100
+        private val STEP_20_SCORES = IntRange(0, 100).step(20)
+
+        // 25, 50, 75, 100
+        private val STEP_25_SCORES = IntRange(0, 100).step(25)
 
         private const val SEARCH_ID_PREFIX = "id:"
     }


### PR DESCRIPTION
We're actually sending the index of the score type in the list, not the score itself.
So for example, when a user with step size 5 wanted to select score 80, we'd set it to 16 instead.

[Demo as to why 16 at the Kotlin Playground](https://pl.kotl.in/v14SheTAE).

Overriding `indexToScore` solves that issue.

Also fixed MangaBaka scores ruining the scores average in the Statistics page by overriding `get10PointScore`.

Also also refactored the ranges to be constants for consistency.