### PR TITLE
fix(reader): reload pages whose cached image no longer decodes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -14,6 +14,7 @@ import logcat.LogPriority
 import okhttp3.Response
 import okio.buffer
 import okio.sink
+import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import java.io.File
@@ -125,6 +126,24 @@ class ChapterCache(
                 logcat(LogPriority.WARN) { "Image is in journal but file is missing: $imageUrl" }
             }
             inJournal && fileExists
+        } catch (_: IOException) {
+            false
+        }
+    }
+
+    /**
+     * Returns true if the image cached for [imageUrl] is still readable by the image decoder.
+     *
+     * A request that failed while still returning a successful response, or a download that was cut
+     * short, leaves bytes in the cache that no decoder can use. Those entries have to be fetched
+     * again instead of being served from the cache.
+     *
+     * @param imageUrl url of image.
+     */
+    fun isUsableImageInCache(imageUrl: String): Boolean {
+        if (!isImageInCache(imageUrl)) return false
+        return try {
+            ImageUtil.findImageType { getImageFile(imageUrl).inputStream() } != null
         } catch (_: IOException) {
             false
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -178,7 +178,7 @@ internal class HttpPageLoader(
             }
             val imageUrl = page.imageUrl!!
 
-            if (force || !chapterCache.isImageInCache(imageUrl)) {
+            if (force || !chapterCache.isUsableImageInCache(imageUrl)) {
                 page.status = Page.State.DownloadImage
                 val imageResponse = source.getImage(page)
                 chapterCache.putImageToCache(imageUrl, imageResponse)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -260,6 +260,11 @@ class PagerPageHolder(
      */
     override fun onImageLoadError(error: Throwable?) {
         super.onImageLoadError(error)
+        // A page that failed to decode is still Ready, which hides it from the automatic retry in
+        // HttpPageLoader.loadPage and from Retry, so record the failure on the page itself.
+        if (error != null) {
+            page.status = Page.State.Error(error)
+        }
         setError(error)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -84,7 +84,14 @@ class WebtoonPageHolder(
         refreshLayoutParams()
 
         frame.onImageLoaded = { onImageDecoded() }
-        frame.onImageLoadError = { error -> setError(error) }
+        frame.onImageLoadError = { error ->
+            // A page that failed to decode is still Ready, which hides it from the automatic retry in
+            // HttpPageLoader.loadPage and from Retry, so record the failure on the page itself.
+            if (error != null) {
+                page?.status = Page.State.Error(error)
+            }
+            setError(error)
+        }
         frame.onScaleChanged = { viewer.activity.hideMenu() }
     }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoaderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoaderTest.kt
@@ -1,0 +1,76 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import eu.kanade.tachiyomi.data.cache.ChapterCache
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.online.HttpSource
+import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.Response
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class HttpPageLoaderTest {
+
+    @Test
+    fun `a cached page that no longer decodes is downloaded again`() = runBlocking {
+        val imageUrl = "https://example.com/page.jpg"
+        val page = readerPage(imageUrl)
+        val chapterCache = mockk<ChapterCache>(relaxed = true)
+        every { chapterCache.isImageInCache(imageUrl) } returns true
+        every { chapterCache.isUsableImageInCache(imageUrl) } returns false
+        val source = mockk<HttpSource>(relaxed = true)
+        coEvery { source.getImage(page) } returns mockk<Response>(relaxed = true)
+        val loader = HttpPageLoader(page.chapter, source, chapterCache)
+
+        try {
+            val subscription = launch { loader.loadPage(page) }
+
+            coVerify(timeout = 5_000, exactly = 1) { source.getImage(page) }
+            subscription.cancel()
+        } finally {
+            loader.recycle()
+        }
+    }
+
+    @Test
+    fun `a cached page that still decodes is served without downloading it again`() = runBlocking {
+        val imageUrl = "https://example.com/page.jpg"
+        val page = readerPage(imageUrl)
+        val chapterCache = mockk<ChapterCache>(relaxed = true)
+        every { chapterCache.isImageInCache(imageUrl) } returns true
+        every { chapterCache.isUsableImageInCache(imageUrl) } returns true
+        val source = mockk<HttpSource>(relaxed = true)
+        val loader = HttpPageLoader(page.chapter, source, chapterCache)
+        val ready = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(5.seconds) { page.statusFlow.first { it == Page.State.Ready } }
+        }
+
+        try {
+            val subscription = launch { loader.loadPage(page) }
+            ready.await()
+
+            coVerify(exactly = 0) { source.getImage(any()) }
+            subscription.cancel()
+        } finally {
+            loader.recycle()
+        }
+    }
+
+    private fun readerPage(imageUrl: String): ReaderPage {
+        val page = ReaderPage(index = 0, imageUrl = imageUrl)
+        val chapter = mockk<ReaderChapter>(relaxed = true)
+        every { chapter.pages } returns listOf(page)
+        page.chapter = chapter
+        return page
+    }
+}


### PR DESCRIPTION
# Reload reader pages whose cached image can no longer be decoded

## Problem

A page request can succeed at the HTTP level and still store bytes that no decoder can use: a
server that answers a page request with a login page, an error body served as `200`, or a download
that is cut short. Those bytes are written to the chapter cache under the page's image URL.

From that point on the page is broken for good:

* `HttpPageLoader.internalLoadPage()` only asks `ChapterCache.isImageInCache()`, so every later open
  of the chapter serves the same unusable file and the reader shows
  `IllegalStateException: Image decoder failed to initialize and get image size`.
* The decode failure never reaches `Page.State`. `PagerPageHolder.onImageLoadError()` and
  `WebtoonPageHolder` only render the error layout, so the page stays `Page.State.Ready`.
  The automatic retry in `HttpPageLoader.loadPage()` and `retryPage()` both look for
  `Page.State.Error`, so neither sees the page.

The user-visible result is a chapter that keeps a set of permanently failing pages, one Retry tap
per page, and no recovery when the chapter is reopened.

Reported in #2515.

## Change

* `ChapterCache.isUsableImageInCache()` checks that the cached entry still resolves to a supported
  image type before it is reused. `internalLoadPage()` uses it instead of `isImageInCache()`, so an
  unusable entry takes the normal download path and is overwritten.
* `PagerPageHolder` and `WebtoonPageHolder` set `Page.State.Error` when the image fails to decode,
  which lets the existing automatic retry and the Retry action pick the page up.

Forced retries (`PriorityPage.RETRY`) and pages that decode normally keep their current behavior:
a valid cached image is still served without a new request.

## Validation

* `./gradlew :app:testDebugUnitTest`
* `./gradlew spotlessCheck`
* Added `HttpPageLoaderTest`, covering both directions: a cached entry that no longer decodes is
  downloaded again, and a cached entry that decodes is served without another request.

## Notes

* #3770 addresses the same symptom from the Retry side by always re-queueing the page. This change
  is independent of it: it does not touch `retryPage()`, and it also covers reopening the chapter
  and the automatic retry path. The two can land together.
* Marking a decode failure as `Page.State.Error` means revisiting such a page re-requests it. That is
  the intended recovery, but it is a behavior change worth calling out for review.
