### PR TITLE
Fix: Include local source in Global Search results

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
@@ -27,6 +27,7 @@ import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.concurrent.Executors
@@ -91,7 +92,7 @@ abstract class SearchViewModel(
 
     open fun getEnabledSources(): List<Source> {
         return sourceManager.getAll()
-            .filter { it.lang in enabledLanguages && "${it.id}" !in disabledSources }
+            .filter { (it.lang in enabledLanguages || it.isLocal()) && "${it.id}" !in disabledSources }
             .sortedWith(
                 compareBy(
                     { "${it.id}" !in pinnedSources },


### PR DESCRIPTION
## Summary

Local source manga were missing from Global Search results, even with the "All" source filter selected (not just "Pinned").

**Root cause**: `SearchViewModel.getEnabledSources()` filters candidate sources by `it.lang in enabledLanguages`. Local source uses the sentinel language code `"other"`, which isn't part of a user's enabled-languages set by default (and isn't a real language a user would opt into). 
Every other place in the app that builds an enabled-sources list already accounts for this. `GetEnabledSources.kt` explicitly does `it.lang in enabledLanguages || it.isLocal()`; but `SearchViewModel`'s own copy of that filter was missing the same exception, so Local source was silently excluded from every Global Search query.

**Fix**: add the same `|| it.isLocal()` exception used elsewhere, so Local source is always eligible for Global Search regardless of language settings, consistent with how it behaves in the rest of the app.

Closes #3783 

## Testing / self-review

- Reproduced: querying Global Search for a local manga's author returned no results with "All" sources selected.
- Confirmed the fix resolves it in the emulator. The same query now returns the local manga.
- Self-reviewed the diff; checked the other `getEnabledSources()` override (`MigrateSearchViewModel`) to confirm it's driven by a different preference entirely and isn't affected by this bug.
