### PR TITLE
Add filter dialog in Migrate Mangas Screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaFilterDialog.kt
@@ -1,0 +1,125 @@
+package eu.kanade.tachiyomi.ui.browse.migration.manga
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import eu.kanade.presentation.category.visualName
+import eu.kanade.presentation.components.TabbedDialog
+import eu.kanade.presentation.components.TabbedDialogPaddings
+import tachiyomi.core.common.preference.TriState
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.SettingsItemsPaddings
+import tachiyomi.presentation.core.components.TriStateItem
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.LoadingScreen
+
+@Composable
+fun MigrateMangaFilterDialog(
+    onDismissRequest: () -> Unit,
+    viewModel: MigrateMangaViewModel,
+) {
+    TabbedDialog(
+        onDismissRequest = onDismissRequest,
+        tabTitles = listOf(
+            stringResource(MR.strings.action_filter),
+            stringResource(MR.strings.categories),
+        ),
+    ) { page ->
+        Column(
+            modifier = Modifier
+                .padding(vertical = TabbedDialogPaddings.Vertical)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            when (page) {
+                0 -> FilterSheet(viewModel = viewModel)
+                1 -> CategoryFilterSheet(viewModel = viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.FilterSheet(
+    viewModel: MigrateMangaViewModel,
+) {
+    val filters by viewModel.filters.collectAsStateWithLifecycle()
+
+    TriStateItem(
+        label = stringResource(MR.strings.label_downloaded),
+        state = filters.downloaded,
+        onClick = { viewModel.toggleFilterDownloaded() },
+    )
+
+    TriStateItem(
+        label = stringResource(MR.strings.action_filter_unread),
+        state = filters.unread,
+        onClick = { viewModel.toggleFilterUnread() },
+    )
+
+    TriStateItem(
+        label = stringResource(MR.strings.label_started),
+        state = filters.started,
+        onClick = { viewModel.toggleFilterStarted() },
+    )
+
+    TriStateItem(
+        label = stringResource(MR.strings.action_filter_bookmarked),
+        state = filters.bookmarked,
+        onClick = { viewModel.toggleFilterBookmarked() },
+    )
+}
+
+@Composable
+private fun ColumnScope.CategoryFilterSheet(
+    viewModel: MigrateMangaViewModel,
+) {
+    Text(
+        stringResource(MR.strings.pref_filter_migrate_manga_categories_details),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SettingsItemsPaddings.Horizontal,
+                vertical = SettingsItemsPaddings.Vertical,
+            ),
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(MaterialTheme.padding.extraSmall))
+
+    val allCategories by viewModel.getCategories.subscribe().collectAsState(initial = emptyList())
+
+    if (allCategories.isEmpty()) {
+        LoadingScreen(modifier = Modifier.padding(16.dp))
+        return
+    }
+
+    val filters by viewModel.filters.collectAsStateWithLifecycle()
+
+    Column {
+        allCategories.fastForEach { category ->
+            val state = when (category.id) {
+                in filters.includedCategories -> TriState.ENABLED_IS
+                in filters.excludedCategories -> TriState.ENABLED_NOT
+                else -> TriState.DISABLED
+            }
+            TriStateItem(
+                label = category.visualName,
+                state = state,
+                onClick = { viewModel.cycleCategory(category) },
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.animateFloatingActionButton
@@ -21,6 +23,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
 import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.manga.components.BaseMangaListItem
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -29,6 +32,7 @@ import kotlinx.coroutines.flow.collectLatest
 import mihon.feature.migration.config.MigrationConfigScreen
 import mihon.icons.materialsymbols.MaterialSymbols
 import mihon.icons.materialsymbols.automirroredrounded.ArrowForward
+import mihon.icons.materialsymbols.rounded.FilterList
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -36,6 +40,7 @@ import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.theme.active
 import tachiyomi.presentation.core.util.selectedBackground
 import tachiyomi.presentation.core.util.shouldExpandFAB
 
@@ -75,6 +80,22 @@ data class MigrateMangaScreen(
                         }
                     },
                     scrollBehavior = scrollBehavior,
+                    actions = {
+                        AppBarActions(
+                            listOf(
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.action_filter),
+                                    icon = MaterialSymbols.Rounded.FilterList,
+                                    iconTint = if (state.hasActiveFilters) {
+                                        MaterialTheme.colorScheme.active
+                                    } else {
+                                        LocalContentColor.current
+                                    },
+                                    onClick = viewModel::showFilterDialog,
+                                ),
+                            ),
+                        )
+                    },
                 )
             },
             floatingActionButton = {
@@ -111,6 +132,16 @@ data class MigrateMangaScreen(
                 onClickItem = viewModel::toggleSelection,
                 onClickCover = { navigator.push(MangaScreen(it.id)) },
             )
+        }
+
+        when (state.dialog) {
+            MigrateMangaViewModel.Dialog.Filter -> {
+                MigrateMangaFilterDialog(
+                    onDismissRequest = viewModel::dismissDialog,
+                    viewModel = viewModel,
+                )
+            }
+            null -> {}
         }
 
         LaunchedEffect(Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaViewModel.kt
@@ -10,6 +10,8 @@ import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
 import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactoryKey
+import eu.kanade.tachiyomi.data.download.DownloadCache
+import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.Source
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -19,8 +21,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -28,9 +32,14 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import logcat.LogPriority
 import mihon.core.common.utils.mutate
+import tachiyomi.core.common.preference.TriState
 import tachiyomi.core.common.util.system.logcat
-import tachiyomi.domain.manga.interactor.GetFavorites
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.library.model.LibraryManga
+import tachiyomi.domain.manga.interactor.GetLibraryManga
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.applyFilter
 import tachiyomi.domain.source.service.SourceManager
 import kotlin.time.Duration.Companion.seconds
 
@@ -38,7 +47,10 @@ import kotlin.time.Duration.Companion.seconds
 class MigrateMangaViewModel(
     @Assisted private val sourceId: Long,
     private val sourceManager: SourceManager,
-    private val getFavorites: GetFavorites,
+    private val getLibraryManga: GetLibraryManga,
+    private val downloadManager: DownloadManager,
+    private val downloadCache: DownloadCache,
+    val getCategories: GetCategories,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -55,24 +67,70 @@ class MigrateMangaViewModel(
 
     private val selection = MutableStateFlow(emptySet<Long>())
 
-    private val favorites = getFavorites.subscribe(sourceId)
-        .catch {
-            logcat(LogPriority.ERROR, it)
-            _events.send(MigrationMangaEvent.FailedFetchingFavorites)
-            emit(listOf())
-        }
-        .map { manga ->
-            manga.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
-        }
+    private val dialog = MutableStateFlow<Dialog?>(null)
+
+    private val _filters = MutableStateFlow(MigrateMangaFilters())
+    val filters: StateFlow<MigrateMangaFilters> = _filters.asStateFlow()
+
+    private val hasActiveFilters = _filters
+        .map { it.isActive }
+        .distinctUntilChanged()
+
+    private val favorites = combine(
+        getLibraryManga.subscribe()
+            .catch {
+                logcat(LogPriority.ERROR, it)
+                _events.send(MigrationMangaEvent.FailedFetchingFavorites)
+                emit(listOf())
+            },
+        downloadCache.changes,
+        _filters,
+    ) { libraryManga, _, filters ->
+        libraryManga
+            .asSequence()
+            .filter { it.manga.source == sourceId }
+            .applyFilters(filters)
+            .map { it.manga }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
+            .toList()
+    }
 
     val state: StateFlow<State> = combine(
         favorites,
         selection,
-    ) { titleList, selection ->
-        State(source = source.await(), selection = selection, titleList = titleList)
+        dialog,
+        hasActiveFilters,
+    ) { titleList, selection, dialog, hasActiveFilters ->
+        State(
+            source = source.await(),
+            selection = selection,
+            dialog = dialog,
+            hasActiveFilters = hasActiveFilters,
+            titleList = titleList,
+        )
     }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5.seconds), State())
+
+    private fun Sequence<LibraryManga>.applyFilters(filters: MigrateMangaFilters): Sequence<LibraryManga> {
+        return this
+            .filter { applyFilter(filters.downloaded) { downloadManager.getDownloadCount(it.manga) > 0 } }
+            .filter { applyFilter(filters.unread) { it.unreadCount > 0 } }
+            .filter { applyFilter(filters.started) { it.hasStarted } }
+            .filter { applyFilter(filters.bookmarked) { it.hasBookmarks } }
+            .filter { libraryManga ->
+                val included = filters.includedCategories
+                val excluded = filters.excludedCategories
+                if (included.isEmpty() && excluded.isEmpty()) {
+                    true
+                } else {
+                    val categories = libraryManga.categories
+                    val isIncluded = included.isEmpty() || categories.any { it in included }
+                    val isExcluded = excluded.isNotEmpty() && categories.any { it in excluded }
+                    isIncluded && !isExcluded
+                }
+            }
+    }
 
     fun toggleSelection(item: Manga) {
         selection.update { selection ->
@@ -86,10 +144,43 @@ class MigrateMangaViewModel(
         selection.update { emptySet() }
     }
 
+    fun showFilterDialog() {
+        dialog.update { Dialog.Filter }
+    }
+
+    fun dismissDialog() {
+        dialog.update { null }
+    }
+
+    fun toggleFilterDownloaded() = _filters.update { it.copy(downloaded = it.downloaded.next()) }
+
+    fun toggleFilterUnread() = _filters.update { it.copy(unread = it.unread.next()) }
+
+    fun toggleFilterStarted() = _filters.update { it.copy(started = it.started.next()) }
+
+    fun toggleFilterBookmarked() = _filters.update { it.copy(bookmarked = it.bookmarked.next()) }
+
+    fun cycleCategory(category: Category) {
+        _filters.update { current ->
+            when (category.id) {
+                in current.includedCategories -> current.copy(
+                    includedCategories = current.includedCategories - category.id,
+                    excludedCategories = current.excludedCategories + category.id,
+                )
+                in current.excludedCategories -> current.copy(
+                    excludedCategories = current.excludedCategories - category.id,
+                )
+                else -> current.copy(includedCategories = current.includedCategories + category.id)
+            }
+        }
+    }
+
     @Immutable
     data class State(
         val source: Source? = null,
         val selection: Set<Long> = emptySet(),
+        val dialog: Dialog? = null,
+        val hasActiveFilters: Boolean = false,
         private val titleList: List<Manga>? = null,
     ) {
 
@@ -104,6 +195,25 @@ class MigrateMangaViewModel(
 
         val selectionMode = selection.isNotEmpty()
     }
+
+    sealed interface Dialog {
+        data object Filter : Dialog
+    }
+}
+
+@Immutable
+data class MigrateMangaFilters(
+    val downloaded: TriState = TriState.DISABLED,
+    val unread: TriState = TriState.DISABLED,
+    val started: TriState = TriState.DISABLED,
+    val bookmarked: TriState = TriState.DISABLED,
+    val includedCategories: Set<Long> = emptySet(),
+    val excludedCategories: Set<Long> = emptySet(),
+) {
+    val isActive: Boolean
+        get() = listOf(downloaded, unread, started, bookmarked).any { it != TriState.DISABLED } ||
+            includedCategories.isNotEmpty() ||
+            excludedCategories.isNotEmpty()
 }
 
 sealed interface MigrationMangaEvent {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -908,6 +908,7 @@
     <string name="migration_help_guide">Source migration guide</string>
     <string name="migration_dialog_what_to_include">Select data to include</string>
     <string name="migration_selection_prompt">Select a source to migrate from</string>
+    <string name="pref_filter_migrate_manga_categories_details">Titles in excluded categories are not shown, even if they are also in any of the included categories.</string>
     <string name="migrate">Migrate</string>
     <!-- Make a copy (noun) when migrating. Don't use for copying to clipboard. -->
     <string name="copy">Copy</string>


### PR DESCRIPTION
Add a Filter action at the top right of the Migrate Manga Screen (After selecting a source)
That action opens a pretty similar dialog to the one in `Updates`, to filter by:
```
- Downloaded
- Unread
- Started
- Bookmarked
- By Category
```

(The warning in the `Categories` section is the same one as in `Updates`, since it uses the same logic to filter out Items)

<table>
  <tr>
    <td><b>Filter</b></td>
    <td><b>Category</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e7107695-6b8a-4a5e-9fd2-a6f9cfcc9045"></td>
    <td><img src="https://github.com/user-attachments/assets/fd010c71-08cb-407b-a73d-ca8b9b909d89"></td>
  </tr>
</table>

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
