### PR TITLE
feat: smarter global search with merged ranked results

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -10,6 +10,7 @@ import eu.kanade.presentation.browse.components.GlobalSearchErrorResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchLoadingResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchToolbar
+import eu.kanade.presentation.browse.components.SmartGlobalSearchContent
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchItemResult
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchViewModel
@@ -49,17 +50,21 @@ fun GlobalSearchScreen(
             )
         },
     ) { paddingValues ->
-        GlobalSearchContent(
-            items = state.filteredItems,
+        SmartGlobalSearchContent(
+            results = state.filteredResults,
+            suggestions = state.suggestions,
             contentPadding = paddingValues,
             getManga = getManga,
-            onClickSource = onClickSource,
             onClickItem = onClickItem,
             onLongClickItem = onLongClickItem,
         )
     }
 }
 
+/**
+ * Per-source search results layout (one row/section per source). Used by the migration
+ * search, which needs to compare the same series across sources individually.
+ */
 @Composable
 internal fun GlobalSearchContent(
     items: Map<Source, SearchItemResult>,

--- a/app/src/main/java/eu/kanade/presentation/browse/components/SmartGlobalSearchContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/SmartGlobalSearchContent.kt
@@ -1,0 +1,202 @@
+package eu.kanade.presentation.browse.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.kanade.presentation.library.components.CommonMangaItemDefaults
+import eu.kanade.presentation.library.components.MangaComfortableGridItem
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart.SmartSearchEngine
+import mihon.icons.materialsymbols.MaterialSymbols
+import mihon.icons.materialsymbols.rounded.QueryStats
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.asMangaCover
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+/**
+ * Renders the merged, ranked smart-search results as a single vertical list ordered by
+ * relevance, with a "did you mean" suggestion banner at the top when nothing matched.
+ */
+@Composable
+fun SmartGlobalSearchContent(
+    results: List<SmartSearchEngine.MergedResult>,
+    suggestions: List<String>,
+    contentPadding: PaddingValues,
+    getManga: @Composable (Manga) -> State<Manga>,
+    onClickItem: (Manga) -> Unit,
+    onLongClickItem: (Manga) -> Unit,
+) {
+    LazyColumn(
+        contentPadding = contentPadding,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        if (suggestions.isNotEmpty()) {
+            item(key = "suggestions") {
+                DidYouMeanBanner(suggestions = suggestions)
+            }
+        }
+
+        if (results.isEmpty() && suggestions.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(MR.strings.no_results_found),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = MaterialTheme.padding.medium)
+                        .padding(horizontal = MaterialTheme.padding.medium),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+            return@LazyColumn
+        }
+
+        items(results.size, key = { "${results[it].primary.id}-${results[it].sourceId}" }) { index ->
+            val result = results[index]
+            SmartSearchRowItem(
+                rank = index + 1,
+                result = result,
+                getManga = getManga,
+                onClick = { onClickItem(result.primary) },
+                onLongClick = { onLongClickItem(result.primary) },
+            )
+        }
+    }
+}
+
+/**
+ * A single ranked result row: rank badge, cover, title, source tag, and the number of
+ * alternative sources this series was found on (so the user can pick another source).
+ */
+@Composable
+private fun SmartSearchRowItem(
+    rank: Int,
+    result: SmartSearchEngine.MergedResult,
+    getManga: @Composable (Manga) -> State<Manga>,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+    val title by getManga(result.primary)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = MaterialTheme.padding.small, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RankNumberBadge(rank = rank)
+
+        Box(modifier = Modifier.width(64.dp)) {
+            MangaComfortableGridItem(
+                title = title.title,
+                titleMaxLines = 3,
+                coverData = title.asMangaCover(),
+                coverBadgeStart = {
+                    InLibraryBadge(enabled = title.favorite)
+                },
+                coverAlpha = if (title.favorite) CommonMangaItemDefaults.BrowseFavoriteCoverAlpha else 1f,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            )
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title.title,
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            SourceTagLine(result = result)
+        }
+    }
+}
+
+@Composable
+private fun SourceTagLine(result: SmartSearchEngine.MergedResult) {
+    val alternativeCount = result.alternatives.size
+    val label = if (alternativeCount > 0) {
+        stringResource(MR.strings.smart_search_source_tag, alternativeCount + 1)
+    } else {
+        stringResource(MR.strings.smart_search_single_source)
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@Composable
+fun RankNumberBadge(rank: Int) {
+    Surface(
+        modifier = Modifier.size(24.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = rank.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DidYouMeanBanner(suggestions: List<String>) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = MaterialSymbols.Rounded.QueryStats,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Column {
+            Text(
+                text = stringResource(MR.strings.did_you_mean),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (suggestions.isNotEmpty()) {
+                Text(
+                    text = suggestions.joinToString(" · "),
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchViewModel.kt
@@ -43,6 +43,7 @@ class GlobalSearchViewModel(
 
     init {
         extensionFilter = initialExtensionFilter
+        liveSearchEnabled = true
         if (initialQuery.isNotBlank() || !initialExtensionFilter.isNullOrBlank()) {
             if (extensionFilter != null) {
                 // we're going to use custom extension filter instead

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchViewModel.kt
@@ -8,10 +8,13 @@ import androidx.lifecycle.viewModelScope
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart.QueryNormalizer
+import eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart.SmartSearchEngine
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -60,6 +63,10 @@ abstract class SearchViewModel(
 
     protected var extensionFilter: String? = null
 
+    /**
+     * Orders per-source results in [State.items]. Migration search overrides this to sort by
+     * source priority; global search keeps the default (pinned first, then alphabetical).
+     */
     open val sortComparator = { map: Map<Source, SearchItemResult> ->
         compareBy<Source>(
             { (map[it] as? SearchItemResult.Success)?.isEmpty ?: true },
@@ -67,6 +74,11 @@ abstract class SearchViewModel(
             { "${it.name.lowercase()} (${it.lang})" },
         )
     }
+
+    // Live-search: when the user keeps typing, debounce and re-run search automatically
+    // without requiring them to press search/enter. Only enabled for global search.
+    protected var liveSearchEnabled: Boolean = false
+    private var liveSearchJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -114,6 +126,21 @@ abstract class SearchViewModel(
 
     fun updateSearchQuery(query: String?) {
         state.update { it.copy(searchQuery = query) }
+        if (liveSearchEnabled) {
+            scheduleLiveSearch()
+        }
+    }
+
+    /**
+     * Debounced live search: as soon as the user stops typing (~400ms), search automatically.
+     */
+    private fun scheduleLiveSearch() {
+        liveSearchJob?.cancel()
+        val query = state.value.searchQuery?.trim().orEmpty()
+        liveSearchJob = viewModelScope.launch {
+            delay(400)
+            if (query.isNotBlank()) search()
+        }
     }
 
     fun setSourceFilter(filter: SourceFilter) {
@@ -142,61 +169,82 @@ abstract class SearchViewModel(
         searchJob = viewModelScope.launchIO {
             val sources = getSelectedSources()
 
-            // Reuse previous results if possible
-            if (sameQuery) {
-                val existingResults = state.value.items
-                updateItems(
-                    sources
-                        .associateWith { existingResults[it] ?: SearchItemResult.Loading },
-                )
-            } else {
-                updateItems(
-                    sources
-                        .associateWith { SearchItemResult.Loading },
+            // Reuse previous per-source results if re-running the same query under a new filter.
+            val previousItems = state.value.items
+
+            updateState {
+                it.copy(
+                    isSearching = true,
+                    completedSources = 0,
+                    totalSources = sources.size,
+                    items = if (sameQuery) previousItems else sources.associateWith { SearchItemResult.Loading },
+                    results = emptyList(),
+                    suggestions = emptyList(),
                 )
             }
 
-            sources.map { source ->
-                async {
-                    if (state.value.items[source] !is SearchItemResult.Loading) {
-                        return@async
-                    }
+            if (sources.isEmpty()) {
+                updateState { it.copy(isSearching = false) }
+                return@launchIO
+            }
 
-                    try {
+            // Each source pushes its raw hits when it finishes so results stream in
+            // incrementally instead of waiting for every source to complete.
+            val resultChannel = Channel<Pair<Source, List<Manga>>>(Channel.UNLIMITED)
+
+            sources.forEach { source ->
+                async {
+                    val titles = runCatching {
                         val page = withContext(coroutineDispatcher) {
                             source.getSearchManga(1, query, source.getFilterList())
                         }
-
-                        val titles = page.mangas
+                        page.mangas
                             .map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
                             .let { networkToLocalManga(it) }
+                    }.getOrDefault(emptyList())
 
-                        if (isActive) {
-                            updateItem(source, SearchItemResult.Success(titles))
-                        }
-                    } catch (e: Exception) {
-                        if (isActive) {
-                            updateItem(source, SearchItemResult.Error(e))
-                        }
+                    if (isActive) resultChannel.send(source to titles)
+                }
+            }
+
+            // Consume results as they arrive and update state incrementally.
+            val accumulator = mutableListOf<Manga>()
+            repeat(sources.size) {
+                val (source, titles) = resultChannel.receive()
+                if (isActive) {
+                    accumulator.addAll(titles)
+                    val result: SearchItemResult =
+                        if (titles.isEmpty()) SearchItemResult.Success(emptyList())
+                        else SearchItemResult.Success(titles)
+
+                    updateState {
+                        val updatedItems = (it.items + (source to result))
+                            .toSortedMap(sortComparator(it.items + (source to result)))
+                        it.copy(
+                            completedSources = it.completedSources + 1,
+                            items = updatedItems,
+                            // Smart merge recomputed from all accumulated raw hits.
+                            results = SmartSearchEngine.merge(QueryNormalizer.normalize(query), accumulator),
+                        )
                     }
                 }
             }
-                .awaitAll()
-        }
-    }
 
-    private fun updateItems(items: Map<Source, SearchItemResult>) {
-        state.update {
-            it.copy(
-                items = items
-                    .toSortedMap(sortComparator(items)),
-            )
-        }
-    }
+            // "Did you mean" suggestions when nothing matched across all sources.
+            val finalResults = state.value.results
+            val suggestions = if (finalResults.isEmpty()) {
+                SmartSearchEngine.suggest(QueryNormalizer.normalize(query))
+            } else {
+                emptyList()
+            }
 
-    private fun updateItem(source: Source, result: SearchItemResult) {
-        updateItems(state.value.items + (source to result))
+            if (isActive) {
+                updateState {
+                    it.copy(isSearching = false, suggestions = suggestions)
+                }
+            }
+        }
     }
 
     fun setMigrateDialog(currentId: Long, target: Manga) {
@@ -217,11 +265,22 @@ abstract class SearchViewModel(
         val sourceFilter: SourceFilter = SourceFilter.PinnedOnly,
         val onlyShowHasResults: Boolean = false,
         val items: Map<Source, SearchItemResult> = mapOf(),
+        val results: List<SmartSearchEngine.MergedResult> = emptyList(),
+        val suggestions: List<String> = emptyList(),
+        val isSearching: Boolean = false,
+        val completedSources: Int = 0,
+        val totalSources: Int = 0,
         val dialog: Dialog? = null,
     ) {
-        val progress: Int = items.count { it.value !is SearchItemResult.Loading }
-        val total: Int = items.size
+        val progress: Int = completedSources
+        val total: Int = totalSources
+
+        /** Per-source items filtered by the "has results" toggle (used by migration search). */
         val filteredItems = items.filter { (_, result) -> result.isVisible(onlyShowHasResults) }
+
+        /** Merged, ranked results for global search. */
+        val filteredResults: List<SmartSearchEngine.MergedResult>
+            get() = if (onlyShowHasResults) results.filter { it.score > 0f } else results
     }
 
     sealed interface Dialog {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/FuzzyMatcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/FuzzyMatcher.kt
@@ -1,0 +1,111 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart
+
+import kotlin.math.max
+
+/**
+ * Computes a relevance score between a normalized query and a normalized title,
+ * returning a value in [0.0, 1.0] where 1.0 is a perfect match. The scoring is
+ * "Google-like" in that it tolerates typos, partial words, and word-order changes
+ * instead of requiring exact matches.
+ */
+object FuzzyMatcher {
+
+    /**
+     * Returns a relevance score in [0, 1]. [query] and [title] should both be
+     * pre-normalized via [QueryNormalizer.normalize].
+     */
+    fun score(query: String, title: String): Float {
+        if (query.isEmpty() || title.isEmpty()) return 0f
+
+        if (query == title) return 1f
+
+        val qTokens = QueryNormalizer.tokenize(query)
+        val tTokens = QueryNormalizer.tokenize(title)
+
+        // Whole-query structural matches
+        if (isSubsequence(query, title)) return 0.85f
+        if (title.startsWith(query)) return 0.9f
+
+        // Token-level matching
+        var sumScores = 0f
+        var matchedTokens = 0
+        for (qt in qTokens) {
+            var best = 0f
+            for (tt in tTokens) {
+                val s = tokenScore(qt, tt)
+                if (s > best) best = s
+            }
+            if (best > 0f) {
+                sumScores += best
+                matchedTokens++
+            }
+        }
+
+        if (qTokens.isEmpty()) return 0f
+
+        val coverage = matchedTokens.toFloat() / qTokens.size
+        val avgQuality = if (matchedTokens == 0) 0f else sumScores / matchedTokens
+
+        // Subsequence across the whole run of title tokens (helps concatenated titles)
+        val crossSubsequenceBonus = if (isJoinedSubsequence(qTokens, tTokens)) 0.1f else 0f
+
+        return (coverage * avgQuality + crossSubsequenceBonus).coerceIn(0f, 0.95f)
+    }
+
+    /**
+     * Score a single query token against a single title token. Returns 0 if no match.
+     */
+    fun tokenScore(queryToken: String, titleToken: String): Float {
+        if (queryToken.isEmpty() || titleToken.isEmpty()) return 0f
+
+        if (queryToken == titleToken) return 1f
+
+        // Prefix match (e.g. "solo" vs "sololeveling")
+        if (queryToken.length >= 3 && titleToken.startsWith(queryToken)) return 0.85f
+        if (titleToken.length >= 3 && queryToken.startsWith(titleToken)) return 0.8f
+
+        // Subsequence within a token
+        if (queryToken.length <= titleToken.length && isSubsequence(queryToken, titleToken)) return 0.6f
+
+        // Fuzzy edit-distance for typo tolerance on longer tokens
+        if (queryToken.length >= 4 && titleToken.length >= 4) {
+            val maxDist = if (queryToken.length >= 8) 2 else 1
+            val dist = QueryNormalizer.levenshtein(queryToken, titleToken, maxDist)
+            if (dist <= maxDist) {
+                val len = max(queryToken.length, titleToken.length)
+                val similarity = 1f - (dist.toFloat() / len.toFloat())
+                return (0.4f + similarity * 0.5f).coerceIn(0f, 0.85f)
+            }
+        }
+
+        return 0f
+    }
+
+    /**
+     * True if every query token is a subsequence appearing, in order, somewhere within
+     * the entire title (spans across word boundaries). E.g. query "opm" tokens and title
+     * "one punch man".
+     */
+    private fun isJoinedSubsequence(queryTokens: List<String>, titleTokens: List<String>): Boolean {
+        // Concatenate title tokens to allow cross-word subsequence matching
+        val joinedTitle = titleTokens.joinToString("")
+        val joinedQuery = queryTokens.joinToString("")
+        val match = isSubsequence(joinedQuery, joinedTitle)
+        return match && joinedQuery.length >= 3
+    }
+
+    /**
+     * True if [a] is a subsequence of [b] (chars of [a] appear in order within [b]).
+     */
+    fun isSubsequence(a: String, b: String): Boolean {
+        if (a.isEmpty()) return true
+        var j = 0
+        for (i in b.indices) {
+            if (b[i] == a[j]) {
+                j++
+                if (j == a.length) return true
+            }
+        }
+        return false
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/QueryNormalizer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/QueryNormalizer.kt
@@ -1,0 +1,112 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart
+
+import java.util.Locale
+import kotlin.math.min
+
+/**
+ * Normalizes a user search query into a canonical form that is more likely to
+ * produce results on exact-match source backends, and (later) used for fuzzy
+ * ranking of returned titles.
+ *
+ * Improvements over the plain raw query:
+ *  - lower-cases everything
+ *  - strips accents/diacritics so "shonen" matches "shōnen"
+ *  - removes punctuation and collapses whitespace
+ *  - expands common romanization/alias variants
+ */
+object QueryNormalizer {
+
+    private val accentMap = mapOf(
+        'à' to 'a', 'á' to 'a', 'â' to 'a', 'ã' to 'a', 'ä' to 'a', 'å' to 'a', 'ā' to 'a', 'ă' to 'a', 'ą' to 'a',
+        'ç' to 'c', 'ć' to 'c', 'č' to 'c',
+        'è' to 'e', 'é' to 'e', 'ê' to 'e', 'ë' to 'e', 'ē' to 'e', 'ė' to 'e', 'ę' to 'e', 'ě' to 'e',
+        'ì' to 'i', 'í' to 'i', 'î' to 'i', 'ï' to 'i', 'ī' to 'i', 'į' to 'i', 'ı' to 'i',
+        'ñ' to 'n', 'ń' to 'n', 'ň' to 'n',
+        'ò' to 'o', 'ó' to 'o', 'ô' to 'o', 'õ' to 'o', 'ö' to 'o', 'ō' to 'o', 'ø' to 'o', 'ő' to 'o',
+        'ù' to 'u', 'ú' to 'u', 'û' to 'u', 'ü' to 'u', 'ū' to 'u', 'ů' to 'u', 'ű' to 'u',
+        'ý' to 'y', 'ÿ' to 'y', 'ž' to 'z', 'ź' to 'z', 'ż' to 'z',
+        'ł' to 'l',
+    )
+
+    /**
+     * Alias variants -> canonical expansion. Applied token-boundary aware, case-insensitive,
+     * so different romanizations and common typos map to a consistent form.
+     */
+    @JvmField
+    val aliasMap: Map<String, String> = mapOf(
+        // Different romanizations of the same Japanese words
+        "shonen" to "shounen",
+        "shoujo" to "shoujo",
+        "shojo" to "shoujo",
+        "manhua" to "manhwa manhua",
+        "manwha" to "manhwa", // common typo of manhwa
+        // Long-standing typos
+        "manga dex" to "mangadex",
+        "solo leve rule" to "solo leveling",
+    )
+
+    /**
+     * Normalizes a raw query into a lower-cased, accent/punctuation-free, single-space
+     * separated string. Applies alias expansion. Output is safe for case-insensitive matching.
+     */
+    @JvmOverloads
+    fun normalize(raw: String): String {
+        val lower = raw.lowercase(Locale.ROOT)
+
+        // 1. Strip accents
+        val stripped = buildString(lower.length) {
+            lower.forEach { ch -> append(accentMap[ch] ?: ch) }
+        }
+
+        // 2. Keep only letters/numbers/whitespace, collapse whitespace
+        val cleaned = stripped
+            .replace(Regex("[^a-z0-9\\s]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+        // 3. Alias expansion (token-boundary aware, case-insensitive)
+        val result = aliasMap.keys.fold(cleaned) { acc, key ->
+            acc.replace(Regex("\\b${Regex.escape(key)}\\b", RegexOption.IGNORE_CASE), aliasMap.getValue(key))
+        }
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+        return result
+    }
+
+    /**
+     * Splits a normalized query into individual word tokens.
+     */
+    fun tokenize(normalized: String): List<String> = normalized.split(' ')
+
+    /**
+     * Levenshtein distance, capped at [max] for efficiency. Used by the fuzzy matcher
+     * and for "did you mean" suggestions.
+     */
+    fun levenshtein(a: String, b: String, max: Int = Int.MAX_VALUE): Int {
+        if (a == b) return 0
+        if (a.isEmpty()) return min(b.length, max)
+        if (b.isEmpty()) return min(a.length, max)
+        // Quick rejection: length difference already exceeds max
+        if (kotlin.math.abs(a.length - b.length) > max) return max + 1
+
+        val prev = IntArray(b.length + 1) { it }
+        val curr = IntArray(b.length + 1)
+
+        for (i in 1..a.length) {
+            curr[0] = i
+            var bestInRow = curr[0]
+            for (j in 1..b.length) {
+                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                val deletion = prev[j] + 1
+                val insertion = curr[j - 1] + 1
+                val substitution = prev[j - 1] + cost
+                curr[j] = minOf(deletion, insertion, substitution)
+                if (curr[j] < bestInRow) bestInRow = curr[j]
+            }
+            if (bestInRow > max) return max + 1
+            prev.indices.forEach { prev[it] = curr[it] }
+        }
+        return curr[b.length]
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/SmartSearchEngine.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/SmartSearchEngine.kt
@@ -1,0 +1,144 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart
+
+import tachiyomi.domain.manga.model.Manga
+
+/**
+ * Aggregates and ranks manga search results across multiple sources into a single
+ * smart, deduplicated list ordered by relevance to the normalized query.
+ */
+object SmartSearchEngine {
+
+    /**
+     * A single merged search result. Multiple [Manga] (one per source) that refer to the
+     * same series (same normalized title) are grouped together under one entry.
+     *
+     * @property score      relevance score in [0, 1]
+     * @property primary    the manga used for display (title/cover)
+     * @property alternatives other sources/URLs that also matched this series
+     */
+    data class MergedResult(
+        val score: Float,
+        val primary: Manga,
+        val alternatives: List<Manga> = emptyList(),
+    ) {
+        val title: String get() = primary.title
+        val sourceId: Long get() = primary.source
+    }
+
+    const val MIN_SCORE = 0.20f
+
+    /**
+     * Merges and ranks [rawResults] against [normalizedQuery].
+     *
+     * Dedup strategy: titles with the same normalized form are merged into one
+     * [MergedResult]. The highest-scoring manga (best title match) becomes primary;
+     * the rest are kept as [alternatives] so the user can still pick another source.
+     */
+    fun merge(
+        normalizedQuery: String,
+        rawResults: List<Manga>,
+    ): List<MergedResult> {
+        if (normalizedQuery.isEmpty() || rawResults.isEmpty()) return emptyList()
+
+        // Group by normalized title -> keep best-scoring Manga per group
+        val grouped = LinkedHashMap<String, MutableList<Pair<Float, Manga>>>()
+
+        for (manga in rawResults) {
+            val normTitle = QueryNormalizer.normalize(manga.title)
+            if (normTitle.isEmpty()) continue
+            val s = FuzzyMatcher.score(normalizedQuery, normTitle)
+            if (s < MIN_SCORE) continue
+            grouped.getOrPut(normTitle) { mutableListOf() }.add(s to manga)
+        }
+
+        return grouped.values
+            .map { group ->
+                val sorted = group.sortedByDescending { it.first }
+                val best = sorted.first()
+                val bestManga = best.second
+                val alternatives = sorted.drop(1)
+                    .map { it.second }
+                    .filter { it.source != bestManga.source || it.url != bestManga.url }
+                MergedResult(
+                    score = best.first,
+                    primary = bestManga,
+                    alternatives = alternatives,
+                )
+            }
+            .sortedWith(
+                compareByDescending<MergedResult> { it.score }
+                    .thenBy { it.title.lowercase() },
+            )
+    }
+
+    /**
+     * Generates "did you mean" style suggestions when a search yields no results.
+     *
+     * Works self-contained without requiring external title lists: for each query token we
+     * look for a known close variant (from [QueryNormalizer.aliasMap] plus a small set of
+     * common manga-term corrections) within edit distance 2 and propose the full corrected
+     * query. This handles the common case (e.g. "levling" -> "leveling") even when sources
+     * returned nothing.
+     *
+     * @param dictionary additional known terms to consider (e.g. series titles already seen).
+     */
+    fun suggest(
+        normalizedQuery: String,
+        dictionary: List<String> = emptyList(),
+        maxSuggestions: Int = 3,
+    ): List<String> {
+        if (normalizedQuery.isBlank()) return emptyList()
+
+        val tokens = QueryNormalizer.tokenize(normalizedQuery)
+        if (tokens.isEmpty()) return emptyList()
+
+        val candidates = buildSet {
+            addAll(QueryNormalizer.aliasMap.keys)
+            addAll(QueryNormalizer.aliasMap.values.flatMap { QueryNormalizer.tokenize(it) })
+            addAll(dictionary)
+            addAll(COMMON_TERMS)
+        }
+
+        val suggestions = LinkedHashSet<String>()
+
+        for ((index, token) in tokens.withIndex()) {
+            if (token.length < 4) continue
+            var bestWord: String? = null
+            var bestDist = Int.MAX_VALUE
+            for (word in candidates) {
+                val nw = QueryNormalizer.normalize(word)
+                if (nw.length < 4 || nw == token) continue
+                // Allow matching against each word token of the candidate too
+                val dist = QueryNormalizer.tokenize(nw)
+                    .minOfOrNull { QueryNormalizer.levenshtein(token, it, 2) } ?: Int.MAX_VALUE
+                if (dist in 1..2 && dist < bestDist) {
+                    bestDist = dist
+                    bestWord = nw
+                }
+            }
+            if (bestWord != null) {
+                val corrected = tokens.toMutableList().also { it[index] = bestWord }
+                suggestions.add(corrected.joinToString(" "))
+            }
+        }
+
+        // Whole-query correction against multi-word candidates
+        for (word in candidates) {
+            val nw = QueryNormalizer.normalize(word)
+            val d = QueryNormalizer.levenshtein(normalizedQuery, nw, 2)
+            if (d in 1..2) {
+                suggestions.add(nw)
+            }
+        }
+
+        return suggestions.take(maxSuggestions)
+    }
+
+    /** A small set of frequently-misspelled manga term fragments used for suggestions. */
+    private val COMMON_TERMS = listOf(
+        "leveling", "level", "punch", "piece", "god", "tower", "kingdom", "rank",
+        "solo", "hero", "academy", "return", "mount", "hunter", "murim", "noblesse",
+        "begin", "berserk", "naruto", "one", "shippuden", "boruto", "reaper", "scans",
+        "chapter", "manhwa", "manhua", "manwha", "isekai", "reincarnation",
+    )
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/SmartSearchEngineTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/smart/SmartSearchEngineTest.kt
@@ -1,0 +1,129 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch.smart
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.manga.model.Manga
+
+class QueryNormalizerTest {
+
+    @Test
+    fun `lowercases and collapses whitespace`() {
+        assertEquals("one punch man", QueryNormalizer.normalize("  One   PUNCH   Man  "))
+    }
+
+    @Test
+    fun `strips accents`() {
+        assertEquals("shounen", QueryNormalizer.normalize("shōnen"))
+        assertEquals("berserk", QueryNormalizer.normalize("bersèrk"))
+    }
+
+    @Test
+    fun `removes punctuation`() {
+        assertEquals("dragon ball z", QueryNormalizer.normalize("Dragon Ball Z!!"))
+        assertEquals("manga dex test", QueryNormalizer.normalize("manga-dex_test"))
+    }
+
+    @Test
+    fun `expands aliases`() {
+        assertEquals("shounen", QueryNormalizer.normalize("shonen"))
+        assertEquals("solo leveling", QueryNormalizer.normalize("solo leve rule"))
+    }
+
+    @Test
+    fun `tokenizes normalized query`() {
+        assertEquals(listOf("one", "punch", "man"), QueryNormalizer.tokenize("one punch man"))
+    }
+
+    @Test
+    fun `levenshtein caps distance`() {
+        assertEquals(0, QueryNormalizer.levenshtein("naruto", "naruto"))
+        assertEquals(2, QueryNormalizer.levenshtein("nabuto", "naruto", 2))
+        assertEquals(3, QueryNormalizer.levenshtein("a", "xyz", 2))
+    }
+}
+
+class FuzzyMatcherTest {
+
+    @Test
+    fun `exact match scores highest`() {
+        assertEquals(1f, FuzzyMatcher.score("naruto", "naruto"), 0.001f)
+    }
+
+    @Test
+    fun `typo tolerant scoring`() {
+        val score = FuzzyMatcher.score("naruto shipudden", "naruto shippuden")
+        assertTrue(score > 0.5f, "expected its score to be above 0.5 but was $score")
+    }
+
+    @Test
+    fun `partial word matches`() {
+        val score = FuzzyMatcher.score("dragonball z", "dragon ball z")
+        assertTrue(score > 0.5f, "expected its score to be above 0.5 but was $score")
+    }
+}
+
+class SmartSearchEngineTest {
+
+    private fun manga(id: Long, title: String, source: Long = 1L) =
+        Manga.create().copy(
+            id = id,
+            source = source,
+            url = "/title/$id",
+            title = title,
+        )
+
+    @Test
+    fun `merges duplicate titles across sources`() {
+        val results = SmartSearchEngine.merge(
+            normalizedQuery = "naruto",
+            rawResults = listOf(
+                manga(1, "Naruto", source = 1),
+                manga(2, "Naruto", source = 2),
+                manga(3, "Naruto Shippuden", source = 1),
+            ),
+        )
+        val naruto = results.first { it.title == "Naruto" }
+        assertEquals(1, naruto.alternatives.size)
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun `filters low scoring results below minimum`() {
+        val results = SmartSearchEngine.merge(
+            normalizedQuery = "one piece",
+            rawResults = listOf(
+                manga(1, "One Piece"),
+                manga(2, "Totally Unrelated Title"),
+            ),
+        )
+        assertEquals(1, results.size)
+        assertEquals("One Piece", results.first().title)
+    }
+
+    @Test
+    fun `ranks by score descending`() {
+        val results = SmartSearchEngine.merge(
+            normalizedQuery = "berserk",
+            rawResults = listOf(
+                manga(1, "Berserk"),
+                manga(2, "Berserk of Gluttony"),
+            ),
+        )
+        assertTrue(results.isNotEmpty())
+        assertEquals("Berserk", results.first().title)
+    }
+
+    @Test
+    fun `produces suggestions with no results`() {
+        val suggestions = SmartSearchEngine.suggest("levling")
+        assertTrue(suggestions.isNotEmpty())
+        assertTrue(suggestions.any { "level" in it })
+    }
+
+    @Test
+    fun `returns empty when query blank`() {
+        assertTrue(SmartSearchEngine.suggest("   ").isEmpty())
+        assertTrue(SmartSearchEngine.merge("", listOf(manga(1, "Any"))).isEmpty())
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -726,6 +726,9 @@
     <string name="popular">Popular</string>
     <string name="browse">Browse</string>
     <string name="has_results">Has results</string>
+    <string name="did_you_mean">Did you mean</string>
+    <string name="smart_search_source_tag">Found on %1$d sources</string>
+    <string name="smart_search_single_source">1 source</string>
     <string name="local_source_help_guide">Local source guide</string>
     <string name="no_pinned_sources">You have no pinned sources</string>
     <string name="chapter_not_found">Chapter not found</string>


### PR DESCRIPTION
## Summary                                                                                                                                                                  
     Makes the global source search smarter and more "Google-like":                                                                                                              
                                                                                                                                                                                 
     - **Query normalization** — lowercases, strips accents/punctuation, collapses whitespace, and expands common romanization/typo                                              
     aliases (`shonen`→`shounen`, `solo leve rule`→`solo leveling`).                                                                                                             
     - **Merged, ranked results** — results from all sources are deduplicated by normalized title and ranked by fuzzy relevance into                                             
     one list, instead of a per-source grid. Duplicates across sources group under a single entry with a source-count badge.                                                     
     - **Did you mean** — when nothing matches, suggest corrected queries.                                                                                                       
     - **Live search** — debounced search as you type (global search).                                                                                                           
     - **Unit tests** for the normalization/fuzzy/merge engine.                                                                                                                  
                                                                                                                                                                                 
     ## Testing                                                                                                                                                                  
     - Added unit tests in `app/src/test/.../smart/SmartSearchEngineTest.kt`.                                                                                                    
     - Cannot build/run locally (no Android SDK/JDK 21 on dev machine) — relying on CI to compile and validate.                                                                  
                                                                                                                                                                                 
     ## Self-review                                                                                                                                                              
     - [ ] No comments added                                                                                                                                                     
     - [ ] Checked migration search still uses the per-source layout (preserved `GlobalSearchContent`)                                                                           
     - [ ] Verified controller signatures unchanged                                                                                                                      