### PR TITLE
History tab list always resume from last page

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -255,6 +255,10 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_mark_duplicate_read_chapter_read),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.historyResumeLastPage,
+                    title = stringResource(MR.strings.pref_history_resume_last_page),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
                     preference = libraryPreferences.hideMissingChapters,
                     title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
                 ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -71,7 +71,7 @@ data object HistoryTab : Tab {
             snackbarHostState = snackbarHostState,
             onSearchQueryChange = viewModel::updateSearchQuery,
             onClickCover = { navigator.push(MangaScreen(it)) },
-            onClickResume = viewModel::getNextChapterForManga,
+            onClickResume = viewModel::resume,
             onDialogChange = viewModel::setDialog,
             onClickFavorite = viewModel::addFavorite,
         )
@@ -140,7 +140,7 @@ data object HistoryTab : Tab {
                         snackbarHostState.showSnackbar(context.stringResource(MR.strings.internal_error))
                     HistoryViewModel.Event.HistoryCleared ->
                         snackbarHostState.showSnackbar(context.stringResource(MR.strings.clear_history_completed))
-                    is HistoryViewModel.Event.OpenChapter -> openChapter(context, e.chapter)
+                    is HistoryViewModel.Event.OpenChapter -> openChapter(context, e.chapter, e.page)
                 }
             }
         }
@@ -152,9 +152,9 @@ data object HistoryTab : Tab {
         }
     }
 
-    private suspend fun openChapter(context: Context, chapter: Chapter?) {
+    private suspend fun openChapter(context: Context, chapter: Chapter?, page: Int? = null) {
         if (chapter != null) {
-            val intent = ReaderActivity.newIntent(context, chapter.mangaId, chapter.id)
+            val intent = ReaderActivity.newIntent(context, chapter.mangaId, chapter.id, page)
             context.startActivity(intent)
         } else {
             snackbarHostState.showSnackbar(context.stringResource(MR.strings.no_next_chapter))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryViewModel.kt
@@ -40,6 +40,7 @@ import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.category.interactor.SetMangaCategories
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.history.interactor.GetHistory
 import tachiyomi.domain.history.interactor.GetNextChapters
@@ -59,6 +60,7 @@ import kotlin.time.Duration.Companion.seconds
 class HistoryViewModel(
     private val addTracks: AddTracks,
     private val getCategories: GetCategories,
+    private val getChapter: GetChapter,
     private val getDuplicateLibraryManga: GetDuplicateLibraryManga,
     private val getHistory: GetHistory,
     private val getManga: GetManga,
@@ -118,15 +120,17 @@ class HistoryViewModel(
         return withIOContext { getNextChapters.await(onlyUnread = false).firstOrNull() }
     }
 
-    fun getNextChapterForManga(mangaId: Long, chapterId: Long) {
+    fun resume(mangaId: Long, chapterId: Long) {
         viewModelScope.launchIO {
-            sendNextChapterEvent(getNextChapters.await(mangaId, chapterId, onlyUnread = false))
+            if (libraryPreferences.historyResumeLastPage.get()) {
+                getChapter.await(chapterId)?.let {
+                    _events.send(Event.OpenChapter(it, it.lastPageRead.toInt()))
+                }
+            } else {
+                val chapter = getNextChapters.await(mangaId, chapterId, onlyUnread = false).firstOrNull()
+                _events.send(Event.OpenChapter(chapter))
+            }
         }
-    }
-
-    private suspend fun sendNextChapterEvent(chapters: List<Chapter>) {
-        val chapter = chapters.firstOrNull()
-        _events.send(Event.OpenChapter(chapter))
     }
 
     fun removeFromHistory(history: HistoryWithRelations) {
@@ -272,7 +276,7 @@ class HistoryViewModel(
     }
 
     sealed interface Event {
-        data class OpenChapter(val chapter: Chapter?) : Event
+        data class OpenChapter(val chapter: Chapter?, val page: Int? = null) : Event
         data object InternalError : Event
         data object HistoryCleared : Event
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -113,10 +113,11 @@ class ReaderActivity : BaseActivity() {
     private val graph: AppGraph by lazy { metroGraph() }
 
     companion object {
-        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?): Intent {
+        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, page: Int? = null): Intent {
             return Intent(context, ReaderActivity::class.java).apply {
                 putExtra("manga", mangaId)
                 putExtra("chapter", chapterId)
+                putExtra("page", page)
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -143,6 +143,7 @@ class ReaderViewModel(
      */
     val mangaId = savedState.get<Long>("manga") ?: -1L
     private val initialChapterId = savedState.get<Long>("chapter") ?: -1L
+    private val initialPage = savedState.get<Int>("page")
 
     val hasValidArgs = mangaId != -1L && initialChapterId != -1L
 
@@ -323,7 +324,7 @@ class ReaderViewModel(
                 val source = sourceManager.getOrStub(manga.source)
                 loader = ChapterLoader(context, downloadManager, downloadProvider, chapterCache, manga, source)
 
-                loadChapter(loader!!, chapterList.first { chapterId == it.chapter.id })
+                loadChapter(loader!!, chapterList.first { chapterId == it.chapter.id }, initialPage)
             } catch (e: Throwable) {
                 if (e is CancellationException) {
                     throw e
@@ -340,8 +341,9 @@ class ReaderViewModel(
     private suspend fun loadChapter(
         loader: ChapterLoader,
         chapter: ReaderChapter,
+        page: Int? = null,
     ): ViewerChapters {
-        loader.loadChapter(chapter)
+        loader.loadChapter(chapter, page)
 
         val chapterPos = chapterList.indexOf(chapter)
         val newChapters = ViewerChapters(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -34,7 +34,7 @@ class ChapterLoader(
      * Assigns the chapter's page loader and loads the its pages. Returns immediately if the chapter
      * is already loaded.
      */
-    suspend fun loadChapter(chapter: ReaderChapter) {
+    suspend fun loadChapter(chapter: ReaderChapter, page: Int? = null) {
         if (chapterIsReady(chapter)) {
             return
         }
@@ -55,8 +55,9 @@ class ChapterLoader(
 
                 // If the chapter is partially read, set the starting page to the last the user read
                 // otherwise use the requested page.
-                if (!chapter.chapter.read) {
-                    chapter.requestedPage = chapter.chapter.last_page_read
+                when {
+                    page != null -> chapter.requestedPage = page
+                    !chapter.chapter.read -> chapter.requestedPage = chapter.chapter.last_page_read
                 }
 
                 chapter.state = ReaderChapter.State.Loaded(pages)

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -71,6 +71,8 @@ class LibraryPreferences(
         emptySet(),
     )
 
+    val historyResumeLastPage: Preference<Boolean> = preferenceStore.getBoolean("pref_history_resume_last_page", true)
+
     // region Filter
 
     val filterDownloaded: Preference<TriState> = preferenceStore.getEnum(

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -321,6 +321,8 @@
     <string name="pref_mark_duplicate_read_chapter_read_existing">After reading a chapter</string>
     <string name="pref_mark_duplicate_read_chapter_read_new">After fetching new chapter</string>
 
+    <string name="pref_history_resume_last_page">History always resume from last page</string>
+
     <string name="pref_hide_missing_chapter_indicators">Hide missing chapter indicators</string>
     <string name="pref_disallow_non_ascii_filenames">Disallow non-ASCII filenames</string>
     <string name="pref_disallow_non_ascii_filenames_details">Ensures compatibility with certain storage media that don't support Unicode. When this is enabled, you'll need to manually rename source and manga folders by replacing non-ASCII characters with their lowercase UTF-8 hexadecimal representations. Chapter files don't need to be renamed.</string>


### PR DESCRIPTION
Currently when selecting an entry on the history tab:
if not complete: loads the last read page
if complete: loads the next chapter if there is a next chapter, otherwise doesn't open anything

Because the entry says the last chapter, it's expected to load that chapter.

This changes the default behavior to always go to the last page read, even if it's complete.
There is an option to change it to the old behavior under Library > Behavior.

The history tab button behavior is unchanged.