### PR TITLE
Fix inverted MAL OAuth expiry check logic

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
@@ -19,5 +19,5 @@ data class MALOAuth(
     val createdAt: Long = Clock.System.now().epochSeconds,
 ) {
     // Assumes expired a minute earlier
-    fun isExpired() = Clock.System.now().plus(1.minutes).epochSeconds <= createdAt + expiresIn
+    fun isExpired() = Clock.System.now().plus(1.minutes).epochSeconds > createdAt + expiresIn
 }


### PR DESCRIPTION
Would explain why MAL has felt a bit slow on my build off of `main` the past few days...

This happened because I swapped operand order without swapping operator direction. Kids, don't forget to logic when refactoring.