### PR TITLE
Allow reader Retry after image decode failures

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -118,9 +118,7 @@ internal class HttpPageLoader(
      * Retries a page. This method is only called from user interaction on the viewer.
      */
     override fun retryPage(page: ReaderPage) {
-        if (page.status is Page.State.Error) {
-            page.status = Page.State.Queue
-        }
+        page.status = Page.State.Queue
         queue.offer(PriorityPage(page, PriorityPage.RETRY))
     }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoaderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoaderTest.kt
@@ -1,0 +1,36 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import eu.kanade.tachiyomi.data.cache.ChapterCache
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import okhttp3.Response
+import org.junit.jupiter.api.Test
+
+class HttpPageLoaderTest {
+
+    @Test
+    fun `retry reloads a ready page after an image decoding failure`() {
+        val chapter = mockk<ReaderChapter>(relaxed = true)
+        val source = mockk<HttpSource>()
+        val chapterCache = mockk<ChapterCache>(relaxed = true)
+        val response = mockk<Response>(relaxed = true)
+        val page = ReaderPage(index = 0, imageUrl = "https://example.com/page.jpg").apply {
+            status = Page.State.Ready
+        }
+        val loader = HttpPageLoader(chapter, source, chapterCache)
+        coEvery { source.getImage(page) } returns response
+
+        try {
+            loader.retryPage(page)
+
+            coVerify(timeout = 5_000, exactly = 1) { source.getImage(page) }
+        } finally {
+            loader.recycle()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- always return a reader page to the queue when the user presses Retry
- cover the ready-page case with a focused unit test

## Problem

A page can finish downloading and enter `Page.State.Ready`, then fail while the reader is decoding or displaying its image.

`HttpPageLoader.retryPage()` currently changes the page back to `Queue` only when its state is `Error`. For a display failure on an otherwise ready page, Retry adds the page to the priority queue without changing it back to a loadable state. The loader can then skip the new image request.

## Change

Retry now unconditionally sets the selected page to `Page.State.Queue` before placing it in the retry queue.

The method is only called from the reader's explicit Retry action, so this keeps the existing forced-reload behavior while also covering failures that happen after the download was marked ready.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :app:testDebugUnitTest`
- focused test starts with a ready page, calls Retry, and verifies that the source is asked for the image again

No reader UI or normal page-loading behavior is changed.
