### PR TITLE
Cancel obsolete reader image requests when views are reused

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ImageRequestLifecycle.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ImageRequestLifecycle.kt
@@ -1,0 +1,35 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import coil3.request.Disposable
+
+/**
+ * Owns the asynchronous image request associated with a reusable reader page view.
+ */
+internal class ImageRequestLifecycle {
+
+    private var generation = 0L
+    private var disposable: Disposable? = null
+
+    fun start(): Long {
+        generation++
+        disposable?.dispose()
+        disposable = null
+        return generation
+    }
+
+    fun track(generation: Long, disposable: Disposable) {
+        if (isCurrent(generation)) {
+            this.disposable = disposable
+        } else {
+            disposable.dispose()
+        }
+    }
+
+    fun isCurrent(generation: Long): Boolean {
+        return generation == this.generation
+    }
+
+    fun dispose() {
+        start()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -68,6 +68,8 @@ open class ReaderPageImageView @JvmOverloads constructor(
 
     private var config: Config? = null
 
+    private val imageRequestLifecycle = ImageRequestLifecycle()
+
     var onImageLoaded: (() -> Unit)? = null
     var onImageLoadError: ((Throwable?) -> Unit)? = null
     var onScaleChanged: ((newScale: Float) -> Unit)? = null
@@ -148,33 +150,38 @@ open class ReaderPageImageView @JvmOverloads constructor(
     }
 
     fun setImage(drawable: Drawable, config: Config) {
+        val requestGeneration = imageRequestLifecycle.start()
         this.config = config
         if (drawable is Animatable) {
             prepareAnimatedImageView()
-            setAnimatedImage(drawable, config)
+            setAnimatedImage(drawable, config, requestGeneration)
         } else {
             prepareNonAnimatedImageView()
-            setNonAnimatedImage(drawable, config)
+            setNonAnimatedImage(drawable, config, requestGeneration)
         }
     }
 
     fun setImage(source: BufferedSource, isAnimated: Boolean, config: Config) {
+        val requestGeneration = imageRequestLifecycle.start()
         this.config = config
         if (isAnimated) {
             prepareAnimatedImageView()
-            setAnimatedImage(source, config)
+            setAnimatedImage(source, config, requestGeneration)
         } else {
             prepareNonAnimatedImageView()
-            setNonAnimatedImage(source, config)
+            setNonAnimatedImage(source, config, requestGeneration)
         }
     }
 
-    fun recycle() = pageView?.let {
-        when (it) {
-            is SubsamplingScaleImageView -> it.recycle()
-            is AppCompatImageView -> it.dispose()
+    fun recycle() {
+        imageRequestLifecycle.dispose()
+        pageView?.let {
+            when (it) {
+                is SubsamplingScaleImageView -> it.recycle()
+                is AppCompatImageView -> it.dispose()
+            }
+            it.isVisible = false
         }
-        it.isVisible = false
     }
 
     /**
@@ -276,6 +283,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     private fun setNonAnimatedImage(
         data: Any,
         config: Config,
+        requestGeneration: Long,
     ) = (pageView as? SubsamplingScaleImageView)?.apply {
         setDoubleTapZoomDuration(config.zoomDuration.getSystemScaledDuration())
         setMinimumScaleType(config.minimumScaleType)
@@ -284,12 +292,14 @@ open class ReaderPageImageView @JvmOverloads constructor(
         setOnImageEventListener(
             object : SubsamplingScaleImageView.DefaultOnImageEventListener() {
                 override fun onReady() {
+                    if (!imageRequestLifecycle.isCurrent(requestGeneration)) return
                     setupZoom(config)
                     if (isVisibleOnScreen()) landscapeZoom(true)
                     this@ReaderPageImageView.onImageLoaded()
                 }
 
                 override fun onImageLoadError(e: Exception) {
+                    if (!imageRequestLifecycle.isCurrent(requestGeneration)) return
                     this@ReaderPageImageView.onImageLoadError(e)
                 }
             },
@@ -314,6 +324,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
                     .diskCachePolicy(CachePolicy.DISABLED)
                     .target(
                         onSuccess = { result ->
+                            if (!imageRequestLifecycle.isCurrent(requestGeneration)) return@target
                             val image = result as BitmapImage
                             setImage(ImageSource.bitmap(image.bitmap))
                             isVisible = true
@@ -321,6 +332,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
                     )
                     .listener(
                         onError = { _, result ->
+                            if (!imageRequestLifecycle.isCurrent(requestGeneration)) return@listener
                             onImageLoadError(result.throwable)
                         },
                     )
@@ -331,6 +343,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
                     .crossfade(false)
                     .build()
                     .let(context.imageLoader::enqueue)
+                    .let { imageRequestLifecycle.track(requestGeneration, it) }
             }
             else -> {
                 throw IllegalArgumentException("Not implemented for class ${data::class.simpleName}")
@@ -380,6 +393,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     private fun setAnimatedImage(
         data: Any,
         config: Config,
+        requestGeneration: Long,
     ) = (pageView as? AppCompatImageView)?.apply {
         if (this is PhotoView) {
             setZoomTransitionDuration(config.zoomDuration.getSystemScaledDuration())
@@ -391,6 +405,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
             .diskCachePolicy(CachePolicy.DISABLED)
             .target(
                 onSuccess = { result ->
+                    if (!imageRequestLifecycle.isCurrent(requestGeneration)) return@target
                     val drawable = result.asDrawable(context.resources)
                     setImageDrawable(drawable)
                     (drawable as? Animatable)?.start()
@@ -400,12 +415,13 @@ open class ReaderPageImageView @JvmOverloads constructor(
             )
             .listener(
                 onError = { _, result ->
+                    if (!imageRequestLifecycle.isCurrent(requestGeneration)) return@listener
                     onImageLoadError(result.throwable)
                 },
             )
             .crossfade(false)
             .build()
-        context.imageLoader.enqueue(request)
+        context.imageLoader.enqueue(request).let { imageRequestLifecycle.track(requestGeneration, it) }
     }
 
     private fun Int.getSystemScaledDuration(): Int {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/ImageRequestLifecycleTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/ImageRequestLifecycleTest.kt
@@ -1,0 +1,50 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import coil3.request.Disposable
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ImageRequestLifecycleTest {
+
+    @Test
+    fun `starting a new request disposes and invalidates the previous request`() {
+        val lifecycle = ImageRequestLifecycle()
+        val firstDisposable = mockk<Disposable>(relaxed = true)
+        val firstGeneration = lifecycle.start()
+        lifecycle.track(firstGeneration, firstDisposable)
+
+        val secondGeneration = lifecycle.start()
+
+        verify(exactly = 1) { firstDisposable.dispose() }
+        assertFalse(lifecycle.isCurrent(firstGeneration))
+        assertTrue(lifecycle.isCurrent(secondGeneration))
+    }
+
+    @Test
+    fun `a request tracked after its view was rebound is disposed immediately`() {
+        val lifecycle = ImageRequestLifecycle()
+        val staleDisposable = mockk<Disposable>(relaxed = true)
+        val staleGeneration = lifecycle.start()
+
+        lifecycle.start()
+        lifecycle.track(staleGeneration, staleDisposable)
+
+        verify(exactly = 1) { staleDisposable.dispose() }
+    }
+
+    @Test
+    fun `recycling the view disposes the request and invalidates its callbacks`() {
+        val lifecycle = ImageRequestLifecycle()
+        val disposable = mockk<Disposable>(relaxed = true)
+        val generation = lifecycle.start()
+        lifecycle.track(generation, disposable)
+
+        lifecycle.dispose()
+
+        verify(exactly = 1) { disposable.dispose() }
+        assertFalse(lifecycle.isCurrent(generation))
+    }
+}


### PR DESCRIPTION
## Summary

- retain and cancel the image request owned by each reusable reader page view
- ignore success and error results from requests that no longer belong to the view
- cover request replacement and view recycling with focused unit tests

## Problem

The Long strip reader reuses the same page view for different pages while scrolling. An image request started for the previous page can still be running when that view is assigned to another page.

`ImageLoader.enqueue()` returns a `Disposable` that can cancel the work, but `ReaderPageImageView` currently discards it. Cancelling the holder's surrounding job therefore does not explicitly cancel the image request itself.

This creates a path where an old success or error result can arrive after the view has been reused.

## Change

`ReaderPageImageView` now owns its active image request and cancels it before starting another request or recycling the view.

Each request also captures a monotonically increasing generation number. Callbacks return without changing the view when that number is no longer current. The generation check covers the small window where cancellation happens after a result has already been scheduled for delivery.

This applies to both animated and non-animated image requests. No visual behavior is intentionally changed.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :app:testDebugUnitTest`
- focused tests verify that replacing a request cancels the previous request, late tracking is rejected, and recycling cancels the request and invalidates its callbacks
- exercised on an Android 16 device with a 40-page local Long strip fixture, including 24 rapid scrolls down and 24 back up; no blank or Retry view appeared

The same controlled fixture also completed on the unchanged build because the timing problem is intermittent. This PR does not claim that every blank-page report has this cause; it enforces the narrower rule that a request for an old page must not update a view that now represents another page.
