### PR TITLE
Fix: Local source filtering

### DIFF
--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -739,6 +739,7 @@
     <string name="unknown_author">Unknown author</string>
     <string name="author">Author</string>
     <string name="artist">Artist</string>
+    <string name="genre">Genre</string>
     <!-- reserved for #6163 -->
     <string name="unknown_status">Unknown status</string>
     <string name="licensed">Licensed</string>

--- a/source-local/src/main/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/main/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.UnmeteredSource
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -35,7 +36,11 @@ import tachiyomi.core.metadata.tachiyomi.MangaDetails
 import tachiyomi.domain.chapter.service.ChapterRecognition
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
+import tachiyomi.source.local.filter.ArtistFilter
+import tachiyomi.source.local.filter.AuthorFilter
+import tachiyomi.source.local.filter.GenreFilter
 import tachiyomi.source.local.filter.OrderBy
+import tachiyomi.source.local.filter.StatusFilter
 import tachiyomi.source.local.image.LocalCoverManager
 import tachiyomi.source.local.io.Archive
 import tachiyomi.source.local.io.Format
@@ -84,19 +89,68 @@ class LocalSource(
             0L
         }
 
+        var authorFilter = ""
+        var artistFilter = ""
+        var genreFilter = ""
+        var statusFilter = StatusFilter.ANY
+
+        filters.forEach { filter ->
+            when (filter) {
+                is AuthorFilter -> authorFilter = filter.state.trim()
+                is ArtistFilter -> artistFilter = filter.state.trim()
+                is GenreFilter -> genreFilter = filter.state.trim()
+                is StatusFilter -> statusFilter = StatusFilter.statusFor(filter.state)
+                else -> { /* Do nothing */ }
+            }
+        }
+
+        val genreTerms = genreFilter.split(',')
+            .map { it.trim() }
+            .filterNot { it.isBlank() }
+
+        // Only pay the cost of reading each manga's metadata file when it's actually needed
+        // to answer the query, i.e. plain browsing keeps the previous, cheap behavior.
+        val needsMetadata = query.isNotBlank() ||
+            authorFilter.isNotBlank() ||
+            artistFilter.isNotBlank() ||
+            genreTerms.isNotEmpty() ||
+            statusFilter != StatusFilter.ANY
+
         var mangaDirs = fileSystem.getFilesInBaseDirectory()
             // Filter out files that are hidden and is not a folder
             .filter { it.isDirectory && !it.name.orEmpty().startsWith('.') }
             .distinctBy { it.name }
-            .filter {
-                if (lastModifiedLimit == 0L && query.isBlank()) {
-                    true
-                } else if (lastModifiedLimit == 0L) {
-                    it.name.orEmpty().contains(query, ignoreCase = true)
-                } else {
-                    it.lastModified() >= lastModifiedLimit
-                }
+            .filter { lastModifiedLimit == 0L || it.lastModified() >= lastModifiedLimit }
+
+        if (needsMetadata) {
+            val metadataByDir = mangaDirs
+                .map { mangaDir -> async { mangaDir to getMetadataForFiltering(mangaDir) } }
+                .awaitAll()
+                .toMap()
+
+            mangaDirs = mangaDirs.filter { mangaDir ->
+                val metadata = metadataByDir[mangaDir]
+
+                val matchesQuery = query.isBlank() ||
+                    mangaDir.name.orEmpty().contains(query, ignoreCase = true) ||
+                    metadata.matchesText(query)
+
+                val matchesAuthor = authorFilter.isBlank() ||
+                    metadata?.author.orEmpty().contains(authorFilter, ignoreCase = true)
+
+                val matchesArtist = artistFilter.isBlank() ||
+                    metadata?.artist.orEmpty().contains(artistFilter, ignoreCase = true)
+
+                val matchesGenre = genreTerms.isEmpty() ||
+                    genreTerms.all { term ->
+                        metadata?.genres.orEmpty().any { it.contains(term, ignoreCase = true) }
+                    }
+
+                val matchesStatus = statusFilter == StatusFilter.ANY || metadata?.status == statusFilter
+
+                matchesQuery && matchesAuthor && matchesArtist && matchesGenre && matchesStatus
             }
+        }
 
         filters.forEach { filter ->
             when (filter) {
@@ -264,6 +318,55 @@ class LocalSource(
         comicInfo.translator?.let { chapter.scanlator = it.value }
     }
 
+    /**
+     * Lightweight metadata used only for filtering/searching the browse list. Read from the
+     * top-level ComicInfo.xml if present, falling back to the legacy details.json. Returns
+     * null when neither file exists or it fails to parse.
+     */
+    private fun getMetadataForFiltering(mangaDir: UniFile): LocalMangaMetadata? {
+        return try {
+            val mangaDirFiles = mangaDir.listFiles().orEmpty()
+            val comicInfoFile = mangaDirFiles.firstOrNull { it.name == COMIC_INFO_FILE }
+            val legacyJsonDetailsFile = mangaDirFiles.firstOrNull { it.extension == "json" }
+
+            when {
+                comicInfoFile != null -> {
+                    val comicInfo = parseComicInfo(comicInfoFile.openInputStream())
+                    val temp = SManga.create().apply { copyFromComicInfo(comicInfo) }
+                    LocalMangaMetadata(
+                        author = temp.author,
+                        artist = temp.artist,
+                        description = temp.description,
+                        genres = temp.getGenres().orEmpty(),
+                        status = temp.status,
+                    )
+                }
+                legacyJsonDetailsFile != null -> {
+                    val details = json.decodeFromStream<MangaDetails>(legacyJsonDetailsFile.openInputStream())
+                    LocalMangaMetadata(
+                        author = details.author,
+                        artist = details.artist,
+                        description = details.description,
+                        genres = details.genre.orEmpty(),
+                        status = details.status ?: SManga.UNKNOWN,
+                    )
+                }
+                else -> null
+            }
+        } catch (e: Throwable) {
+            logcat(LogPriority.ERROR, e) { "Error reading local metadata for filtering: ${mangaDir.name}" }
+            null
+        }
+    }
+
+    private fun LocalMangaMetadata?.matchesText(text: String): Boolean {
+        if (this == null) return false
+        return author.orEmpty().contains(text, ignoreCase = true) ||
+            artist.orEmpty().contains(text, ignoreCase = true) ||
+            description.orEmpty().contains(text, ignoreCase = true) ||
+            genres.any { it.contains(text, ignoreCase = true) }
+    }
+
     // Chapters
     private suspend fun getChapterList(manga: SManga): List<SChapter> = withIOContext {
         val chapters = fileSystem.getFilesInMangaDirectory(manga.url)
@@ -310,7 +413,14 @@ class LocalSource(
     }
 
     // Filters
-    override fun getFilterList() = FilterList(OrderBy.Popular(context))
+    override fun getFilterList() = FilterList(
+        OrderBy.Popular(context),
+        Filter.Separator(),
+        AuthorFilter(context),
+        ArtistFilter(context),
+        GenreFilter(context),
+        StatusFilter(context),
+    )
 
     // Unused stuff
     override suspend fun getPageList(chapter: SChapter): List<Page> = throw UnsupportedOperationException("Unused")
@@ -378,6 +488,18 @@ class LocalSource(
         private val LATEST_THRESHOLD = 7.days.inWholeMilliseconds
     }
 }
+
+/**
+ * Metadata parsed from a local manga's ComicInfo.xml or legacy details.json, used purely to
+ * support filtering/searching in [LocalSource.getSearchManga].
+ */
+private data class LocalMangaMetadata(
+    val author: String?,
+    val artist: String?,
+    val description: String?,
+    val genres: List<String>,
+    val status: Int,
+)
 
 fun Manga.isLocal(): Boolean = source == LocalSource.ID
 

--- a/source-local/src/main/kotlin/tachiyomi/source/local/filter/MetadataFilters.kt
+++ b/source-local/src/main/kotlin/tachiyomi/source/local/filter/MetadataFilters.kt
@@ -1,0 +1,62 @@
+package tachiyomi.source.local.filter
+
+import android.content.Context
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.SManga
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+
+/**
+ * Free-text filter matched case-insensitively against the author parsed from a local manga's
+ * ComicInfo.xml (or legacy details.json).
+ */
+class AuthorFilter(context: Context) : Filter.Text(context.stringResource(MR.strings.author))
+
+/**
+ * Free-text filter matched case-insensitively against the artist parsed from a local manga's
+ * ComicInfo.xml (or legacy details.json).
+ */
+class ArtistFilter(context: Context) : Filter.Text(context.stringResource(MR.strings.artist))
+
+/**
+ * Free-text filter matched against the genres parsed from a local manga's ComicInfo.xml (or
+ * legacy details.json). Accepts a comma-separated list of terms; a manga must match every term
+ * (logical AND) to be included.
+ */
+class GenreFilter(context: Context) : Filter.Text(context.stringResource(MR.strings.genre))
+
+/**
+ * Restricts results to local manga whose parsed publishing status matches the selection.
+ */
+class StatusFilter(context: Context) : Filter.Select<String>(
+    context.stringResource(MR.strings.status),
+    arrayOf(
+        context.stringResource(MR.strings.all),
+        context.stringResource(MR.strings.unknown),
+        context.stringResource(MR.strings.ongoing),
+        context.stringResource(MR.strings.completed),
+        context.stringResource(MR.strings.licensed),
+        context.stringResource(MR.strings.publishing_finished),
+        context.stringResource(MR.strings.cancelled),
+        context.stringResource(MR.strings.on_hiatus),
+    ),
+) {
+    companion object {
+        /** Sentinel meaning "no status restriction" (the "All" option). */
+        const val ANY = Int.MIN_VALUE
+
+        // Index in the dropdown above -> SManga status constant.
+        private val STATUSES = intArrayOf(
+            ANY,
+            SManga.UNKNOWN,
+            SManga.ONGOING,
+            SManga.COMPLETED,
+            SManga.LICENSED,
+            SManga.PUBLISHING_FINISHED,
+            SManga.CANCELLED,
+            SManga.ON_HIATUS,
+        )
+
+        fun statusFor(selectedIndex: Int): Int = STATUSES.getOrElse(selectedIndex) { ANY }
+    }
+}


### PR DESCRIPTION
The local source didn't use any metadata from ComicInfo.xml (or the legacy details.json) when browsing/searching. Only the folder name was searchable, so tags like `genre`, `author`, `artist`, and `publishing status` were effectively write-only.

This adds:
- New filters in the local source's filter sheet: **Author**, **Artist**, and **Genre** (free-text, genre supports comma-separated terms matched with AND logic), and **Status** (dropdown matching the six ComicInfo publishing statuses).
- The existing search box now also matches against author, artist, description, and genre pulled from metadata, not just the folder name.

Metadata is parsed from each manga's top-level `ComicInfo.xml`, falling back to the legacy `details.json` if that's what a given manga folder has (read in parallel across the library, and only when a filter/query is actually active, so plain browsing with no filters is unaffected performance-wise).

**For visibility**: I'm aware of #437, which tackles this alongside broader indexing/performance work. This PR is a narrower, immediately mergeable fix for the search/filter bug specifically (#397), not a replacement for that effort.

Closes #397

## Testing / self-review

- Tested against a local library in the emulator with manga folders containing `ComicInfo.xml` files covering different genres/authors/status values; confirmed each filter narrows results correctly, and that they combine (e.g. genre + status together).
- Self-reviewed the diff.
- No new UI was introduced. The new filters reuse the existing `Filter.Text`/`Filter.Select` components already used by other sources, so they render through the app's existing filter sheet and pick up theming/tablet layout for free. Nothing to check there beyond confirming the sheet still displays correctly, which it does.