### PR TITLE
Add score info to MangaUpdates search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Show updates and upcoming filter icon as active for categories ([@Secozzi](https://github.com/Secozzi)) ([#3772](https://github.com/mihonapp/mihon/pull/3772))
+- Show scores in MangaUpdates search results (and authors for `id:` prefix searches) ([@MajorTanya](https://github.com/MajorTanya)) ([#3795](https://github.com/mihonapp/mihon/pull/3795))
 
 ### Fixed
 - Fixed app and extension update check running again on configuration change ([@AntsyLich](https://github.com/AntsyLich)) ([#3708](https://github.com/mihonapp/mihon/pull/3708))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MUAuthor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MUAuthor.kt
@@ -1,0 +1,9 @@
+package eu.kanade.tachiyomi.data.track.mangaupdates.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MUAuthor(
+    val name: String,
+    val type: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
@@ -21,6 +21,7 @@ data class MURecord(
     val ratingVotes: Int? = null,
     @SerialName("latest_chapter")
     val latestChapter: Int? = null,
+    val authors: List<MUAuthor> = emptyList(),
 )
 
 fun MURecord.toTrackSearch(id: Long): TrackSearch {
@@ -34,5 +35,8 @@ fun MURecord.toTrackSearch(id: Long): TrackSearch {
         publishing_status = ""
         publishing_type = this@toTrackSearch.type.toString()
         start_date = this@toTrackSearch.year.toString()
+        score = this@toTrackSearch.bayesianRating?.takeIf { it > 0 } ?: -1.0
+        authors = this@toTrackSearch.authors.filter { it.type == "Author" }.map { it.name }
+        artists = this@toTrackSearch.authors.filter { it.type == "Artist" }.map { it.name }
     }
 }


### PR DESCRIPTION
Also added author info for `id:` prefix search results since those hit the single-series endpoint instead of `/search`, which does not include author information (I wish it did).

Maybe unintuitive but the info is nice to have when available.