### PR TITLE
Fix GPU memory leak in WebGpuViewer when jumping pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webgpu/WebGpuViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webgpu/WebGpuViewer.kt
@@ -1050,6 +1050,7 @@ open class WebGpuViewer(
                     pager.state.invalidate()
                 } else {
                     if (pageInCache(page)) page.state = PageState.IDLE
+                    imagePage.cleanup()
                 }
             }
         }


### PR DESCRIPTION
Fixes #3863

### Summary
When using the page navigator slider to rapidly jump through a chapter on the new WebGpu renderer, pages that were queued and subsequently evicted from the `WebGpuViewer` cache *before* they finished decoding were leaking their GPU textures.

This PR adds a missing `imagePage.cleanup()` call in `decodeReaderPage` to ensure that if a page finishes decoding but has already been evicted from the cache, the newly allocated texture is properly destroyed.

- **Tested:** Yes (Compiled and verified on physical hardware to confirm the massive GC pressure, freezing, and OOM crash are resolved).
- **Self-Reviewed:** Yes.
- **Visual Changes:** No UI changes, strictly memory management.
