### PR TITLE
Per page progress sync to Komga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/Komga.kt
@@ -79,6 +79,14 @@ class Komga(id: Long) : BaseTracker(id, "Komga"), EnhancedTracker {
         return track
     }
 
+    /**
+     * Page-level progress side channel (ADR-0001), independent of the chapter-level
+     * [update]/[refresh] flow above.
+     */
+    suspend fun pullBookReadProgress(bookUrl: String): KomgaBookProgress = api.getBookReadProgress(bookUrl)
+
+    suspend fun pushBookReadProgress(bookUrl: String, page: Int) = api.updateBookReadProgress(bookUrl, page)
+
     override suspend fun login(username: String, password: String) {
         saveCredentials("user", "pass")
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -80,6 +80,45 @@ class KomgaApi(
             }
         }
 
+    /**
+     * Pulls the per-book page-level read progress for the book at [bookUrl] (distinct from the
+     * series-level [getTrackSearch]/[updateProgress] pair above). Preserves "no progress
+     * recorded" as [KomgaBookProgress.Absent], distinct from a genuinely-zero page.
+     *
+     * Converts Komga's 1-indexed page to Mihon's 0-indexed convention.
+     */
+    suspend fun getBookReadProgress(bookUrl: String): KomgaBookProgress =
+        withIOContext {
+            val readProgress = client.newCall(GET(bookUrl, headers))
+                .awaitSuccess()
+                .let { with(json) { it.parseAs<BookDto>() } }
+                .readProgress
+
+            if (readProgress == null) {
+                KomgaBookProgress.Absent
+            } else {
+                KomgaBookProgress.Recorded(readProgress.page - 1)
+            }
+        }
+
+    /**
+     * Pushes the current [page] for the book at [bookUrl] via Komga's per-book read-progress
+     * endpoint, converting from Mihon's 0-indexed page to Komga's 1-indexed format.
+     */
+    suspend fun updateBookReadProgress(bookUrl: String, page: Int) {
+        withIOContext {
+            val payload = json.encodeToString(BookReadProgressUpdateDto(page = page + 1, completed = false))
+            client.newCall(
+                Request.Builder()
+                    .url("$bookUrl/read-progress")
+                    .headers(headers)
+                    .patch(payload.toRequestBody("application/json".toMediaType()))
+                    .build(),
+            )
+                .awaitSuccess()
+        }
+    }
+
     suspend fun updateProgress(track: Track): Track {
         val payload = if (track.tracking_url.contains("/api/v1/series/")) {
             json.encodeToString(ReadProgressUpdateV2Dto(track.last_chapter_read))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
@@ -105,3 +105,29 @@ data class ReadProgressV2Dto(
     val lastReadContinuousNumberSort: Double,
     val maxNumberSort: Float,
 )
+
+@Serializable
+data class BookDto(
+    val readProgress: BookReadProgressDto? = null,
+)
+
+@Serializable
+data class BookReadProgressDto(
+    val page: Int,
+    val completed: Boolean,
+)
+
+@Serializable
+data class BookReadProgressUpdateDto(
+    val page: Int,
+    val completed: Boolean,
+)
+
+/**
+ * Result of a page-level read-progress pull for a single book. [Absent] means Komga has no
+ * progress recorded (e.g. after being marked unread), distinct from [Recorded] at page 0.
+ */
+sealed interface KomgaBookProgress {
+    data class Recorded(val page: Int) : KomgaBookProgress
+    data object Absent : KomgaBookProgress
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaPageProgress.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaPageProgress.kt
@@ -1,0 +1,43 @@
+package eu.kanade.tachiyomi.data.track.komga
+
+/** Outcome of a chapter-open pull, adding [Failure] to the raw [KomgaBookProgress]. */
+sealed interface KomgaPullResult {
+    data class Recorded(val page: Int) : KomgaPullResult
+    data object Absent : KomgaPullResult
+    data object Failure : KomgaPullResult
+}
+
+/** What the reader should do once a chapter-open pull resolves. */
+sealed interface ReconciliationAction {
+    data object NoOp : ReconciliationAction
+    data class JumpTo(val page: Int) : ReconciliationAction
+    data object Reset : ReconciliationAction
+}
+
+/**
+ * Reconciliation only jumps forward: remote wins only when it's strictly ahead of [currentPage].
+ * Absent remote progress is an explicit reset. A hard pull failure is a no-op.
+ */
+fun reconcile(currentPage: Int, pullResult: KomgaPullResult): ReconciliationAction = when (pullResult) {
+    is KomgaPullResult.Recorded -> if (pullResult.page > currentPage) {
+        ReconciliationAction.JumpTo(pullResult.page)
+    } else {
+        ReconciliationAction.NoOp
+    }
+    KomgaPullResult.Absent -> ReconciliationAction.Reset
+    KomgaPullResult.Failure -> ReconciliationAction.NoOp
+}
+
+/**
+ * Push suppression for a single chapter-viewing session. New sessions start suppressed;
+ * [onPullResolved] lifts suppression unless the pull hard-failed.
+ */
+class KomgaChapterSession {
+    var isPushSuppressed = true
+        private set
+
+    fun onPullResolved(result: KomgaPullResult, currentPage: Int): ReconciliationAction {
+        isPushSuppressed = result is KomgaPullResult.Failure
+        return reconcile(currentPage, result)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -138,6 +138,7 @@ class ReaderActivity : BaseActivity() {
 
     private var menuToggleToast: Toast? = null
     private var readingModeToast: Toast? = null
+    private var komgaSyncToast: Toast? = null
     private val displayRefreshHost = DisplayRefreshHost()
 
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
@@ -247,6 +248,13 @@ class ReaderActivity : BaseActivity() {
                     is ReaderViewModel.Event.SetCoverResult -> {
                         onSetAsCoverResult(event.result)
                     }
+                    is ReaderViewModel.Event.KomgaProgressSynced -> {
+                        moveToPageIndex(event.page)
+                        if (event.showToast) {
+                            komgaSyncToast?.cancel()
+                            komgaSyncToast = toast(MR.strings.komga_synced_progress)
+                        }
+                    }
                 }
             }
             .launchIn(lifecycleScope)
@@ -348,6 +356,7 @@ class ReaderActivity : BaseActivity() {
         config = null
         menuToggleToast?.cancel()
         readingModeToast?.cancel()
+        komgaSyncToast?.cancel()
     }
 
     override fun onPause() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.net.Uri
 import androidx.annotation.IntRange
 import androidx.compose.runtime.Immutable
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.createSavedStateHandle
@@ -35,6 +38,11 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.saver.Image
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.saver.Location
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.komga.KomgaBookProgress
+import eu.kanade.tachiyomi.data.track.komga.KomgaChapterSession
+import eu.kanade.tachiyomi.data.track.komga.KomgaPullResult
+import eu.kanade.tachiyomi.data.track.komga.ReconciliationAction
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.loader.ChapterLoader
@@ -55,9 +63,12 @@ import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -87,11 +98,18 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.track.interactor.GetTracks
 import tachiyomi.source.local.image.LocalCoverManager
 import tachiyomi.source.local.isLocal
 import java.util.Date
 import kotlin.getValue
 import kotlin.time.Clock
+
+/** How long to wait for more page changes before pushing Komga page-level progress. */
+private const val KOMGA_PUSH_DEBOUNCE_MILLIS = 3000L
+
+/** A pending Komga page-level push, tagged with the chapter session it belongs to. */
+private data class KomgaPushRequest(val bookUrl: String, val page: Int, val session: KomgaChapterSession)
 
 /**
  * Presenter used by the activity to perform background operations.
@@ -109,6 +127,8 @@ class ReaderViewModel(
     private val downloadPreferences: DownloadPreferences,
     private val trackPreferences: TrackPreferences,
     private val trackChapter: TrackChapter,
+    private val trackerManager: TrackerManager,
+    private val getTracks: GetTracks,
     private val getManga: GetManga,
     private val getChaptersByMangaId: GetChaptersByMangaId,
     private val getNextChapters: GetNextChapters,
@@ -268,6 +288,19 @@ class ReaderViewModel(
     private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading.get()
 
+    // Komga page-level progress side channel (ADR-0001).
+    private var komgaTrackingEnabled = false
+    private var komgaSession = KomgaChapterSession()
+    private val komgaPushRequests = MutableSharedFlow<KomgaPushRequest>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    private val komgaLifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStop(owner: LifecycleOwner) {
+            flushKomgaPush()
+        }
+    }
+
     init {
         // To save state
         state.map { it.viewerChapters?.currChapter }
@@ -284,6 +317,14 @@ class ReaderViewModel(
             }
             .launchIn(viewModelScope)
 
+        komgaPushRequests
+            .debounce(KOMGA_PUSH_DEBOUNCE_MILLIS)
+            .onEach { pushKomgaProgress(it.bookUrl, it.page, it.session) }
+            .launchIn(viewModelScope)
+
+        // Backgrounding the app should still flush the last page immediately.
+        ProcessLifecycleOwner.get().lifecycle.addObserver(komgaLifecycleObserver)
+
         if (hasValidArgs) {
             viewModelScope.launch { init() }
         }
@@ -297,13 +338,16 @@ class ReaderViewModel(
                 downloadManager.addDownloadsToStartOfQueue(listOf(it))
             }
         }
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(komgaLifecycleObserver)
     }
 
     /**
      * Called when the user pressed the back button and is going to leave the reader. Used to
-     * trigger deletion of the downloaded chapters.
+     * trigger deletion of the downloaded chapters and to flush the last Komga page-level push
+     * (must happen here, not in [onCleared], since [viewModelScope] is cancelled before that runs).
      */
     fun onActivityFinish() {
+        flushKomgaPush()
         deletePendingChapters()
     }
 
@@ -319,6 +363,9 @@ class ReaderViewModel(
                 sourceManager.isInitialized.first { it }
                 mutableState.update { it.copy(manga = manga) }
                 if (chapterId == -1L) chapterId = initialChapterId
+
+                komgaTrackingEnabled = trackerManager.komga.isLoggedIn &&
+                    getTracks.await(manga.id).any { it.trackerId == trackerManager.komga.id }
 
                 val source = sourceManager.getOrStub(manga.source)
                 loader = ChapterLoader(context, downloadManager, downloadProvider, chapterCache, manga, source)
@@ -341,6 +388,12 @@ class ReaderViewModel(
         loader: ChapterLoader,
         chapter: ReaderChapter,
     ): ViewerChapters {
+        val previousChapter = state.value.viewerChapters?.currChapter
+        if (previousChapter != null && previousChapter.chapter.id != chapter.chapter.id) {
+            // Captured before startKomgaPull below replaces komgaSession for the incoming chapter.
+            flushKomgaPush(previousChapter, komgaSession)
+        }
+
         loader.loadChapter(chapter)
 
         val chapterPos = chapterList.indexOf(chapter)
@@ -363,6 +416,9 @@ class ReaderViewModel(
                 )
             }
         }
+
+        startKomgaPull(chapter)
+
         return newChapters
     }
 
@@ -572,6 +628,7 @@ class ReaderViewModel(
 
         if (!incognitoMode && page.status !is Page.State.Error) {
             readerChapter.chapter.last_page_read = pageIndex
+            requestKomgaPush(readerChapter.chapter.url, pageIndex)
 
             if (readerChapter.pages?.lastIndex == pageIndex) {
                 updateChapterProgressOnComplete(readerChapter)
@@ -585,6 +642,87 @@ class ReaderViewModel(
                 ),
             )
         }
+    }
+
+    /** Requests a debounced Komga page-level push, withheld until the current session's pull resolves. */
+    private fun requestKomgaPush(bookUrl: String, page: Int) {
+        if (!komgaTrackingEnabled) return
+        komgaPushRequests.tryEmit(KomgaPushRequest(bookUrl, page, komgaSession))
+    }
+
+    /**
+     * Immediate (non-debounced) push, bypassing [requestKomgaPush]'s throttling. [session] must be
+     * captured by the caller before a later chapter open reassigns [komgaSession]. Runs via
+     * [launchNonCancellable] since a flush on activity teardown races [viewModelScope] cancellation.
+     */
+    private fun flushKomgaPush(readerChapter: ReaderChapter, session: KomgaChapterSession) {
+        if (!komgaTrackingEnabled) return
+        val chapter = readerChapter.chapter
+        val bookUrl = chapter.url
+        val page = chapter.last_page_read
+        viewModelScope.launchNonCancellable {
+            pushKomgaProgress(bookUrl, page, session)
+        }
+    }
+
+    private fun flushKomgaPush() {
+        getCurrentChapter()?.let { flushKomgaPush(it, komgaSession) }
+    }
+
+    private suspend fun pushKomgaProgress(bookUrl: String, page: Int, session: KomgaChapterSession) {
+        // last_page_read doesn't advance in incognito, so skip pushing it too.
+        if (incognitoMode) return
+        if (session.isPushSuppressed) return
+        try {
+            trackerManager.komga.pushBookReadProgress(bookUrl, page)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            logcat(LogPriority.WARN, e) { "Failed to push Komga page progress for $bookUrl" }
+        }
+    }
+
+    /** Pulls Komga's remote page for [readerChapter]'s book and starts a fresh push-suppressed session. */
+    private fun startKomgaPull(readerChapter: ReaderChapter) {
+        val session = KomgaChapterSession()
+        komgaSession = session
+        if (!komgaTrackingEnabled) return
+
+        val bookUrl = readerChapter.chapter.url
+        viewModelScope.launchIO {
+            val result = try {
+                when (val progress = trackerManager.komga.pullBookReadProgress(bookUrl)) {
+                    is KomgaBookProgress.Recorded -> KomgaPullResult.Recorded(progress.page)
+                    KomgaBookProgress.Absent -> KomgaPullResult.Absent
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                logcat(LogPriority.WARN, e) { "Failed to pull Komga page progress for $bookUrl" }
+                KomgaPullResult.Failure
+            }
+
+            when (val action = session.onPullResolved(result, readerChapter.chapter.last_page_read)) {
+                // Only a forward jump shows the "Synced from Komga" toast; a reset is silent.
+                is ReconciliationAction.JumpTo -> applyKomgaReconciliation(readerChapter, action.page, showToast = true)
+                ReconciliationAction.Reset -> applyKomgaReconciliation(readerChapter, 0, showToast = false)
+                ReconciliationAction.NoOp -> Unit
+            }
+        }
+    }
+
+    private suspend fun applyKomgaReconciliation(readerChapter: ReaderChapter, page: Int, showToast: Boolean) {
+        readerChapter.chapter.last_page_read = page
+        updateChapter.await(
+            ChapterUpdate(
+                id = readerChapter.chapter.id!!,
+                lastPageRead = page.toLong(),
+            ),
+        )
+
+        if (getCurrentChapter()?.chapter?.id != readerChapter.chapter.id) return
+        chapterPageIndex = page
+        readerChapter.requestedPage = page
+        mutableState.update { it.copy(currentPage = page + 1) }
+        eventChannel.send(Event.KomgaProgressSynced(page, showToast))
     }
 
     private suspend fun updateChapterProgressOnComplete(readerChapter: ReaderChapter) {
@@ -1012,5 +1150,8 @@ class ReaderViewModel(
         data class SavedImage(val result: SaveImageResult) : Event
         data class ShareImage(val uri: Uri, val page: ReaderPage) : Event
         data class CopyImage(val uri: Uri) : Event
+
+        /** A Komga pull reconciled to [page]; [showToast] is true only for a forward jump, not a reset. */
+        data class KomgaProgressSynced(val page: Int, val showToast: Boolean) : Event
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaApiTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaApiTest.kt
@@ -1,0 +1,110 @@
+package eu.kanade.tachiyomi.data.track.komga
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.addSingleton
+
+private const val BOOK_URL = "https://example.com/api/v1/books/abc-123"
+
+class KomgaApiTest {
+
+    @BeforeEach
+    fun setUp() {
+        Injekt.addSingleton(
+            Json {
+                ignoreUnknownKeys = true
+                explicitNulls = false
+            },
+        )
+    }
+
+    private fun apiRespondingWith(body: String): KomgaApi {
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body(body.toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            .build()
+        return KomgaApi(trackId = 6L, client = client)
+    }
+
+    @Test
+    fun `pull distinguishes a genuinely absent read progress from page zero`() = runTest {
+        val api = apiRespondingWith("""{"id":"abc-123"}""")
+
+        val progress = api.getBookReadProgress(BOOK_URL)
+
+        progress shouldBe KomgaBookProgress.Absent
+    }
+
+    @Test
+    fun `pull parses a recorded first page, including it distinctly from absent`() = runTest {
+        // Komga's page 1 is the first page; still distinct from no progress recorded.
+        val api = apiRespondingWith(
+            """{"id":"abc-123","readProgress":{"page":1,"completed":false}}""",
+        )
+
+        val progress = api.getBookReadProgress(BOOK_URL)
+
+        // Converted to Mihon's 0-indexed convention.
+        progress shouldBe KomgaBookProgress.Recorded(0)
+    }
+
+    @Test
+    fun `pull parses a recorded page in progress, converting Komga's 1-indexed page to 0-indexed`() = runTest {
+        val api = apiRespondingWith(
+            """{"id":"abc-123","readProgress":{"page":42,"completed":false}}""",
+        )
+
+        val progress = api.getBookReadProgress(BOOK_URL)
+
+        progress shouldBe KomgaBookProgress.Recorded(41)
+    }
+
+    @Test
+    fun `push converts Mihon's 0-indexed page to Komga's 1-indexed page`() = runTest {
+        var capturedUrl: String? = null
+        var capturedMethod: String? = null
+        var capturedBody: String? = null
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                capturedUrl = request.url.toString()
+                capturedMethod = request.method
+                val buffer = okio.Buffer()
+                request.body?.writeTo(buffer)
+                capturedBody = buffer.readUtf8()
+
+                Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(204)
+                    .message("No Content")
+                    .body("".toResponseBody(null))
+                    .build()
+            }
+            .build()
+        val api = KomgaApi(trackId = 6L, client = client)
+
+        api.updateBookReadProgress(BOOK_URL, 17)
+
+        capturedUrl shouldBe "$BOOK_URL/read-progress"
+        capturedMethod shouldBe "PATCH"
+        capturedBody shouldBe """{"page":18,"completed":false}"""
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaPageProgressTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaPageProgressTest.kt
@@ -1,0 +1,94 @@
+package eu.kanade.tachiyomi.data.track.komga
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class KomgaPageProgressTest {
+
+    @Test
+    fun `fresh session is push-suppressed before any pull resolves`() {
+        val session = KomgaChapterSession()
+
+        session.isPushSuppressed shouldBe true
+    }
+
+    @Test
+    fun `remote strictly ahead jumps forward and lifts suppression`() {
+        val session = KomgaChapterSession()
+
+        val action = session.onPullResolved(KomgaPullResult.Recorded(page = 42), currentPage = 10)
+
+        action shouldBe ReconciliationAction.JumpTo(42)
+        session.isPushSuppressed shouldBe false
+    }
+
+    @Test
+    fun `remote equal to current page is a no-op and still lifts suppression`() {
+        val session = KomgaChapterSession()
+
+        val action = session.onPullResolved(KomgaPullResult.Recorded(page = 10), currentPage = 10)
+
+        action shouldBe ReconciliationAction.NoOp
+        session.isPushSuppressed shouldBe false
+    }
+
+    @Test
+    fun `remote behind current page never rewinds and still lifts suppression`() {
+        val session = KomgaChapterSession()
+
+        // A slow pull resolving after the reader has already advanced further locally.
+        val action = session.onPullResolved(KomgaPullResult.Recorded(page = 5), currentPage = 20)
+
+        action shouldBe ReconciliationAction.NoOp
+        session.isPushSuppressed shouldBe false
+    }
+
+    @Test
+    fun `absent remote progress is an explicit reset overriding forward-only, and lifts suppression`() {
+        val session = KomgaChapterSession()
+
+        // Remote is "absent" (e.g. marked unread via Komga's UI), even though local is way ahead.
+        val action = session.onPullResolved(KomgaPullResult.Absent, currentPage = 50)
+
+        action shouldBe ReconciliationAction.Reset
+        session.isPushSuppressed shouldBe false
+    }
+
+    @Test
+    fun `a late-resolving success still lifts suppression and reconciles`() {
+        val session = KomgaChapterSession()
+        session.isPushSuppressed shouldBe true
+
+        // No timeout concept here: however long the pull took, resolving successfully lifts
+        // suppression and yields the same reconciliation decision as an immediate resolution.
+        val action = session.onPullResolved(KomgaPullResult.Recorded(page = 7), currentPage = 3)
+
+        action shouldBe ReconciliationAction.JumpTo(7)
+        session.isPushSuppressed shouldBe false
+    }
+
+    @Test
+    fun `a hard pull failure is a no-op and leaves the session push-suppressed`() {
+        val session = KomgaChapterSession()
+
+        val action = session.onPullResolved(KomgaPullResult.Failure, currentPage = 10)
+
+        action shouldBe ReconciliationAction.NoOp
+        session.isPushSuppressed shouldBe true
+    }
+
+    @Test
+    fun `a fresh chapter session starts independent of a prior session's outcome`() {
+        val failedSession = KomgaChapterSession()
+        failedSession.onPullResolved(KomgaPullResult.Failure, currentPage = 10)
+        failedSession.isPushSuppressed shouldBe true
+
+        // Opening the next chapter creates a brand-new session, unaffected by the previous one.
+        val nextSession = KomgaChapterSession()
+
+        nextSession.isPushSuppressed shouldBe true
+        val action = nextSession.onPullResolved(KomgaPullResult.Recorded(page = 1), currentPage = 0)
+        action shouldBe ReconciliationAction.JumpTo(1)
+        nextSession.isPushSuppressed shouldBe false
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -795,6 +795,7 @@
     <string name="no_scanlators_found">No scanlators found</string>
     <string name="confirm_tracker_update">Update trackers to chapter %d?</string>
     <string name="trackers_updated_summary">Trackers updated to chapter %d</string>
+    <string name="komga_synced_progress">Synced from Komga</string>
 
     <!-- Tracking Screen -->
     <string name="manga_tracking_tab">Tracking</string>


### PR DESCRIPTION
## Hi!
I've implemented a two-way progress sync to Komga. 

- It's periodically syncing progress to komga when reading. Somewhat inspired by progress sync from Jellyfin. It's also syncing when exiting the reader or app going to background.
It's not syncing on each page turn by design.

- It's syncing progress from Komga when opening a chapter. It's non-blocking sync, meaning we aren't waiting for a response to open reader. 
When testing on a local network, it's an instant action.

### Some other decisions that I made when implementing
- It has smaller surface area than this solution https://github.com/mihonapp/mihon/pull/3481, because I'm not implementing any settings for users, and I'm not touching the existing Komga chapter sync.
- When pulling progress, we only jump forward.
- When pulling progress and we don't have any(eg. chapter marked as read in Komga) we reset to page 0 - an exception to the first decision