### PR TITLE
Keep installed NSFW extensions visible when NSFW toggle is off

### DIFF
--- a/app/src/main/java/eu/kanade/domain/extension/interactor/GetExtensionsByType.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/interactor/GetExtensionsByType.kt
@@ -21,8 +21,9 @@ class GetExtensionsByType(
             extensionManager.untrustedExtensionsFlow,
             extensionManager.availableExtensionsFlow,
         ) { enabledLanguages, _installed, _untrusted, _available ->
+            // Installed extensions are always shown regardless of the NSFW preference; the
+            // toggle only controls discovery of new NSFW extensions (see `available` below).
             val (updates, installed) = _installed
-                .filter { (showNsfwSources || !it.isNsfw) }
                 .sortedWith(
                     compareBy<Extension.Installed> { !it.isObsolete }
                         .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name },

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.pm.PackageInfoCompat
 import eu.kanade.domain.extension.interactor.TrustExtension
-import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.model.Extension
 import eu.kanade.tachiyomi.extension.model.LoadResult
 import eu.kanade.tachiyomi.source.Source
@@ -39,11 +38,7 @@ import java.io.File
  */
 internal object ExtensionLoader {
 
-    private val preferences: SourcePreferences by injectLazy()
     private val trustExtension: TrustExtension by injectLazy()
-    private val loadNsfwSource by lazy {
-        preferences.showNsfwSource.get()
-    }
 
     private const val EXTENSION_FEATURE = "tachiyomi.extension"
     private const val METADATA_SOURCE_CLASS = "tachiyomi.extension.class"
@@ -272,12 +267,11 @@ internal object ExtensionLoader {
             return LoadResult.Untrusted(extension)
         }
 
+        // NSFW extensions are always loaded here because this only runs for packages already
+        // installed on the device. The NSFW preference only gates discovery of new extensions
+        // (see GetExtensionsByType), so installed ones stay usable and keep receiving updates.
         val isNsfw = appInfo.metaData.getInt(METADATA_CONTENT_WARNING) > 0 ||
             appInfo.metaData.getInt(METADATA_NSFW) == 1
-        if (!loadNsfwSource && isNsfw) {
-            logcat(LogPriority.WARN) { "NSFW extension $pkgName not allowed" }
-            return LoadResult.Error
-        }
 
         val classLoader = try {
             ChildFirstPathClassLoader(appInfo.sourceDir, null, context.classLoader)


### PR DESCRIPTION
## Keep installed NSFW extensions visible when the NSFW toggle is off

Closes #1673

### Problem
Turning off **Settings → Browse → "Show NSFW (18+) sources"** removed *any*
NSFW-flagged extension from the app — including ones the user had already
installed and was actively using. This also silently stopped those
extensions from receiving updates, since they no longer loaded at all.

### Root cause
`ExtensionLoader.loadExtension()` runs once per installed package (at
startup and after install/update) and short-circuited with
`LoadResult.Error` whenever the extension was NSFW-flagged and the
preference was off. That kept the extension out of
`installedExtensionMapFlow` entirely — it never loaded, so it couldn't
appear in the UI or be matched up for updates.

`GetExtensionsByType` additionally filtered the installed list by the same
preference, which would have hidden it from Browse even if it had loaded.

### Fix
The NSFW preference should only gate **discovery of new extensions**, not
access to ones already installed:

- `ExtensionLoader.kt`: removed the early-return that rejected installed
  NSFW extensions during load. `isNsfw` is still computed and passed
  through to `Extension.Installed`, so the flag is preserved for badges/UI
  — the extension just isn't blocked from loading anymore. Removed the now
  unused `SourcePreferences` injection alongside it.
- `GetExtensionsByType.kt`: removed the NSFW filter on the *installed*
  extensions list. The filter on the *available* (not-yet-installed) list
  is untouched, so undiscovered NSFW extensions still stay hidden from
  Browse when the toggle is off.

No changes to the update-checker (`ExtensionManager`) or the network layer
— neither of them filtered by NSFW to begin with, so installed NSFW
extensions were already eligible for update checks; they just couldn't
load in the first place before this fix.

### Behavior after this change
| Scenario | Result |
|---|---|
| Toggle OFF, NSFW extension installed | Stays visible, usable, still updates |
| Toggle OFF, NSFW extension NOT installed | Stays hidden from Browse (unchanged) |
| Toggle ON | Unchanged from current behavior |
| Uninstall an NSFW extension while toggle is OFF | Disappears again (package no longer present, so it's simply not loaded) |
| Fresh install, no extensions installed yet | Nothing to show either way; discovery still hides NSFW (unchanged) |