### PR TITLE
Make tracker utils package-internal

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistUtils.kt
@@ -4,7 +4,7 @@ import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.database.models.Track
 import tachiyomi.domain.track.model.Track as DomainTrack
 
-fun Track.toApiStatus() = when (status) {
+internal fun Track.toApiStatus() = when (status) {
     Anilist.READING -> "CURRENT"
     Anilist.COMPLETED -> "COMPLETED"
     Anilist.ON_HOLD -> "PAUSED"
@@ -14,7 +14,7 @@ fun Track.toApiStatus() = when (status) {
     else -> throw NotImplementedError("Unknown status: $status")
 }
 
-fun DomainTrack.toApiScore(preferences: TrackPreferences): String = when (preferences.anilistScoreType.get()) {
+internal fun DomainTrack.toApiScore(preferences: TrackPreferences): String = when (preferences.anilistScoreType.get()) {
     // 10 point
     "POINT_10" -> (score.toInt() / 10).toString()
     // 100 point

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.bangumi
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Track.toApiStatus() = when (status) {
+internal fun Track.toApiStatus() = when (status) {
     Bangumi.PLAN_TO_READ -> 1
     Bangumi.COMPLETED -> 2
     Bangumi.READING -> 3

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/HikkaUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/hikka/HikkaUtils.kt
@@ -3,7 +3,7 @@ package eu.kanade.tachiyomi.data.track.hikka
 import eu.kanade.tachiyomi.data.database.models.Track
 import java.util.UUID
 
-fun Track.toApiStatus() = when (status) {
+internal fun Track.toApiStatus() = when (status) {
     Hikka.READING -> "reading"
     Hikka.COMPLETED -> "completed"
     Hikka.ON_HOLD -> "on_hold"
@@ -13,7 +13,7 @@ fun Track.toApiStatus() = when (status) {
     else -> throw NotImplementedError("Hikka: Unknown status: $status")
 }
 
-fun toTrackStatus(status: String) = when (status) {
+internal fun toTrackStatus(status: String) = when (status) {
     "reading" -> Hikka.READING
     "completed" -> Hikka.COMPLETED
     "on_hold" -> Hikka.ON_HOLD
@@ -22,7 +22,7 @@ fun toTrackStatus(status: String) = when (status) {
     else -> throw NotImplementedError("Hikka: Unknown status: $status")
 }
 
-fun stringToNumber(input: String): Long {
+internal fun stringToNumber(input: String): Long {
     val uuid = UUID.nameUUIDFromBytes(input.toByteArray())
     return uuid.mostSignificantBits and Long.MAX_VALUE
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.kitsu
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Track.toKitsuApiStatus() = when (status) {
+internal fun Track.toKitsuApiStatus() = when (status) {
     Kitsu.READING -> "CURRENT"
     Kitsu.COMPLETED -> "COMPLETED"
     Kitsu.ON_HOLD -> "ON_HOLD"
@@ -11,7 +11,7 @@ fun Track.toKitsuApiStatus() = when (status) {
     else -> throw Exception("Unknown status: $status")
 }
 
-fun String.toKitsuLocalStatus() = when (this) {
+internal fun String.toKitsuLocalStatus() = when (this) {
     "CURRENT" -> Kitsu.READING
     "COMPLETED" -> Kitsu.COMPLETED
     "ON_HOLD" -> Kitsu.ON_HOLD

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangabaka/MangaBakaUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.mangabaka
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Track.toApiStatus() = when (status) {
+internal fun Track.toApiStatus() = when (status) {
     MangaBaka.CONSIDERING -> "considering"
     MangaBaka.COMPLETED -> "completed"
     MangaBaka.DROPPED -> "dropped"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
@@ -7,8 +7,6 @@ import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.MUListItem
 import eu.kanade.tachiyomi.data.track.mangaupdates.dto.MURating
-import eu.kanade.tachiyomi.data.track.mangaupdates.dto.copyTo
-import eu.kanade.tachiyomi.data.track.mangaupdates.dto.toTrackSearch
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import tachiyomi.i18n.MR
 import tachiyomi.domain.track.model.Track as DomainTrack

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MUListItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MUListItem.kt
@@ -12,11 +12,11 @@ data class MUListItem(
     val listId: Long? = null,
     val status: MUStatus? = null,
     val priority: Int? = null,
-)
-
-fun MUListItem.copyTo(track: Track): Track {
-    return track.apply {
-        this.status = listId ?: READING_LIST
-        this.last_chapter_read = this@copyTo.status?.chapter?.toDouble() ?: 0.0
+) {
+    fun copyTo(track: Track): Track {
+        return track.apply {
+            this.status = listId ?: READING_LIST
+            this.last_chapter_read = this@MUListItem.status?.chapter?.toDouble() ?: 0.0
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURating.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURating.kt
@@ -6,10 +6,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MURating(
     val rating: Double? = null,
-)
-
-fun MURating.copyTo(track: Track): Track {
-    return track.apply {
-        this.score = rating ?: 0.0
+) {
+    fun copyTo(track: Track): Track {
+        return track.apply {
+            this.score = rating ?: 0.0
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/dto/MURecord.kt
@@ -22,21 +22,21 @@ data class MURecord(
     @SerialName("latest_chapter")
     val latestChapter: Int? = null,
     val authors: List<MUAuthor> = emptyList(),
-)
-
-fun MURecord.toTrackSearch(id: Long): TrackSearch {
-    return TrackSearch.create(id).apply {
-        remote_id = this@toTrackSearch.seriesId ?: 0L
-        title = this@toTrackSearch.title?.htmlDecode() ?: ""
-        total_chapters = 0
-        cover_url = this@toTrackSearch.image?.url?.original ?: ""
-        summary = this@toTrackSearch.description?.htmlDecode() ?: ""
-        tracking_url = this@toTrackSearch.url ?: ""
-        publishing_status = ""
-        publishing_type = this@toTrackSearch.type.toString()
-        start_date = this@toTrackSearch.year.toString()
-        score = this@toTrackSearch.bayesianRating?.takeIf { it > 0 } ?: -1.0
-        authors = this@toTrackSearch.authors.filter { it.type == "Author" }.map { it.name }
-        artists = this@toTrackSearch.authors.filter { it.type == "Artist" }.map { it.name }
+) {
+    fun toTrackSearch(id: Long): TrackSearch {
+        return TrackSearch.create(id).apply {
+            remote_id = this@MURecord.seriesId ?: 0L
+            title = this@MURecord.title?.htmlDecode() ?: ""
+            total_chapters = 0
+            cover_url = this@MURecord.image?.url?.original ?: ""
+            summary = this@MURecord.description?.htmlDecode() ?: ""
+            tracking_url = this@MURecord.url ?: ""
+            publishing_status = ""
+            publishing_type = this@MURecord.type.toString()
+            start_date = this@MURecord.year.toString()
+            score = this@MURecord.bayesianRating?.takeIf { it > 0 } ?: -1.0
+            authors = this@MURecord.authors.filter { it.type == "Author" }.map { it.name }
+            artists = this@MURecord.authors.filter { it.type == "Artist" }.map { it.name }
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.myanimelist
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Track.toMyAnimeListStatus() = when (status) {
+internal fun Track.toMyAnimeListStatus() = when (status) {
     MyAnimeList.READING -> "reading"
     MyAnimeList.COMPLETED -> "completed"
     MyAnimeList.ON_HOLD -> "on_hold"
@@ -12,7 +12,7 @@ fun Track.toMyAnimeListStatus() = when (status) {
     else -> null
 }
 
-fun getStatus(status: String?) = when (status) {
+internal fun getStatus(status: String?) = when (status) {
     "reading" -> MyAnimeList.READING
     "completed" -> MyAnimeList.COMPLETED
     "on_hold" -> MyAnimeList.ON_HOLD

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriUtils.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.track.shikimori
 
 import eu.kanade.tachiyomi.data.database.models.Track
 
-fun Track.toShikimoriStatus() = when (status) {
+internal fun Track.toShikimoriStatus() = when (status) {
     Shikimori.READING -> "watching"
     Shikimori.COMPLETED -> "completed"
     Shikimori.ON_HOLD -> "on_hold"
@@ -12,7 +12,7 @@ fun Track.toShikimoriStatus() = when (status) {
     else -> throw NotImplementedError("Unknown status: $status")
 }
 
-fun toTrackStatus(status: String) = when (status) {
+internal fun toTrackStatus(status: String) = when (status) {
     "watching" -> Shikimori.READING
     "completed" -> Shikimori.COMPLETED
     "on_hold" -> Shikimori.ON_HOLD


### PR DESCRIPTION
It gets really annoying to use any of them when they have name collisions. Especially extensions on `Track` or basic public functions.

Also make some same-file extension function in the MangaUpdates package method on the class they extended.

I would have done the same for the DTOs themselves but any that are used on method signatures have to be public and then all their members also have to be public. We'd end up with a confusing mess of some internal and some public DTOs, even at the top level (since generics can be internal to the `dto` package (e.g. with parseAs<...>) but return annotations cannot be).

Wish I thought of this literally yesterday so it could have been in #3900 but cest la vie or something

I was worried this might get R8'd out of existence but a sample check of AniList seems to work fine on a fully minified `release` build.