### PR TITLE
Add paged reader option to disable swipe

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -277,6 +277,10 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_page_rotate_invert),
                     enabled = rotateToFit,
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.disablePageSwipe,
+                    title = stringResource(MR.strings.pref_disable_page_swipe),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -22,6 +22,8 @@ class ReaderPreferences(
 
     val pageTransitions: Preference<Boolean> = preferenceStore.getBoolean("pref_enable_transitions_key", true)
 
+    val disablePageSwipe: Preference<Boolean> = preferenceStore.getBoolean("pref_disable_page_swipe", false)
+
     val flashOnPageChange: Preference<Boolean> = preferenceStore.getBoolean("pref_reader_flash", false)
 
     val flashDurationMillis: Preference<Int> = preferenceStore.getInt("pref_reader_flash_duration", MILLI_CONVERSION)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/Pager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/Pager.kt
@@ -6,6 +6,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import androidx.viewpager.widget.DirectionalViewPager
 import eu.kanade.tachiyomi.ui.reader.viewer.GestureDetectorWithLongTap
+import mihon.app.di.appGraph
 
 /**
  * Pager implementation that listens for tap and long tap and allows temporarily disabling touch
@@ -16,6 +17,8 @@ open class Pager(
     context: Context,
     isHorizontal: Boolean = true,
 ) : DirectionalViewPager(context, isHorizontal) {
+
+    val disableSwipe: Boolean = context.appGraph.readerPreferences.disablePageSwipe.get()
 
     /**
      * Tap listener function to execute when a tap is detected.
@@ -70,6 +73,8 @@ open class Pager(
      * views manipulate [requestDisallowInterceptTouchEvent].
      */
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        if (disableSwipe) return false
+
         return try {
             super.onInterceptTouchEvent(ev)
         } catch (e: IllegalArgumentException) {
@@ -82,6 +87,8 @@ open class Pager(
      * [requestDisallowInterceptTouchEvent].
      */
     override fun onTouchEvent(ev: MotionEvent): Boolean {
+        if (disableSwipe) return true
+
         return try {
             super.onTouchEvent(ev)
         } catch (e: NullPointerException) {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -388,6 +388,7 @@
     <string name="pref_dual_page_invert_summary">If the placement of the split wide pages don\'t match reading direction</string>
     <string name="pref_page_rotate">Rotate wide pages to fit</string>
     <string name="pref_page_rotate_invert">Flip orientation of rotated wide pages</string>
+    <string name="pref_disable_page_swipe">Disable swiping between pages</string>
     <string name="pref_double_tap_zoom">Double tap to zoom</string>
     <string name="pref_cutout_short">Show content in cutout area</string>
     <string name="pref_page_transitions">Animate page transitions</string>


### PR DESCRIPTION
This improves usability on e-ink devices as it prevents accidental large-scale animations triggered by swiping.

Also helps with system-level swipe gestures, e.g. I have my e-reader tablet configured to do a full redraw when swiping from the left, which doesn't really work if it also shifts the image slightly (and thus can cause new ghosting).

---

I don't have a good overview of the codebase and very little experience with Android development, so I really hope that I did everything right and didn't accidentally break something else.

I did confirm that double-tap zoom, pinch zoom, and moving by swiping when zoomed in still work with the option enabled, and that the reader is still very much usable. I didn't find anything that was broken by this, but I also haven't used the app that much, so maybe there's something I didn't check or didn't realize was broken.

---

The new WebGPU renderer already allows having the same effect by disabling page transition animations, with the added benefit that you can still use swipes to switch pages even without an animation. I tried looking into if that would also be possible to implement for the old paged reader, but I'd guess you'd have to change the DirectionalViewPager directly for that and that's way beyond my abilities, so I instead opted for disabling swiping completely.