### PR TITLE
CloudflareInterceptor: Exit early in WebView when challenge is interactive

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -86,7 +86,7 @@ class CloudflareInterceptor(
                     // The challenge cannot be solved non-interactively, abort.
                     latch.countDown()
                 }
-            }, "jsInterface")
+            }, "mihon")
 
             webview.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String) {
@@ -110,7 +110,7 @@ class CloudflareInterceptor(
                             view.evaluateJavascript("""
                                 addEventListener("message", ({data}) => {
                                     if (data?.source === "cloudflare-challenge" && data?.event === "interactiveBegin") {
-                                        jsInterface.interactiveDetected();
+                                        mihon.interactiveDetected();
                                     }
                                 })
                             """.trimIndent(), null)

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -79,14 +79,17 @@ class CloudflareInterceptor(
         executor.execute {
             webview = createWebView(originalRequest)
 
-            webview.addJavascriptInterface(object {
-                @Suppress("unused")
-                @JavascriptInterface
-                fun interactiveDetected() {
-                    // The challenge cannot be solved non-interactively, abort.
-                    latch.countDown()
-                }
-            }, "mihon")
+            webview.addJavascriptInterface(
+                object {
+                    @Suppress("unused")
+                    @JavascriptInterface
+                    fun interactiveDetected() {
+                        // The challenge cannot be solved non-interactively, abort.
+                        latch.countDown()
+                    }
+                },
+                "mihon",
+            )
 
             webview.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String) {
@@ -107,13 +110,16 @@ class CloudflareInterceptor(
                             latch.countDown()
                         } else {
                             // Listen for an interactiveBegin event
-                            view.evaluateJavascript("""
+                            view.evaluateJavascript(
+                                """
                                 addEventListener("message", ({data}) => {
                                     if (data?.source === "cloudflare-challenge" && data?.event === "interactiveBegin") {
                                         mihon.interactiveDetected();
                                     }
                                 })
-                            """.trimIndent(), null)
+                                """.trimIndent(),
+                                null,
+                            )
                         }
                     }
                 }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -112,11 +112,11 @@ class CloudflareInterceptor(
                             // Listen for an interactiveBegin event
                             view.evaluateJavascript(
                                 """
-                                addEventListener("message", ({data}) => {
-                                    if (data?.source === "cloudflare-challenge" && data?.event === "interactiveBegin") {
-                                        mihon.interactiveDetected();
-                                    }
-                                })
+                                    addEventListener("message", ({data}) => {
+                                        if (data?.source === "cloudflare-challenge" && data?.event === "interactiveBegin") {
+                                            mihon.interactiveDetected();
+                                        }
+                                    })
                                 """.trimIndent(),
                                 null,
                             )

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.network.interceptor
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -32,18 +33,9 @@ class CloudflareInterceptor(
 
     override fun shouldIntercept(response: Response): Boolean {
         // Check if Cloudflare anti-bot is on
-        return if (response.code in ERROR_CODES && response.header("Server") in SERVER_CHECK) {
-            val document = Jsoup.parse(
-                response.peekBody(Long.MAX_VALUE).string(),
-                response.request.url.toString(),
-            )
-
-            // solve with webview only on captcha, not on geo block
-            document.getElementById("challenge-error-title") != null ||
-                document.getElementById("challenge-error-text") != null
-        } else {
-            false
-        }
+        // Checking the cf-mitigated header is the official way to detect a Cloudflare challenge:
+        // https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/
+        return response.header("cf-mitigated") == "challenge" && response.header("Server") in SERVER_CHECK
     }
 
     override fun intercept(
@@ -87,6 +79,15 @@ class CloudflareInterceptor(
         executor.execute {
             webview = createWebView(originalRequest)
 
+            webview.addJavascriptInterface(object {
+                @Suppress("unused")
+                @JavascriptInterface
+                fun interactiveDetected() {
+                    // The challenge cannot be solved non-interactively, abort.
+                    latch.countDown()
+                }
+            }, "jsInterface")
+
             webview.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String) {
                     fun isCloudFlareBypassed(): Boolean {
@@ -100,9 +101,20 @@ class CloudflareInterceptor(
                         latch.countDown()
                     }
 
-                    if (url == origRequestUrl && !challengeFound) {
-                        // The first request didn't return the challenge, abort.
-                        latch.countDown()
+                    if (url == origRequestUrl) {
+                        if (!challengeFound) {
+                            // The first request didn't return the challenge, abort.
+                            latch.countDown()
+                        } else {
+                            // Listen for an interactiveBegin event
+                            view.evaluateJavascript("""
+                                addEventListener("message", ({data}) => {
+                                    if (data?.source === "cloudflare-challenge" && data?.event === "interactiveBegin") {
+                                        jsInterface.interactiveDetected();
+                                    }
+                                })
+                            """.trimIndent(), null)
+                        }
                     }
                 }
 
@@ -112,7 +124,7 @@ class CloudflareInterceptor(
                     errorResponse: WebResourceResponse?,
                 ) {
                     if (request?.isForMainFrame == true) {
-                        if (errorResponse?.statusCode in ERROR_CODES) {
+                        if (errorResponse?.responseHeaders["cf-mitigated"] == "challenge") {
                             // Found the Cloudflare challenge page.
                             challengeFound = true
                         } else {
@@ -151,7 +163,6 @@ class CloudflareInterceptor(
     }
 }
 
-private val ERROR_CODES = listOf(403, 503)
 private val SERVER_CHECK = arrayOf("cloudflare-nginx", "cloudflare")
 private val COOKIE_NAMES = listOf("cf_clearance")
 


### PR DESCRIPTION
Listens for the `interactiveBegin` message event in the WebView, which is only sent when the challenge is interactive.

Check the `cf-mitigated` header to detect a Cloudflare challenge [as mentioned in Cloudflare's documentation](https://developers.cloudflare.com/cloudflare-challenges/challenge-types/challenge-pages/detect-response/). I've verified that geo-blocked responses don't have the `cf-mitigated` header.